### PR TITLE
[Feat/#1] 도메인별 entity작성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+.env

--- a/README.md
+++ b/README.md
@@ -1,0 +1,83 @@
+# 파일 구조
+```
+domain/
+├── global/                               ← 전 도메인 공통 (BaseEntity, enum)
+│   ├── entity/
+│   │   ├── BaseCreatedAtEntity.java      
+│   │   └── BaseUpdatedAtEntity.java     
+│   ├── exception/                        ← 전역 예외 처리
+│   │   ├── CustomException.java         
+│   │   ├── ErrorCode.java                
+│   │   └── GlobalExceptionHandler.java  
+│   └── rsdata/                           ← 공통 API 응답
+│       └── RsData.java                   
+│
+├── account/                              ← 계정 & 동의
+│   └── entity/
+│       ├── User.java                     
+│       ├── Consent.java                
+│       └── ConsentType.java              
+│
+├── plan/                                 ← 계획 생성 · 삶의 구역 · AI 구조화
+│   └── entity/
+│       ├── Plan.java                     
+│       ├── PlanStatus.java               
+│       ├── PlanVersion.java            
+│       ├── LifeArea.java                 
+│       ├── LifeAreaCategory.java         
+│       ├── Item.java                     
+│       ├── ItemStatus.java               
+│       └── DisclosureScope.java          
+│
+├── recipient/                            ← 역할 담당자
+│   └── entity/
+│       ├── Recipient.java                
+│       ├── RoleType.java                 
+│       └── AcceptanceStatus.java         
+│
+├── confirmer/                            ← 지정 확인자 · 이의제기 연락처
+│   └── entity/
+│       ├── Confirmer.java                
+│       ├── Relationship.java             
+│       ├── ReportStatus.java             
+│       └── DisputeContact.java           
+│
+├── stage/                                ← 충돌 점검 · 발송 순서
+│   └── entity/
+│       ├── Dependency.java              
+│       ├── HandoverStage.java            
+│       └── HandoverStageStatus.java      
+│
+├── handoffcheck/                         ← 생전 인계 점검 (선택기능)
+│   └── entity/
+│       ├── HandoffCheck.java             
+│       └── HandoffCheckResponse.java    
+├── releasecase/                          ← 사망 확인 · 대기기간 · 이의제기
+│   └── entity/
+│       ├── ReleaseCase.java              
+│       ├── ReleaseCaseStatus.java        
+│       ├── Objection.java               
+│       └── ObjectionStatus.java          
+│
+├── evidence/                             ← 공식 증빙 제출 · 검토 · 삭제감사
+│   └── entity/
+│       ├── Evidence.java                
+│       └── EvidenceReviewStatus.java    
+│
+├── partner/                              ← 외부 법무·장례 파트너 검토
+│   └── entity/
+│       ├── ExternalPartner.java         
+│       ├── PartnerReviewer.java         
+│       └── PartnerType.java             m
+│
+├── postaccess/                           ← 사후 인계 인증 · 패키지 문제 신고
+│   └── entity/
+│       ├── AccessToken.java             
+│       ├── PackageIssue.java             
+│       └── PackageIssueStatus.java       
+│
+└── audit/                                ← 운영자 감사
+    └── entity/
+        ├── EmailLog.java                
+        └── EmailType.java                
+```

--- a/src/main/java/com/mamoki/ieojuda/IeojudaApplication.java
+++ b/src/main/java/com/mamoki/ieojuda/IeojudaApplication.java
@@ -2,7 +2,9 @@ package com.mamoki.ieojuda;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class IeojudaApplication {
 

--- a/src/main/java/com/mamoki/ieojuda/account/entity/Consent.java
+++ b/src/main/java/com/mamoki/ieojuda/account/entity/Consent.java
@@ -1,0 +1,42 @@
+package com.mamoki.ieojuda.account.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "consents")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Consent {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "consent_id")
+    private Long consentId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "consent_type", length = 30)
+    private ConsentType consentType;
+
+    @Column(name = "agreed_at")
+    private LocalDateTime agreedAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Builder
+    public Consent(ConsentType consentType, User user) {
+        this.consentType = consentType;
+        this.user = user;
+    }
+
+    public void agree() {
+        this.agreedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/account/entity/ConsentType.java
+++ b/src/main/java/com/mamoki/ieojuda/account/entity/ConsentType.java
@@ -1,0 +1,6 @@
+package com.mamoki.ieojuda.account.entity;
+
+public enum ConsentType {
+    SAFETY_AGREEMENT // 안전 동의 (사망 확인 절차·안전 범위 필수 동의)
+}
+

--- a/src/main/java/com/mamoki/ieojuda/account/entity/User.java
+++ b/src/main/java/com/mamoki/ieojuda/account/entity/User.java
@@ -1,0 +1,43 @@
+package com.mamoki.ieojuda.account.entity;
+
+import com.mamoki.ieojuda.global.entity.BaseCreatedAtEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "users")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseCreatedAtEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "email", length = 255, nullable = false)
+    private String email;
+
+    @Column(name = "password", length = 255, nullable = false)
+    private String password;
+
+    @Column(name = "name", length = 50)
+    private String name;
+
+    @Column(name = "refresh_token", length = 255)
+    private String refreshToken;
+
+    @Builder
+    public User(String email, String password, String name) {
+        this.email = email;
+        this.password = password;
+        this.name = name;
+    }
+
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/audit/entity/EmailLog.java
+++ b/src/main/java/com/mamoki/ieojuda/audit/entity/EmailLog.java
@@ -1,0 +1,71 @@
+package com.mamoki.ieojuda.audit.entity;
+
+import com.mamoki.ieojuda.plan.entity.Plan;
+import com.mamoki.ieojuda.stage.entity.HandoverStage;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "email_logs")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EmailLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "log_id")
+    private Long logId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "plan_id", nullable = false)
+    private Plan plan;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "stage_id", nullable = true)
+    private HandoverStage handoverStage;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "email_type", length = 30)
+    private EmailType emailType;
+
+    @Column(name = "recipient_email", length = 255)
+    private String recipientEmail;
+
+    @Column(name = "message_id", length = 255)
+    private String messageId;
+
+    @Column(name = "retry_count")
+    private Integer retryCount;
+
+    @Column(name = "sent_at")
+    private LocalDateTime sentAt;
+
+    @Column(name = "opened_at")
+    private LocalDateTime openedAt;
+
+    @Column(name = "bounced_at")
+    private LocalDateTime bouncedAt;
+
+    @Column(name = "canceled_at")
+    private LocalDateTime canceledAt;
+
+    @Builder
+    public EmailLog(Plan plan, HandoverStage handoverStage, EmailType emailType,
+                    String recipientEmail, String messageId) {
+        this.plan = plan;
+        this.handoverStage = handoverStage;
+        this.emailType = emailType;
+        this.recipientEmail = recipientEmail;
+        this.messageId = messageId;
+        this.retryCount = 0;
+        this.sentAt = LocalDateTime.now();
+    }
+
+
+
+}

--- a/src/main/java/com/mamoki/ieojuda/audit/entity/EmailType.java
+++ b/src/main/java/com/mamoki/ieojuda/audit/entity/EmailType.java
@@ -1,0 +1,13 @@
+package com.mamoki.ieojuda.audit.entity;
+
+public enum EmailType {
+    ROLE_ACCEPTANCE_INVITE,       // 역할 수락 요청
+    CONFIRMER_ACCEPTANCE_INVITE,  // 확인자 수락 요청
+    DISPUTE_CONTACT_VERIFICATION, // 이의 제기 연락처 검증
+    DEATH_REPORT_REQUEST,         // 사망 신고 안내
+    EVIDENCE_SUBMISSION_REQUEST,  // 증빙 제출 안내
+    WAITING_PERIOD_WARNING,       // 대기 기간 경고
+    POSTHUMOUS_HANDOFF_LINK,      // 사후 인계 링크
+    OTP,                          // OTP 코드
+    HANDOFF_CHECK
+}

--- a/src/main/java/com/mamoki/ieojuda/confirmer/entity/Confirmer.java
+++ b/src/main/java/com/mamoki/ieojuda/confirmer/entity/Confirmer.java
@@ -1,0 +1,99 @@
+package com.mamoki.ieojuda.confirmer.entity;
+
+import com.mamoki.ieojuda.plan.entity.Plan;
+import com.mamoki.ieojuda.recipient.entity.AcceptanceStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "death_confirmers")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Confirmer {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "confirm_id")
+    private Long confirmId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "plan_id", nullable = false)
+    private Plan plan;
+
+    @Column(name = "name", length = 100)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "relationship", length = 30)
+    private Relationship relationship;
+
+    @Column(name = "email", length = 255)
+    private String email;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "acceptance_status", length = 30)
+    private AcceptanceStatus acceptanceStatus;
+
+    @Column(name = "accepted_at")
+    private LocalDateTime acceptedAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "report_status", length = 30)
+    private ReportStatus reportStatus;
+
+    @Column(name = "reported_at")
+    private LocalDateTime reportedAt;
+
+    @Column(name = "invite_token", length = 255)
+    private String inviteToken;
+
+    @Builder
+    public Confirmer(Plan plan, String name, Relationship relationship, String email) {
+        this.plan = plan;
+        this.name = name;
+        this.relationship = relationship;
+        this.email = email;
+        this.acceptanceStatus = AcceptanceStatus.PENDING; // 처음 생성할떄 대기 상태
+        this.reportStatus = ReportStatus.NOT_REPORTED;
+    }
+
+    public void issueInviteToken(String inviteToken) {
+        this.inviteToken = inviteToken;
+    }
+
+    //  수락 상태
+    public void accept() {
+        this.acceptanceStatus = AcceptanceStatus.ACCEPTED;
+        this.acceptedAt = LocalDateTime.now();
+    }
+    // 거절 상태
+    public void decline() {
+        this.acceptanceStatus = AcceptanceStatus.DECLINED;
+    }
+    // 만료 상태
+    public void expire() {
+        this.acceptanceStatus = AcceptanceStatus.EXPIRED;
+    }
+
+    // 사망 신고 접수 ( 각 확인자 독립 신고)
+    public void report() {
+        this.reportStatus = ReportStatus.REPORTED;
+        this.reportedAt = LocalDateTime.now();
+    }
+
+    // 다른 확인자 신고와 대상·사건이 일치한다고 판정
+    public void markMatched() {
+        this.reportStatus = ReportStatus.MATCHED;
+    }
+
+    // 다른 확인자 신고와 불일치 → 절차 중지, 운영 검토 전환
+    public void markMismatched() {
+        this.reportStatus = ReportStatus.MISMATCHED;
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/confirmer/entity/DisputeContact.java
+++ b/src/main/java/com/mamoki/ieojuda/confirmer/entity/DisputeContact.java
@@ -1,0 +1,52 @@
+package com.mamoki.ieojuda.confirmer.entity;
+
+import com.mamoki.ieojuda.plan.entity.Plan;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "dispute_contacts")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DisputeContact {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "contact_id")
+    private Long contactId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "plan_id", nullable = false)
+    private Plan plan;
+
+    @Column(name = "email", length = 255)
+    private String email;
+
+    @Column(name = "name", length = 100)
+    private String name;
+
+    @Column(name = "is_verified")
+    private Boolean isVerified;
+
+    @Column(name = "verified_at")
+    private LocalDateTime verifiedAt;
+
+    @Builder
+    public DisputeContact(Plan plan, String email, String name) {
+        this.plan = plan;
+        this.email = email;
+        this.name = name;
+        this.isVerified = false;
+    }
+
+    // 이메일 검증 완료
+    public void verify() {
+        this.isVerified = true;
+        this.verifiedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/confirmer/entity/Relationship.java
+++ b/src/main/java/com/mamoki/ieojuda/confirmer/entity/Relationship.java
@@ -1,0 +1,11 @@
+package com.mamoki.ieojuda.confirmer.entity;
+
+public enum Relationship {
+    SPOUSE,    // 배우자
+    CHILD,     // 자녀
+    PARENT,    // 부모
+    SIBLING,   // 형제자매
+    FRIEND,    // 친구
+    COLLEAGUE, // 동료
+    OTHER      // 기타
+}

--- a/src/main/java/com/mamoki/ieojuda/confirmer/entity/ReportStatus.java
+++ b/src/main/java/com/mamoki/ieojuda/confirmer/entity/ReportStatus.java
@@ -1,0 +1,8 @@
+package com.mamoki.ieojuda.confirmer.entity;
+
+public enum ReportStatus {
+    NOT_REPORTED, // 미신고
+    REPORTED,     // 신고 완료 (상대방 신고 대기)
+    MATCHED,      // 신고 일치
+    MISMATCHED    // 신고 불일치
+}

--- a/src/main/java/com/mamoki/ieojuda/evidence/entity/Evidence.java
+++ b/src/main/java/com/mamoki/ieojuda/evidence/entity/Evidence.java
@@ -1,0 +1,111 @@
+package com.mamoki.ieojuda.evidence.entity;
+
+import com.mamoki.ieojuda.confirmer.entity.Confirmer;
+import com.mamoki.ieojuda.partner.entity.PartnerReviewer;
+import com.mamoki.ieojuda.plan.entity.Plan;
+import com.mamoki.ieojuda.releasecase.entity.ReleaseCase;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "evidences")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Evidence {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "evidence_id")
+    private Long evidenceId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "confirm_id", nullable = false)
+    private Confirmer confirmer;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "plan_id", nullable = false)
+    private Plan plan;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "case_id", nullable = false)
+    private ReleaseCase releaseCase;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reviewer_id", nullable = true)
+    private PartnerReviewer reviewer;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "review_status", length = 30)
+    private EvidenceReviewStatus reviewStatus;
+
+    @Column(name = "submitted_at")
+    private LocalDateTime submittedAt;
+
+    @Column(name = "reviewed_at")
+    private LocalDateTime reviewedAt;
+
+    @Column(name = "delete_scheduled_at")
+    private LocalDateTime deleteScheduledAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @Column(name = "integrity_hash", length = 255)
+    private String integrityHash;
+
+    @Column(name = "failure_reason", columnDefinition = "TEXT")
+    private String failureReason;
+
+    @Column(name = "storage_key", length = 500, nullable = false)
+    private String storageKey;
+
+    @Column(name = "file_name", length = 255)
+    private String fileName;
+
+    @Column(name = "mime_type", length = 100)
+    private String mimeType;
+
+    @Builder
+    public Evidence(Confirmer confirmer, Plan plan, ReleaseCase releaseCase,
+                    String storageKey, String fileName, String mimeType, String integrityHash) {
+        this.confirmer = confirmer;
+        this.plan = plan;
+        this.releaseCase = releaseCase;
+        this.storageKey = storageKey;
+        this.fileName = fileName;
+        this.mimeType = mimeType;
+        this.integrityHash = integrityHash;
+        this.submittedAt = LocalDateTime.now();
+        this.reviewStatus = EvidenceReviewStatus.PENDING;
+    }
+
+
+
+    // 승인. 검토 완료일 기준 30일 이내 삭제 규정에 따라 삭제 예정일 자동 계산 - 명세서상 30일로 임의 지정
+    public void approve() {
+        this.reviewStatus = EvidenceReviewStatus.APPROVED;
+        this.reviewedAt = LocalDateTime.now();
+        this.deleteScheduledAt = this.reviewedAt.plusDays(30);
+    }
+
+    // 반려. 검토 완료 시점 기준 삭제 일정 부여  - 명세서 상 30일로 임의 지정
+    public void reject(String failureReason) {
+        this.reviewStatus = EvidenceReviewStatus.REJECTED;
+        this.reviewedAt = LocalDateTime.now();
+        this.failureReason = failureReason;
+        this.deleteScheduledAt = this.reviewedAt.plusDays(30);
+    }
+
+    public void reAdditionalInfo() {
+        this.reviewStatus = EvidenceReviewStatus.ADDITIONAL_INFO_REQUESTED;
+    }
+
+    public void markDeleted() {
+        this.deletedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/evidence/entity/EvidenceReviewStatus.java
+++ b/src/main/java/com/mamoki/ieojuda/evidence/entity/EvidenceReviewStatus.java
@@ -1,0 +1,8 @@
+package com.mamoki.ieojuda.evidence.entity;
+
+public enum EvidenceReviewStatus {
+    PENDING,                   // 검토 대기
+    APPROVED,                  // 승인
+    REJECTED,                  // 반려
+    ADDITIONAL_INFO_REQUESTED  // 추가자료 요청
+}

--- a/src/main/java/com/mamoki/ieojuda/global/entity/BaseCreatedAtEntity.java
+++ b/src/main/java/com/mamoki/ieojuda/global/entity/BaseCreatedAtEntity.java
@@ -1,0 +1,20 @@
+package com.mamoki.ieojuda.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseCreatedAtEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/mamoki/ieojuda/global/entity/BaseUpdatedAtEntity.java
+++ b/src/main/java/com/mamoki/ieojuda/global/entity/BaseUpdatedAtEntity.java
@@ -1,0 +1,20 @@
+package com.mamoki.ieojuda.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseUpdatedAtEntity {
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/mamoki/ieojuda/handoffcheck/entity/HandoffCheck.java
+++ b/src/main/java/com/mamoki/ieojuda/handoffcheck/entity/HandoffCheck.java
@@ -1,0 +1,35 @@
+package com.mamoki.ieojuda.handoffcheck.entity;
+
+import com.mamoki.ieojuda.plan.entity.Plan;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "handoff_checks")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class HandoffCheck {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "check_id")
+    private Long checkId;
+
+    @Column(name = "sent_at")
+    private LocalDateTime sentAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "plan_id", nullable = false)
+    private Plan plan;
+
+    @Builder
+    public HandoffCheck(Plan plan) {
+        this.plan = plan;
+        this.sentAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/handoffcheck/entity/HandoffCheckResponse.java
+++ b/src/main/java/com/mamoki/ieojuda/handoffcheck/entity/HandoffCheckResponse.java
@@ -1,0 +1,54 @@
+package com.mamoki.ieojuda.handoffcheck.entity;
+
+import com.mamoki.ieojuda.recipient.entity.Recipient;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "handoff_check_responses")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class HandoffCheckResponse {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "response_id")
+    private Long responseId;
+
+    @Column(name = "email_reached")
+    private Boolean emailReached;
+
+    @Column(name = "role_understood")
+    private Boolean roleUnderstood;
+
+    @Column(name = "disclosure_understood")
+    private Boolean disclosureUnderstood;
+
+    @Column(name = "responded_at")
+    private LocalDateTime respondedAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "check_id", nullable = false)
+    private HandoffCheck handoffCheck;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "assigne_id", nullable = false) // role_assigness.assigne_id 오탈자 그대로
+    private Recipient recipient;
+
+    @Builder
+    public HandoffCheckResponse(HandoffCheck handoffCheck, Recipient recipient,
+                                Boolean emailReached, Boolean roleUnderstood,
+                                Boolean disclosureUnderstood) {
+        this.handoffCheck = handoffCheck;
+        this.recipient = recipient;
+        this.emailReached = emailReached;
+        this.roleUnderstood = roleUnderstood;
+        this.disclosureUnderstood = disclosureUnderstood;
+        this.respondedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/partner/entity/ExternalPartner.java
+++ b/src/main/java/com/mamoki/ieojuda/partner/entity/ExternalPartner.java
@@ -1,0 +1,36 @@
+package com.mamoki.ieojuda.partner.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "external_partners")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ExternalPartner {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "partner_id")
+    private Long partnerId;
+
+    @Column(name = "name", length = 100)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "partner_type", length = 30)
+    private PartnerType partnerType;
+
+    @Column(name = "contact_info", length = 255)
+    private String contactInfo;
+
+    @Builder
+    public ExternalPartner(String name, PartnerType partnerType, String contactInfo) {
+        this.name = name;
+        this.partnerType = partnerType;
+        this.contactInfo = contactInfo;
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/partner/entity/PartnerReviewer.java
+++ b/src/main/java/com/mamoki/ieojuda/partner/entity/PartnerReviewer.java
@@ -1,0 +1,49 @@
+package com.mamoki.ieojuda.partner.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "partner_reviewers")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PartnerReviewer {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "reviewer_id")
+    private Long reviewerId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "partner_id", nullable = false)
+    private ExternalPartner partner;
+
+    @Column(name = "name", length = 100)
+    private String name;
+
+    @Column(name = "email", length = 255)
+    private String email;
+
+    @Column(name = "is_active")
+    private Boolean isActive;
+
+    @Builder
+    public PartnerReviewer(ExternalPartner partner, String name, String email) {
+        this.partner = partner;
+        this.name = name;
+        this.email = email;
+        this.isActive = true;
+    }
+
+    /** 이해충돌·권한 만료 시 비활성화 (명세서 "다른 검토자에게 재배정") */
+    public void deactivate() {
+        this.isActive = false;
+    }
+
+    public void activate() {
+        this.isActive = true;
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/partner/entity/PartnerType.java
+++ b/src/main/java/com/mamoki/ieojuda/partner/entity/PartnerType.java
@@ -1,0 +1,6 @@
+package com.mamoki.ieojuda.partner.entity;
+
+public enum PartnerType {
+    LEGAL,  // 법무 파트너
+    FUNERAL // 장례 파트너
+}

--- a/src/main/java/com/mamoki/ieojuda/plan/entity/DisclosureScope.java
+++ b/src/main/java/com/mamoki/ieojuda/plan/entity/DisclosureScope.java
@@ -1,0 +1,7 @@
+package com.mamoki.ieojuda.plan.entity;
+
+public enum DisclosureScope {
+    FAMILY,       // 가족
+    WORK,         // 업무
+    RELATIONSHIP  // 관계 정리
+}

--- a/src/main/java/com/mamoki/ieojuda/plan/entity/Item.java
+++ b/src/main/java/com/mamoki/ieojuda/plan/entity/Item.java
@@ -1,0 +1,79 @@
+package com.mamoki.ieojuda.plan.entity;
+
+import com.mamoki.ieojuda.recipient.entity.Recipient;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "items")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Item {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "item_id")
+    private Long itemId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "assigne_id", nullable = true)
+    private Recipient recipient;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "life_id", nullable = false)
+    private LifeArea lifeArea;
+
+    @Column(name = "location_type", length = 100)
+    private String locationType;
+
+    @Column(name = "action", columnDefinition = "TEXT")
+    private String action;
+
+    @Column(name = "precondition", columnDefinition = "TEXT")
+    private String precondition;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "disclosure_scope", length = 30)
+    private DisclosureScope disclosureScope;
+
+    @Column(name = "source_excerpt", columnDefinition = "TEXT")
+    private String sourceExcerpt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 30)
+    private ItemStatus status;
+
+    @Column(name = "reviewed_at")
+    private LocalDateTime reviewedAt;
+
+    @Builder
+    public Item(LifeArea lifeArea, String locationType, String action,
+                String precondition, DisclosureScope disclosureScope, String sourceExcerpt) {
+        this.lifeArea = lifeArea;
+        this.locationType = locationType;
+        this.action = action;
+        this.precondition = precondition;
+        this.disclosureScope = disclosureScope;
+        this.sourceExcerpt = sourceExcerpt;
+        this.status = ItemStatus.PROPOSED;
+    }
+
+    public void approve() {
+        this.status = ItemStatus.APPROVED;
+        this.reviewedAt = LocalDateTime.now();
+    }
+
+    public void reject() {
+        this.status = ItemStatus.REJECTED;
+        this.reviewedAt = LocalDateTime.now();
+    }
+
+    public void assignRecipient(Recipient recipient) {
+        this.recipient = recipient;
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/plan/entity/ItemStatus.java
+++ b/src/main/java/com/mamoki/ieojuda/plan/entity/ItemStatus.java
@@ -1,0 +1,7 @@
+package com.mamoki.ieojuda.plan.entity;
+
+public enum ItemStatus {
+    PROPOSED, // 제안됨
+    APPROVED, // 승인됨
+    REJECTED  // 기각됨
+}

--- a/src/main/java/com/mamoki/ieojuda/plan/entity/LifeArea.java
+++ b/src/main/java/com/mamoki/ieojuda/plan/entity/LifeArea.java
@@ -1,0 +1,58 @@
+package com.mamoki.ieojuda.plan.entity;
+
+import com.mamoki.ieojuda.global.entity.BaseUpdatedAtEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "life_areas")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LifeArea extends BaseUpdatedAtEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "life_id")
+    private Long lifeId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "plan_id", nullable = false)
+    private Plan plan;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category", length = 30)
+    private LifeAreaCategory category;
+
+    @Column(name = "raw_text", columnDefinition = "TEXT")
+    private String rawText;
+
+    @Column(name = "ai_structured_result", columnDefinition = "TEXT")
+    private String aiStructuredResult;
+
+    @Column(name = "reviewed_at")
+    private LocalDateTime reviewedAt;
+
+
+    // 명세서 삶의 구역 재작성에서 사용자가 처음 원문저장에서 AI 구조조화 결과, 검토 완료 시각 없어서 우선 제외 시킴
+    @Builder
+    public LifeArea(Plan plan, LifeAreaCategory category, String rawText) {
+        this.plan = plan;
+        this.category = category;
+        this.rawText = rawText;
+    }
+
+    // AI 구조화 요청 시점에서 호출하기 위해 설정
+    public void applyAiStructuredResult(String aiStructuredResult) {
+        this.aiStructuredResult = aiStructuredResult;
+    }
+
+    // AI 구조화 검토에서 호출되게 설정
+    public void review() {
+        this.reviewedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/plan/entity/LifeAreaCategory.java
+++ b/src/main/java/com/mamoki/ieojuda/plan/entity/LifeAreaCategory.java
@@ -1,0 +1,7 @@
+package com.mamoki.ieojuda.plan.entity;
+
+public enum LifeAreaCategory {
+    FAMILY,               // 가족
+    RELATIONSHIP_CLEANUP, // 관계 정리
+    WORK_CONTINUITY       // 업무 연속성
+}

--- a/src/main/java/com/mamoki/ieojuda/plan/entity/Plan.java
+++ b/src/main/java/com/mamoki/ieojuda/plan/entity/Plan.java
@@ -1,0 +1,45 @@
+package com.mamoki.ieojuda.plan.entity;
+
+import com.mamoki.ieojuda.account.entity.User;
+import com.mamoki.ieojuda.global.entity.BaseCreatedAtEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "plans")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Plan extends BaseCreatedAtEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "plan_id")
+    private Long planId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "name", length = 100)
+    private String name;
+
+    @Column(name = "waiting_days")
+    private Integer waitingDays;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 30)
+    private PlanStatus status;
+
+    @Builder
+    public Plan(User user, String name, Integer waitingDays) {
+        this.user = user;
+        this.name = name;
+        this.waitingDays = waitingDays;
+        this.status = PlanStatus.DRAFT; // plan 생성하면 '작성중' 적용하기 위해
+    }
+
+
+}

--- a/src/main/java/com/mamoki/ieojuda/plan/entity/PlanStatus.java
+++ b/src/main/java/com/mamoki/ieojuda/plan/entity/PlanStatus.java
@@ -1,0 +1,8 @@
+package com.mamoki.ieojuda.plan.entity;
+
+public enum PlanStatus {
+    DRAFT,       // 작성 중
+    SEALED,      // 봉인됨 (사후 공개 가능)
+    DEACTIVATED  // 비활성화됨
+}
+

--- a/src/main/java/com/mamoki/ieojuda/plan/entity/PlanVersion.java
+++ b/src/main/java/com/mamoki/ieojuda/plan/entity/PlanVersion.java
@@ -1,0 +1,45 @@
+package com.mamoki.ieojuda.plan.entity;
+
+import com.mamoki.ieojuda.global.entity.BaseCreatedAtEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "plan_versions")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PlanVersion extends BaseCreatedAtEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "version_id")
+    private Long versionId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "plan_id", nullable = false)
+    private Plan plan;
+
+    @Column(name = "version_num")
+    private Integer versionNum;
+
+    @Column(name = "snapshot_data", columnDefinition = "TEXT")
+    private String snapshotData;
+
+    @Column(name = "is_sealed")
+    private Boolean isSealed;
+
+    @Builder
+    public PlanVersion(Plan plan, Integer versionNum, String snapshotData) {
+        this.plan = plan;
+        this.versionNum = versionNum;
+        this.snapshotData = snapshotData;
+        this.isSealed = false;
+    }
+
+    public void seal() {
+        this.isSealed = true;
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/postaccess/entity/AccessToken.java
+++ b/src/main/java/com/mamoki/ieojuda/postaccess/entity/AccessToken.java
@@ -1,0 +1,58 @@
+package com.mamoki.ieojuda.postaccess.entity;
+
+import com.mamoki.ieojuda.stage.entity.HandoverStage;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "posthumouse_access_tokens")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AccessToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "token_id")
+    private Long tokenId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "stage_id", nullable = false)
+    private HandoverStage handoverStage;
+
+    @Column(name = "token_hash", length = 255)
+    private String tokenHash;
+
+    @Column(name = "otp_code_hash", length = 255)
+    private String otpCodeHash;
+
+    @Column(name = "otp_sent_at")
+    private LocalDateTime otpSentAt;
+
+    @Column(name = "attempt_count")
+    private Integer attemptCount;
+
+    @Column(name = "expires_at")
+    private LocalDateTime expiresAt;
+
+    @Column(name = "verified_at")
+    private LocalDateTime verifiedAt;
+
+    @Column(name = "used")
+    private Boolean used;
+
+    @Builder
+    public AccessToken(HandoverStage handoverStage, String tokenHash, LocalDateTime expiresAt) {
+        this.handoverStage = handoverStage;
+        this.tokenHash = tokenHash;
+        this.expiresAt = expiresAt;
+        this.attemptCount = 0;
+        this.used = false;
+    }
+
+
+}

--- a/src/main/java/com/mamoki/ieojuda/postaccess/entity/PackageIssue.java
+++ b/src/main/java/com/mamoki/ieojuda/postaccess/entity/PackageIssue.java
@@ -1,0 +1,59 @@
+package com.mamoki.ieojuda.postaccess.entity;
+
+import com.mamoki.ieojuda.plan.entity.Item;
+import com.mamoki.ieojuda.recipient.entity.Recipient;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "package_issues")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PackageIssue {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "issue_id")
+    private Long issueId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "item_id", nullable = false)
+    private Item item;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "assigne_id", nullable = false) // role_assigness.assigne_id 오탈자 그대로
+    private Recipient recipient;
+
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "reported_at")
+    private LocalDateTime reportedAt;
+
+    @Column(name = "resolved_at")
+    private LocalDateTime resolvedAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 30)
+    private PackageIssueStatus status;
+
+    @Builder
+    public PackageIssue(Item item, Recipient recipient, String description) {
+        this.item = item;
+        this.recipient = recipient;
+        this.description = description;
+        this.reportedAt = LocalDateTime.now();
+        this.status = PackageIssueStatus.OPEN;
+    }
+
+    //명세서 "역할별 사후 패키지" - 문제 신고
+    public void resolve() {
+        this.status = PackageIssueStatus.RESOLVED;
+        this.resolvedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/postaccess/entity/PackageIssueStatus.java
+++ b/src/main/java/com/mamoki/ieojuda/postaccess/entity/PackageIssueStatus.java
@@ -1,0 +1,6 @@
+package com.mamoki.ieojuda.postaccess.entity;
+
+public enum PackageIssueStatus {
+    OPEN,    // 미해결
+    RESOLVED // 해결됨
+}

--- a/src/main/java/com/mamoki/ieojuda/recipient/entity/AcceptanceStatus.java
+++ b/src/main/java/com/mamoki/ieojuda/recipient/entity/AcceptanceStatus.java
@@ -1,0 +1,8 @@
+package com.mamoki.ieojuda.recipient.entity;
+
+public enum AcceptanceStatus {
+    PENDING,   // 대기 중 (초대 발송, 응답 대기)
+    ACCEPTED,  // 수락
+    DECLINED,  // 거절
+    EXPIRED    // 만료 (링크 유효기간 초과)
+}

--- a/src/main/java/com/mamoki/ieojuda/recipient/entity/Recipient.java
+++ b/src/main/java/com/mamoki/ieojuda/recipient/entity/Recipient.java
@@ -1,0 +1,118 @@
+package com.mamoki.ieojuda.recipient.entity;
+
+import com.mamoki.ieojuda.plan.entity.DisclosureScope;
+import com.mamoki.ieojuda.plan.entity.Plan;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "role_assigness")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Recipient {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "assigne_id") // 오탈자 DB 그대로 유지 (올바른 표기: assignee_id)
+    private Long assigneeId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "plan_id", nullable = false)
+    private Plan plan;
+
+    @Column(name = "name", length = 100)
+    private String name;
+
+    @Column(name = "email", length = 255)
+    private String email;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role_type", length = 30)
+    private RoleType roleType;
+
+    @Column(name = "is_backup")
+    private Boolean isBackup;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "acceptance_status", length = 30)
+    private AcceptanceStatus acceptanceStatus;
+
+    @Column(name = "accepted_at")
+    private LocalDateTime acceptedAt;
+
+    /**
+     * 사후 인계 단계에서 이 담당자에게 이메일이 발송된 시각(응답 대기 시작점).
+     * max_wait_hours 이내에 완료/응답이 없으면 대체 담당자로 전환하는 기준.
+     */
+    @Column(name = "wait_at")
+    private LocalDateTime waitAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "disclosure_scope", length = 30)
+    private DisclosureScope disclosureScope;
+
+    @Column(name = "max_wait_hours")
+    private Integer maxWaitHours;
+
+    @Column(name = "invite_token", length = 255)
+    private String inviteToken;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "backup_for_id")
+    private Recipient backupFor;
+
+    // 담당자 등록 시점 - 역할명, 담당자 이름, 이메일, 공개 범주, 최대 단계 대기 시간, 대체 담당자 입력
+    @Builder
+    public Recipient(Plan plan, String name, String email, RoleType roleType,
+                     Boolean isBackup, DisclosureScope disclosureScope,
+                     Integer maxWaitHours, Recipient backupFor) {
+        this.plan = plan;
+        this.name = name;
+        this.email = email;
+        this.roleType = roleType;
+        this.isBackup = isBackup;
+        this.disclosureScope = disclosureScope;
+        this.maxWaitHours = maxWaitHours;
+        this.backupFor = backupFor;
+        this.acceptanceStatus = AcceptanceStatus.PENDING;
+    }
+
+    // 초대 이메일 토큰 저장
+    public void issueInviteToken(String inviteToken) {
+        this.inviteToken = inviteToken;
+    }
+
+    // 담당자 수락
+    public void accept() {
+        this.acceptanceStatus = AcceptanceStatus.ACCEPTED;
+        this.acceptedAt = LocalDateTime.now();
+    }
+
+    // 담당자 거절
+    public void decline() {
+        this.acceptanceStatus = AcceptanceStatus.DECLINED;
+    }
+
+    // 초대 링크 만료
+    public void expire() {
+        this.acceptanceStatus = AcceptanceStatus.EXPIRED;
+    }
+
+    //이메일 변경 시 기존 수락 무효화 후 재검증 (명세서 "역할 수락 이메일/화면" 예외 처리)
+    public void ReVerification(String newEmail) {
+        this.email = newEmail;
+        this.acceptanceStatus = AcceptanceStatus.PENDING;
+        this.acceptedAt = null;
+        this.inviteToken = null;
+    }
+
+    // 사후 인계 단계에서 담당자에게 이메일을 보낸 시간 기록
+    public void startWait() {
+        this.waitAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/recipient/entity/RoleType.java
+++ b/src/main/java/com/mamoki/ieojuda/recipient/entity/RoleType.java
@@ -1,0 +1,7 @@
+package com.mamoki.ieojuda.recipient.entity;
+
+public enum RoleType {
+    FAMILY_MANAGER,       // 가족 담당자
+    WORK_MANAGER,         // 업무 담당자
+    RELATIONSHIP_MANAGER  // 관계 정리 담당자
+}

--- a/src/main/java/com/mamoki/ieojuda/releasecase/entity/Objection.java
+++ b/src/main/java/com/mamoki/ieojuda/releasecase/entity/Objection.java
@@ -1,0 +1,70 @@
+package com.mamoki.ieojuda.releasecase.entity;
+
+import com.mamoki.ieojuda.confirmer.entity.DisputeContact;
+import com.mamoki.ieojuda.plan.entity.Plan;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "objections")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Objection {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "objection_id")
+    private Long objectionId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "plan_id", nullable = false)
+    private Plan plan;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "case_id", nullable = false)
+    private ReleaseCase releaseCase;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "contact_id", nullable = false)
+    private DisputeContact disputeContact;
+
+    @Column(name = "raised_at")
+    private LocalDateTime raisedAt;
+
+    @Column(name = "reason", columnDefinition = "TEXT")
+    private String reason;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 30)
+    private ObjectionStatus status;
+
+    @Builder
+    public Objection(Plan plan, ReleaseCase releaseCase, DisputeContact disputeContact, String reason) {
+        this.plan = plan;
+        this.releaseCase = releaseCase;
+        this.disputeContact = disputeContact;
+        this.reason = reason;
+        this.raisedAt = LocalDateTime.now();
+        this.status = ObjectionStatus.RAISED; // 접수됨
+    }
+
+    // 검토중
+    public void startReview() {
+        this.status = ObjectionStatus.UNDER_REVIEW;
+    }
+
+    // 이의 해소
+    public void resolve() {
+        this.status = ObjectionStatus.RESOLVED;
+    }
+
+    // 기각 됨
+    public void dismiss() {
+        this.status = ObjectionStatus.DISMISSED;
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/releasecase/entity/ObjectionStatus.java
+++ b/src/main/java/com/mamoki/ieojuda/releasecase/entity/ObjectionStatus.java
@@ -1,0 +1,8 @@
+package com.mamoki.ieojuda.releasecase.entity;
+
+public enum ObjectionStatus {
+    RAISED,       // 접수됨
+    UNDER_REVIEW, // 검토 중
+    RESOLVED,     // 해소됨
+    DISMISSED     // 기각됨
+}

--- a/src/main/java/com/mamoki/ieojuda/releasecase/entity/ReleaseCase.java
+++ b/src/main/java/com/mamoki/ieojuda/releasecase/entity/ReleaseCase.java
@@ -1,0 +1,63 @@
+package com.mamoki.ieojuda.releasecase.entity;
+
+import com.mamoki.ieojuda.plan.entity.Plan;
+import com.mamoki.ieojuda.plan.entity.PlanVersion;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "release_cases")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReleaseCase {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "case_id")
+    private Long caseId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "plan_id", nullable = false)
+    private Plan plan;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "version_id", nullable = false)
+    private PlanVersion planVersion;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 30)
+    private ReleaseCaseStatus status;
+
+    @Column(name = "confirmed_at")
+    private LocalDateTime confirmedAt;
+
+    @Column(name = "evidence_approved_at")
+    private LocalDateTime evidenceApprovedAt;
+
+    @Column(name = "waiting_ends_at")
+    private LocalDateTime waitingEndsAt;
+
+    @Column(name = "frozen")
+    private Boolean frozen;
+
+    @Column(name = "canceled_at")
+    private LocalDateTime canceledAt;
+
+    @Column(name = "completed_at")
+    private LocalDateTime completedAt;
+
+    @Builder
+    public ReleaseCase(Plan plan, PlanVersion planVersion) {
+        this.plan = plan;
+        this.planVersion = planVersion;
+        this.status = ReleaseCaseStatus.REPORT_PENDING; // 신고 대기 상태
+        this.frozen = false;
+    }
+
+
+}

--- a/src/main/java/com/mamoki/ieojuda/releasecase/entity/ReleaseCaseStatus.java
+++ b/src/main/java/com/mamoki/ieojuda/releasecase/entity/ReleaseCaseStatus.java
@@ -1,0 +1,15 @@
+package com.mamoki.ieojuda.releasecase.entity;
+
+public enum ReleaseCaseStatus {
+    REPORT_PENDING,     // 신고 대기
+    REPORT_CONFIRMED,   // 신고 확인됨 (2인 일치)
+    EVIDENCE_PENDING,   // 증빙 제출 대기
+    EVIDENCE_REVIEWING, // 증빙 검토 중
+    EVIDENCE_APPROVED,  // 증빙 승인됨
+    EVIDENCE_REJECTED,  // 증빙 반려됨
+    WAITING,            // 대기 기간 진행 중
+    DISPUTED,           // 이의 제기됨
+    CANCELED,           // 취소됨
+    RELEASING,          // 발송 진행 중
+    COMPLETED           // 완료됨
+}

--- a/src/main/java/com/mamoki/ieojuda/stage/entity/Dependency.java
+++ b/src/main/java/com/mamoki/ieojuda/stage/entity/Dependency.java
@@ -1,0 +1,41 @@
+package com.mamoki.ieojuda.stage.entity;
+
+import com.mamoki.ieojuda.plan.entity.Item;
+import com.mamoki.ieojuda.plan.entity.Plan;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "item_dependencies")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Dependency {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "dependency_id")
+    private Long dependencyId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "plan_id", nullable = false)
+    private Plan plan;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "item_id", nullable = false)
+    private Item item;
+
+    /** 이 item이 실행되기 전에 먼저 완료되어야 하는 선행 item */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "depends_on_item_id", nullable = false)
+    private Item dependsOnItem;
+
+    @Builder
+    public Dependency(Plan plan, Item item, Item dependsOnItem) {
+        this.plan = plan;
+        this.item = item;
+        this.dependsOnItem = dependsOnItem;
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/stage/entity/HandoverStage.java
+++ b/src/main/java/com/mamoki/ieojuda/stage/entity/HandoverStage.java
@@ -1,0 +1,94 @@
+package com.mamoki.ieojuda.stage.entity;
+
+import com.mamoki.ieojuda.plan.entity.Plan;
+import com.mamoki.ieojuda.recipient.entity.Recipient;
+import com.mamoki.ieojuda.releasecase.entity.ReleaseCase;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "handover_stages")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class HandoverStage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "stage_id")
+    private Long stageId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "case_id", nullable = true)
+    private ReleaseCase releaseCase;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "assigne_id", nullable = false) // role_assigness.assigne_id 오탈자 그대로
+    private Recipient recipient;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "plan_id", nullable = false)
+    private Plan plan;
+
+    @Column(name = "stage_order")
+    private Integer stageOrder;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 30)
+    private HandoverStageStatus status;
+
+    @Column(name = "sent_at")
+    private LocalDateTime sentAt;
+
+    @Column(name = "confirmed_at")
+    private LocalDateTime confirmedAt;
+
+    @Builder
+    public HandoverStage(Plan plan, Recipient recipient, Integer stageOrder) {
+        this.plan = plan;
+        this.recipient = recipient;
+        this.stageOrder = stageOrder;
+        this.status = HandoverStageStatus.PENDING; // 대기
+    }
+
+    //사망 확인 후 실제 사후 사건과 연결
+    public void assignToCase(ReleaseCase releaseCase) {
+        this.releaseCase = releaseCase;
+    }
+
+    // 발송준비 완료
+    public void markReady() {
+        this.status = HandoverStageStatus.READY;
+    }
+
+    // 발송됨
+    public void send() {
+        this.status = HandoverStageStatus.SENT;
+        this.sentAt = LocalDateTime.now();
+    }
+
+    // 완료
+    public void complete() {
+        this.status = HandoverStageStatus.COMPLETED;
+        this.confirmedAt = LocalDateTime.now();
+    }
+
+    // 반송
+    public void bounce() {
+        this.status = HandoverStageStatus.BOUNCED;
+    }
+
+    // 대체 담당자 전환됨
+    public void fallback() {
+        this.status = HandoverStageStatus.FALLBACK;
+    }
+
+    //차단
+    public void block() {
+        this.status = HandoverStageStatus.BLOCKED;
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/stage/entity/HandoverStageStatus.java
+++ b/src/main/java/com/mamoki/ieojuda/stage/entity/HandoverStageStatus.java
@@ -1,0 +1,11 @@
+package com.mamoki.ieojuda.stage.entity;
+
+public enum HandoverStageStatus {
+    PENDING,   // 대기 (선행 단계 미완료)
+    READY,     // 발송 준비 완료
+    SENT,      // 발송됨
+    COMPLETED, // 완료
+    BOUNCED,   // 반송
+    FALLBACK,  // 대체 담당자 전환됨
+    BLOCKED    // 차단 (대체 담당자 없음)
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,15 @@
 spring.application.name=ieojuda
+
+# .env 파일 import
+spring.config.import=optional:file:.env[.properties]
+
+# JPA + Hibernate Setting
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+
+#Postgresql DB 연결
+spring.datasource.url=${DB_URL}
+spring.datasource.username=${DB_USERNAME}
+spring.datasource.password=${DB_PASSWORD}
+spring.datasource.driver-class-name=org.postgresql.Driver


### PR DESCRIPTION
## 연관 Issue
- closes #1 

## 요약
기능명세서 · Entity 설계문서 · DDL을 기준으로 이어두다 백엔드 전체 도메인의 Entity 클래스를 확정하고, 도메인 패키지 구조와 공통 기반(BaseEntity, enum)을 구현했습니다.

## 변경 사항
- 전 도메인 패키지 구조 확정 (global, account, plan, recipient, confirmer, stage, handoffcheck, releasecase, evidence, partner, postaccess, audit) — `ieojuda_backend_build_order`에 맞춰 구성
- 전 도메인 Entity 클래스 작성 (JPA 연관관계 매핑  방식 적용)
  - User, Consent, Plan, PlanVersion, LifeArea, Item, Recipient, Confirmer, DisputeContact, Dependency, HandoverStage, HandoffCheck, HandoffCheckResponse, ReleaseCase, Objection, Evidence, ExternalPartner, PartnerReviewer, AccessToken, PackageIssue, EmailLog
- BaseCreatedAtEntity / BaseUpdatedAtEntity 공통 엔티티 분리 작성 (created_at·updated_at 자동 채움)
- enum 17종 정의 및 소속 도메인 배치
- DDL과 실제 기능 흐름 간 불일치 3건 확인 및 조정
  - `items.assigne_id`, `evidences.reviewer_id`, `email_logs.stage_id` → JPA nullable 처리
- `release_cases.status`에서 FROZEN 값을 분리하여 별도 boolean 컬럼(`frozen`)으로 관리
- 각 엔티티에 상태 전이 메서드 선구현 (기능명세서에서 확인 가능한 범위만)
- application.properties에 PostgreSQL 연결 및 JPA + Hibernate 설정, `.env` 파일 import 처리
- `IeojudaApplication.java`에 `@EnableJpaAuditing` 적용
- 도메인별 파일 구조를 README.md에 정리

## 범위
### 포함:
- 전 도메인 패키지 구조 확정
- 전 도메인 Entity 클래스 작성 (JPA 연관관계 매핑 방식)
- enum 타입 17종 정의 및 도메인 배치
- DDL과 실제 기능 흐름 간 불일치 사항 확인 및 조정
- PostgreSQL 연동 설정

### 제외:
- Repository / Service / Controller 레이어 구현

