### PR TITLE
[Feat#4] 공통 이메일 모듈 구현 

### DIFF
--- a/src/main/java/com/mamoki/ieojuda/global/email/contract/BounceType.java
+++ b/src/main/java/com/mamoki/ieojuda/global/email/contract/BounceType.java
@@ -1,0 +1,7 @@
+package com.mamoki.ieojuda.global.email.contract;
+
+public enum BounceType {
+    NONE, // 정상 발송
+    TEMPORARY, // 일시 반송
+    PERMANENT// 영구 반송
+}

--- a/src/main/java/com/mamoki/ieojuda/global/email/contract/EmailContent.java
+++ b/src/main/java/com/mamoki/ieojuda/global/email/contract/EmailContent.java
@@ -1,0 +1,20 @@
+package com.mamoki.ieojuda.global.email.contract;
+
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+
+
+
+public record EmailContent(
+        String subject,
+        String body
+) {
+    public EmailContent {
+        if (subject == null || subject.isBlank()) {
+            throw new CustomException(ErrorCode.EMAIL_CONTENT_GENERATION_FAILED);
+        }
+        if (body == null || body.isBlank()) {
+            throw new CustomException(ErrorCode.EMAIL_CONTENT_GENERATION_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/global/email/contract/EmailFaill.java
+++ b/src/main/java/com/mamoki/ieojuda/global/email/contract/EmailFaill.java
@@ -1,0 +1,8 @@
+package com.mamoki.ieojuda.global.email.contract;
+
+public enum EmailFaill {
+    INVALID_ADDRESS_FORMAT,   // 주소 형식 오류 (SendFailedException, 555 5.5.2)
+    AUTHENTICATION_FAILED,    // SMTP 인증 실패 (MailAuthenticationException)
+    CONNECTION_TIMEOUT,       // 연결 타임아웃/서버 응답 없음
+    UNKNOWN                   // 실패 원인 분류 할 수 없음 (위에 케이스 이외 예외)
+}

--- a/src/main/java/com/mamoki/ieojuda/global/email/contract/EmailSendResult.java
+++ b/src/main/java/com/mamoki/ieojuda/global/email/contract/EmailSendResult.java
@@ -1,0 +1,16 @@
+package com.mamoki.ieojuda.global.email.contract;
+
+public record EmailSendResult(
+        boolean success,
+        String messageId,      // 우리 서버가 발급한 메일 한통을 가르키는 고유 식별자
+        BounceType bounceType,// 실패 원인
+        EmailFaill emailFaill
+) {
+    public static EmailSendResult success(String messageId) {
+        return new EmailSendResult(true, messageId, BounceType.NONE, null);
+    }
+
+    public static EmailSendResult failure(BounceType bounceType, EmailFaill failureReason) {
+        return new EmailSendResult(false, null, bounceType, failureReason);
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/global/email/sender/EmailSender.java
+++ b/src/main/java/com/mamoki/ieojuda/global/email/sender/EmailSender.java
@@ -1,0 +1,13 @@
+package com.mamoki.ieojuda.global.email.sender;
+
+import com.mamoki.ieojuda.global.email.contract.EmailContent;
+import com.mamoki.ieojuda.global.email.contract.EmailSendResult;
+
+public interface EmailSender {
+
+   /** 이메일 발송 인터페이스
+   * @param  toEmail -> 수신자 이메일 주소
+   * @param  content > 발송할 본문
+   */
+    EmailSendResult send(String toEmail, EmailContent content);
+}

--- a/src/main/java/com/mamoki/ieojuda/global/email/sender/FailureAnalyzer.java
+++ b/src/main/java/com/mamoki/ieojuda/global/email/sender/FailureAnalyzer.java
@@ -1,0 +1,49 @@
+package com.mamoki.ieojuda.global.email.sender;
+
+import com.mamoki.ieojuda.global.email.contract.BounceType;
+import com.mamoki.ieojuda.global.email.contract.EmailFaill;
+import jakarta.mail.SendFailedException;
+import jakarta.mail.internet.AddressException;
+import org.springframework.mail.MailAuthenticationException;
+import org.springframework.mail.MailSendException;
+
+public class FailureAnalyzer {
+
+    public record Result(BounceType bounceType, EmailFaill emailFaill) {
+    }
+
+    private FailureAnalyzer() {
+    }
+
+    public static Result analyze(Exception exception) {
+        // 주소 형식 오류 (전송 시도 이전, MimeMessageHelper.setTo() 등에서 발생)
+        if (exception instanceof AddressException) {
+            return new Result(BounceType.PERMANENT, EmailFaill.INVALID_ADDRESS_FORMAT);
+        }
+
+        // 메일 서버 인증 실패
+        if (exception instanceof MailAuthenticationException) {
+            return new Result(BounceType.TEMPORARY, EmailFaill.AUTHENTICATION_FAILED);
+        }
+
+        // 메일 전송 실패
+        if (exception instanceof MailSendException mailSendException) {
+            if (hasSendFailedCause(mailSendException)) {
+                return new Result(BounceType.PERMANENT, EmailFaill.INVALID_ADDRESS_FORMAT);
+            }
+            return new Result(BounceType.TEMPORARY, EmailFaill.CONNECTION_TIMEOUT);
+        }
+
+        // 알 수 없는 오류
+        return new Result(BounceType.TEMPORARY, EmailFaill.UNKNOWN);
+    }
+
+    private static boolean hasSendFailedCause(MailSendException mailSendException) {
+        for (Exception messageException : mailSendException.getMessageExceptions()) {
+            if (messageException instanceof SendFailedException) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/global/email/sender/GmailSender.java
+++ b/src/main/java/com/mamoki/ieojuda/global/email/sender/GmailSender.java
@@ -1,0 +1,46 @@
+package com.mamoki.ieojuda.global.email.sender;
+
+import com.mamoki.ieojuda.global.email.contract.EmailContent;
+import com.mamoki.ieojuda.global.email.contract.EmailSendResult;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GmailSender implements EmailSender {
+
+    private final JavaMailSender javaMailSender;
+
+    @Override
+    public EmailSendResult send(String toEmail, EmailContent content) {
+        try {
+            MimeMessage message = javaMailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, false, "UTF-8");
+
+            helper.setTo(toEmail);
+            helper.setSubject(content.subject());
+            helper.setText(content.body(), false);
+
+            javaMailSender.send(message);
+
+            //이 메일 한 통의 고유 식별자 (어떤 발송 건인지)
+            String messageId = message.getMessageID() != null // 이메일 발송 이력 추적을 위해 (phase8 고려)
+                    ? message.getMessageID()
+                    : UUID.randomUUID().toString(); // 가끔 null 값을 반환 하는 경우가 있어 UUID로 임의 번호 부여
+
+            return EmailSendResult.success(messageId);
+
+        } catch (Exception e) {
+            log.error("[Email Send Failed] to={}, cause={}", toEmail, e.getMessage(), e);
+            FailureAnalyzer.Result result = FailureAnalyzer.analyze(e);
+            return EmailSendResult.failure(result.bounceType(), result.emailFaill());
+        }
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/global/email/sender/RetryPolicy.java
+++ b/src/main/java/com/mamoki/ieojuda/global/email/sender/RetryPolicy.java
@@ -1,0 +1,60 @@
+package com.mamoki.ieojuda.global.email.sender;
+
+import com.mamoki.ieojuda.global.email.contract.BounceType;
+
+import java.time.Instant;
+
+public class RetryPolicy {
+
+    private RetryPolicy() {
+        // 순수 정적 유틸 클래스 — 인스턴스화 방지
+    }
+
+    /**
+     * 일시 반송(TEMPORARY) 상황에서 재시도 가능 여부를 판단.
+     * PERMANENT -> 반송X ->  항상 false.
+     *
+     * @param bounceType   FailureAnalyzer가 분류한 반송 유형
+     * @param retryCount   지금까지 재시도한 횟수
+     * @param maxRetries   허용된 최대 재시도 횟수
+     * @return 재시도 가능하면 true
+     */
+    public static boolean canRetry(BounceType bounceType, int retryCount, int maxRetries) {
+        if (bounceType != BounceType.TEMPORARY) {
+            return false;
+        }
+        return retryCount < maxRetries;
+    }
+
+    /**
+     * 담당자가 최대 대기 시간을 초과했는지 판단.
+     * role_assigness.max_wait_hours(담당자 테이블 -> max_wait_hours 필드 기준.)
+     *
+     * @param sentAt        이메일이 처음 발송된 시각
+     * @param maxWaitHours  허용된 최대 대기 시간(시간 단위)
+     * @param now           기준 시각 (호출부에서 Instant.now()를 넘겨줌)
+     * @return 최대 대기 시간을 초과했으면 true
+     */
+    public static boolean isWaitExceeded(Instant sentAt, long maxWaitHours, Instant now) {
+        if (sentAt == null || now == null) {
+            return true; // 발송 시각이 없으면 안전하게 "초과됨"으로 처리
+        }
+        Instant deadline = sentAt.plusSeconds(maxWaitHours * 3600);
+        return now.isAfter(deadline);
+    }
+
+    /**
+     * 현재 담당자 처리가 끝난 뒤(반송/대기초과 등), 다음 단계로 자동 진행해도 되는지 판단.
+     * 대체 담당자가 없으면 절대 자동 진행하지 않는다 (FALLBACK_RECIPIENT_MISSING 규칙의 실체).
+     *
+     * @param bounceType   반송 유형 (PERMANENT면 이 담당자는 더 이상 가망 없음)
+     * @param hasFallback  사전 수락된 대체 담당자가 있는지 여부
+     * @return 다음 단계로 진행 가능하면 true
+     */
+    public static boolean canProceed(BounceType bounceType, boolean hasFallback) {
+        if (bounceType == BounceType.PERMANENT) {
+            return hasFallback;
+        }
+        return true; // TEMPORARY/NONE이면 아직 재시도 여지가 있으므로 이 판단 대상 아님
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/global/email/template/EmailBuilder.java
+++ b/src/main/java/com/mamoki/ieojuda/global/email/template/EmailBuilder.java
@@ -1,0 +1,106 @@
+package com.mamoki.ieojuda.global.email.template;
+
+import com.mamoki.ieojuda.global.email.contract.EmailContent;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Locale;
+
+public class EmailBuilder {
+
+    private static final String SERVICE_NAME = "이어두다";
+    private static final DateTimeFormatter EXPIRY_FORMAT =
+            DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 HH:mm", Locale.KOREAN);
+
+
+    private EmailBuilder() {
+        //인스턴스화 방지
+    }
+
+    /**
+     * 링크 기반 공통 이메일 본문 조립.
+     * @param roleName     역할명
+     * @param nextAction   필요한 다음 행동
+     * @param expiresAt    링크 만료 시각
+     * @param secureLink   보안 링크
+     * @param contactEmail 문의 주소
+     */
+    public static EmailContent build(
+            String roleName,
+            String nextAction,
+            ZonedDateTime expiresAt,
+            String secureLink,
+            String contactEmail
+    ) {
+        String subject = String.format("[%s] %s 안내", SERVICE_NAME, roleName);
+
+        String body = String.format("""
+                %s입니다.
+
+                [%s] %s
+
+                다음 행동: %s
+
+                보안 링크: %s
+                (이 링크는 %s까지 유효합니다)
+
+                본 메일은 발신 전용이며, 링크를 통해서만 안전하게 진행됩니다.
+                의심스러운 요청이나 피싱이 우려되면 아래 문의 주소로 연락해주세요.
+
+                문의: %s
+                """,
+                SERVICE_NAME,
+                SERVICE_NAME, roleName,
+                nextAction,
+                secureLink,
+                expiresAt.format(EXPIRY_FORMAT),
+                contactEmail
+        );
+
+        return new EmailContent(subject, body);
+    }
+
+    /**
+     * OTP 코드 이메일 본문 조립
+     * @param otpCode      6자리 등 OTP 코드 값
+     * @param expiresAt    코드 만료 시각
+     * @param contactEmail 문의 주소
+     * 검증을 통과한 EmailContent
+     */
+    public static EmailContent buildOtp(
+            String otpCode,
+            ZonedDateTime expiresAt,
+            String contactEmail
+    ) {
+        String subject = String.format("[%s] 인증 코드 안내", SERVICE_NAME);
+
+        String body = String.format("""
+                %s입니다.
+
+                인증 코드: %s
+
+                다음 행동: 화면에 위 코드를 입력해 본인 확인을 완료해주세요.
+
+                (이 코드는 %s까지 유효합니다)
+
+                본 메일은 발신 전용입니다. 이 코드를 타인에게 절대 알려주지 마세요.
+                의심스러운 요청이나 피싱이 우려되면 아래 문의 주소로 연락해주세요.
+
+                문의: %s
+                """,
+                SERVICE_NAME,
+                otpCode,
+                expiresAt.format(EXPIRY_FORMAT),
+                contactEmail
+        );
+
+
+        return new EmailContent(subject, body);
+    }
+
+
+
+}

--- a/src/main/java/com/mamoki/ieojuda/global/email/template/EmailBuilder.java
+++ b/src/main/java/com/mamoki/ieojuda/global/email/template/EmailBuilder.java
@@ -1,12 +1,8 @@
 package com.mamoki.ieojuda.global.email.template;
 
 import com.mamoki.ieojuda.global.email.contract.EmailContent;
-import com.mamoki.ieojuda.global.exception.CustomException;
-import com.mamoki.ieojuda.global.exception.ErrorCode;
-
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.List;
 import java.util.Locale;
 
 public class EmailBuilder {

--- a/src/main/java/com/mamoki/ieojuda/global/email/token/TokenProvider.java
+++ b/src/main/java/com/mamoki/ieojuda/global/email/token/TokenProvider.java
@@ -1,0 +1,53 @@
+package com.mamoki.ieojuda.global.email.token;
+
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+public class TokenProvider {
+
+    private static final int TOKEN_BYTE_LENGTH = 32; // 256bit
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+    private TokenProvider() {
+        // static 메서드만 존재 하는 클래스 이므로 인스턴스화 방지
+    }
+
+    //발급용 평문 토큰 생성.
+
+    public static String generatePlainToken() {
+        byte[] randomBytes = new byte[TOKEN_BYTE_LENGTH];
+        SECURE_RANDOM.nextBytes(randomBytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(randomBytes); // URL에서 문제가 발생하지 않도록 UTF-Safe Base 64 문자열로 인코딩
+    }
+
+    /*
+     * 평문 토큰을 SHA-256 hex 문자열로 해싱.
+     * 이 값만 DB(invite_token 컬럼)에 저장, 대조한다.
+     */
+    public static String hashToken(String plainToken) {
+        if (plainToken == null || plainToken.isBlank()) {
+            throw new CustomException(ErrorCode.INVALID_TOKEN_FORMAT);
+        }
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hashBytes = digest.digest(plainToken.getBytes(StandardCharsets.UTF_8));
+            return toHex(hashBytes); // 64자리 16진수로 변환
+        } catch (NoSuchAlgorithmException e) {
+            throw new CustomException(ErrorCode.TOKEN_HASHING_FAILED);
+        }
+    }
+
+    private static String toHex(byte[] bytes) {  // hashBytes 형식을 문자열(16진수)로 반환
+        StringBuilder sb = new StringBuilder(bytes.length * 2);
+        for (byte b : bytes) {
+            sb.append(String.format("%02x", b));
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/global/email/token/TokenValidator.java
+++ b/src/main/java/com/mamoki/ieojuda/global/email/token/TokenValidator.java
@@ -1,0 +1,56 @@
+package com.mamoki.ieojuda.global.email.token;
+
+import java.time.Instant;
+
+// 토큰의 만료 여부와 사용가능 여부 판단하는 함수, 예외처리는 이 결과를 사용하는 서비스 레이어 담당
+
+public class TokenValidator {
+
+    private TokenValidator() {
+        // 인스턴스화 방지
+    }
+
+    /**
+     * 토큰이 만료되었는지 판단.
+     * @param  expiresAt 토큰의 만료 시각
+     * @param  now        기준 시각 (호출부에서 Instant.now()를 넘겨줌)
+     * 만료되었으면 true
+     */
+    public static boolean isExpired(Instant expiresAt, Instant now) {
+        if (expiresAt == null || now == null) {
+            return true; // 만료 시각이 없으면 안전하게 "만료됨"으로 처리
+        }
+        return now.isAfter(expiresAt);
+    }
+
+    /**
+     * 1회성 링크의 사용 가능 여부.
+     * 이미 사용된(used=true) 링크는 재사용할 수 없음
+     * @param  used 이미 사용되었는지 여부 (DB의 used 컬럼)
+     *아직 사용 가능하면 true
+     */
+    public static boolean isUsable(boolean used) {
+        return !used;
+    }
+
+    /**
+     * 제한 횟수 기반 링크의 사용 가능 여부.(여러번 가능)
+     * @param  attemptCount: 지금까지 시도한 횟수
+     * @param  maxAttempts :  허용된 최대 시도 횟수
+     * 아직 시도 가능하면 true
+     */
+    public static boolean isUsable(int attemptCount, int maxAttempts) {
+        return attemptCount < maxAttempts;
+    }
+
+    /**
+     * 토큰이 지금 시점에 실제로 사용 가능한 상태인지 종합 판단 (만료 + 1회성).
+     * @param expiresAt: 만료 시각
+     * @param now:        기준 시각
+     * @param used:       이미 사용되었는지 여부
+     * 만료되지 않았고 아직 사용 안 됐으면 true
+     */
+    public static boolean isValid(Instant expiresAt, Instant now, boolean used) {
+        return !isExpired(expiresAt, now) && isUsable(used);
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/global/exception/ErrorCode.java
+++ b/src/main/java/com/mamoki/ieojuda/global/exception/ErrorCode.java
@@ -27,6 +27,12 @@ public enum ErrorCode {
     DEATH_REPORT_MISMATCH(HttpStatus.BAD_REQUEST, "DEATH_REPORT_MISMATCH", "두 확인자의 신고 내용이 일치하지 않아 절차를 중지합니다."),
     EVIDENCE_SUBMISSION_INVALID(HttpStatus.BAD_REQUEST, "EVIDENCE_SUBMISSION_INVALID", "증빙 파일 형식이 올바르지 않거나 보안 검사에 실패했습니다."),
 
+    // 공통 이메일 발송 모듈 관련 예외 (500)
+    EMAIL_CONTENT_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "EMAIL_CONTENT_GENERATION_FAILED", "이메일 본문 생성에 실패했습니다."),
+    //이메일 토큰 관련 예외 (400/500)
+    INVALID_TOKEN_FORMAT(HttpStatus.BAD_REQUEST, "INVALID_TOKEN_FORMAT", "토큰 값이 비어있거나 형식이 올바르지 않습니다."),
+    TOKEN_HASHING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "TOKEN_HASHING_FAILED", "토큰 처리 중 서버 오류가 발생했습니다."),
+
     // 인증 관련 예외 처리 (401)
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "INVALID_CREDENTIALS", "이메일 또는 비밀번호가 올바르지 않습니다."),
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "TOKEN_EXPIRED", "Access Token이 만료되었습니다."),

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,3 +13,11 @@ spring.datasource.url=${DB_URL}
 spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}
 spring.datasource.driver-class-name=org.postgresql.Driver
+
+#Gmail 설정
+spring.mail.host=smtp.gmail.com
+spring.mail.port=587
+spring.mail.username=${MAIL_USERNAME}
+spring.mail.password=${MAIL_PASSWORD}
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true


### PR DESCRIPTION
## 연관 Issue

- Closes #4 

## 요약

전 도메인에서 공통으로 재사용할 이메일 발송 모듈 구현


## 변경 사항
-  토큰 생성/해싱
- 만료 검증
- 1회성 사용 여부 판단
- 이메일 본문 템플릿 생성
- 발송 성공/실패 인터페이스
- 예외 기반 반송 분류
- 재시도 횟수 제한 판단
- 최대 대기 시간 초과 판단
- 대체 담당자 유무에 따른 진행 가능 여부
- ./exception/ErrorCode - 이메일 , 토큰 관련 예외 추가 

## 범위
### 포함
- 공통 이메일 발송 인터페이스/서비스
- 토큰 발급·검증·만료 처리 (토큰 평문 미저장)
- 이메일 템플릿 (서비스명/역할명/다음 행동/만료시각/보안링크/피싱안내만 포함)


### 제외
- 이메일 주소 변경 시 무효화 로직 -> 도메인에서 처리 ( 나중에 조합해서 사용)
- 각 도메인별 이메일 발송 트리거 연동 

## 스크린샷 / 미리 보기
<img width="1852" height="822" alt="image" src="https://github.com/user-attachments/assets/5953560b-0ae7-418b-9956-16808e6f8414" />

