### PR TITLE
Feat#7 암호화 증빙 저장소 준비

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ out/
 .env
 
 application.properties
+Docs

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,8 @@ repositories {
 }
 
 dependencies {
+	implementation platform('software.amazon.awssdk:bom:2.46.7')
+	implementation 'software.amazon.awssdk:s3'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/src/main/java/com/mamoki/ieojuda/global/exception/ErrorCode.java
+++ b/src/main/java/com/mamoki/ieojuda/global/exception/ErrorCode.java
@@ -27,6 +27,9 @@ public enum ErrorCode {
     DEATH_REPORT_MISMATCH(HttpStatus.BAD_REQUEST, "DEATH_REPORT_MISMATCH", "두 확인자의 신고 내용이 일치하지 않아 절차를 중지합니다."),
     EVIDENCE_SUBMISSION_INVALID(HttpStatus.BAD_REQUEST, "EVIDENCE_SUBMISSION_INVALID", "증빙 파일 형식이 올바르지 않거나 보안 검사에 실패했습니다."),
 
+    // 암호화 증빙 저장소 관련 예외 (500)
+    EVIDENCE_STORAGE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "EVIDENCE_STORAGE_FAILED", "증빙 저장소 처리 중 오류가 발생했습니다."),
+
     // 공통 이메일 발송 모듈 관련 예외 (500)
     EMAIL_CONTENT_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "EMAIL_CONTENT_GENERATION_FAILED", "이메일 본문 생성에 실패했습니다."),
     //이메일 토큰 관련 예외 (400/500)

--- a/src/main/java/com/mamoki/ieojuda/global/storage/EvidenceStorageClient.java
+++ b/src/main/java/com/mamoki/ieojuda/global/storage/EvidenceStorageClient.java
@@ -1,0 +1,13 @@
+package com.mamoki.ieojuda.global.storage;
+
+import com.mamoki.ieojuda.global.storage.contract.EvidenceUpload;
+import com.mamoki.ieojuda.global.storage.contract.StoredEvidence;
+
+public interface EvidenceStorageClient {
+
+    StoredEvidence store(Long caseId, EvidenceUpload upload);
+
+    byte[] load(String storageKey);
+
+    void delete(String storageKey);
+}

--- a/src/main/java/com/mamoki/ieojuda/global/storage/IntegrityHasher.java
+++ b/src/main/java/com/mamoki/ieojuda/global/storage/IntegrityHasher.java
@@ -1,0 +1,33 @@
+package com.mamoki.ieojuda.global.storage;
+
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+public class IntegrityHasher {
+
+    private IntegrityHasher() {
+        // static 메서드만 존재 하는 클래스 이므로 인스턴스화 방지
+    }
+
+    // 증빙 원본 바이트의 무결성 해시. DB에는 이 값만 저장하고 원본은 저장하지 않는다.
+    public static String sha256Hex(byte[] content) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hashBytes = digest.digest(content);
+            return toHex(hashBytes);
+        } catch (NoSuchAlgorithmException e) {
+            throw new CustomException(ErrorCode.EVIDENCE_STORAGE_FAILED);
+        }
+    }
+
+    private static String toHex(byte[] bytes) {
+        StringBuilder sb = new StringBuilder(bytes.length * 2);
+        for (byte b : bytes) {
+            sb.append(String.format("%02x", b));
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/global/storage/S3EvidenceStorageClient.java
+++ b/src/main/java/com/mamoki/ieojuda/global/storage/S3EvidenceStorageClient.java
@@ -1,0 +1,81 @@
+package com.mamoki.ieojuda.global.storage;
+
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import com.mamoki.ieojuda.global.storage.config.S3Properties;
+import com.mamoki.ieojuda.global.storage.contract.EvidenceUpload;
+import com.mamoki.ieojuda.global.storage.contract.StoredEvidence;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.core.sync.ResponseTransformer;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.ServerSideEncryption;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class S3EvidenceStorageClient implements EvidenceStorageClient {
+
+    private final S3Client s3Client;
+    private final S3Properties s3Properties;
+
+    @Override
+    public StoredEvidence store(Long caseId, EvidenceUpload upload) {
+        String integrityHash = IntegrityHasher.sha256Hex(upload.content());
+        String storageKey = StorageKeyGenerator.generate(caseId, upload.fileName());
+
+        try {
+            s3Client.putObject(
+                    PutObjectRequest.builder()
+                            .bucket(s3Properties.getBucket())
+                            .key(storageKey)
+                            .contentType(upload.mimeType())
+                            .serverSideEncryption(ServerSideEncryption.AES256)
+                            .build(),
+                    RequestBody.fromBytes(upload.content()));
+        } catch (SdkException e) {
+            log.error("[Evidence Store Failed] caseId={}, cause={}", caseId, e.getMessage(), e);
+            throw new CustomException(ErrorCode.EVIDENCE_STORAGE_FAILED);
+        }
+
+        return new StoredEvidence(storageKey, integrityHash, upload.content().length);
+    }
+
+    @Override
+    public byte[] load(String storageKey) {
+        try {
+            return s3Client.getObject(
+                    GetObjectRequest.builder()
+                            .bucket(s3Properties.getBucket())
+                            .key(storageKey)
+                            .build(),
+                    ResponseTransformer.toBytes()).asByteArray();
+        } catch (NoSuchKeyException e) { //S3에 해당 storageKey에 해당하는 파일이 없을 경우
+            throw new CustomException(ErrorCode.EVIDENCE_NOT_FOUND);
+        } catch (SdkException e) { // 네트워크 단계나 S3 연동 문제
+            log.error("[Evidence Load Failed] storageKey={}, cause={}", storageKey, e.getMessage(), e);
+            throw new CustomException(ErrorCode.EVIDENCE_STORAGE_FAILED);
+        }
+    }
+
+    @Override
+    public void delete(String storageKey) {
+        try {
+            s3Client.deleteObject(
+                    DeleteObjectRequest.builder()
+                            .bucket(s3Properties.getBucket())
+                            .key(storageKey)
+                            .build());
+        } catch (SdkException e) {
+            log.error("[Evidence Delete Failed] storageKey={}, cause={}", storageKey, e.getMessage(), e);
+            throw new CustomException(ErrorCode.EVIDENCE_STORAGE_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/global/storage/StorageKeyGenerator.java
+++ b/src/main/java/com/mamoki/ieojuda/global/storage/StorageKeyGenerator.java
@@ -1,0 +1,36 @@
+package com.mamoki.ieojuda.global.storage;
+
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+public class StorageKeyGenerator {
+
+    private static final Pattern SAFE_EXTENSION = Pattern.compile("^[a-zA-Z0-9]{1,10}$");
+
+    private StorageKeyGenerator() {
+        // static 메서드만 존재 하는 클래스 이므로 인스턴스화 방지
+    }
+
+    // 원본 파일명은 키에 넣지 않는다 (경로 조작·개인 정보 노출 방지). 파일명은 DB 컬럼에만 보관한다.
+    public static String generate(Long caseId, String fileName) {
+        String extension = extractSafeExtension(fileName);
+        String uuid = UUID.randomUUID().toString();
+        return extension.isEmpty()
+                ? "evidence/%d/%s".formatted(caseId, uuid) // 확장자 없음
+                : "evidence/%d/%s.%s".formatted(caseId, uuid, extension); // 확장자 있음
+    }
+
+
+    // 확장자 추출 매세드
+    private static String extractSafeExtension(String fileName) {
+        if (fileName == null) {
+            return "";
+        }
+        int dotIndex = fileName.lastIndexOf('.');
+        if (dotIndex < 0 || dotIndex == fileName.length() - 1) {
+            return "";
+        }
+        String extension = fileName.substring(dotIndex + 1);
+        return SAFE_EXTENSION.matcher(extension).matches() ? extension : "";
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/global/storage/config/S3Config.java
+++ b/src/main/java/com/mamoki/ieojuda/global/storage/config/S3Config.java
@@ -1,0 +1,22 @@
+package com.mamoki.ieojuda.global.storage.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+
+    @Bean
+    public S3Client s3Client(S3Properties s3Properties) {
+        return S3Client.builder()
+                .region(Region.of(s3Properties.getRegion()))
+                // EC2 배포 시 이 한 줄만 DefaultCredentialsProvider.create()로 교체하면 IAM Role을 쓴다
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(s3Properties.getAccessKey(), s3Properties.getSecretKey())))
+                .build();
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/global/storage/config/S3Properties.java
+++ b/src/main/java/com/mamoki/ieojuda/global/storage/config/S3Properties.java
@@ -1,0 +1,24 @@
+package com.mamoki.ieojuda.global.storage.config;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Getter
+@NoArgsConstructor
+@Component
+public class S3Properties {
+
+    @Value("${aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${aws.s3.region}")
+    private String region;
+
+    @Value("${aws.s3.access-key}")
+    private String accessKey;
+
+    @Value("${aws.s3.secret-key}")
+    private String secretKey;
+}

--- a/src/main/java/com/mamoki/ieojuda/global/storage/contract/EvidenceUpload.java
+++ b/src/main/java/com/mamoki/ieojuda/global/storage/contract/EvidenceUpload.java
@@ -1,0 +1,8 @@
+package com.mamoki.ieojuda.global.storage.contract;
+
+public record EvidenceUpload(
+        String fileName,
+        String mimeType,
+        byte[] content
+) {
+}

--- a/src/main/java/com/mamoki/ieojuda/global/storage/contract/StoredEvidence.java
+++ b/src/main/java/com/mamoki/ieojuda/global/storage/contract/StoredEvidence.java
@@ -1,0 +1,9 @@
+package com.mamoki.ieojuda.global.storage.contract;
+
+// 저장이 끝난 뒤 돌려받는 결과 값
+public record StoredEvidence(
+        String storageKey, // S3에 실제로 저장된 위치
+        String integrityHash, // SHA-256 해시
+        long fileSize
+) {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -25,3 +25,9 @@ spring.mail.username=${MAIL_USERNAME}
 spring.mail.password=${MAIL_PASSWORD}
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
+
+#암호화 증빙 저장소(S3) 설정 - EC2 배포 전까지 로컬 자격증명 사용
+aws.s3.bucket=${AWS_S3_BUCKET}
+aws.s3.region=${AWS_S3_REGION}
+aws.s3.access-key=${AWS_ACCESS_KEY_ID}
+aws.s3.secret-key=${AWS_SECRET_ACCESS_KEY}


### PR DESCRIPTION
## 연관 Issue                                                                                                                                                                    
                                                                                                                                                                                   
  - Closes #7                                                                                                                                                                      
                                                                                                                                                                                   
  ## 요약                                                                                                                                                                          
                                                                                                                                                                                   
  '공식 증빙 보안 제출 화면' 작업 전에, 증빙 원본을 암호화 저장소(S3)에 저장·조회·삭제할 수 있는 저장소 클라이언트를 준비.                                                   
                                                                                                                                                                                   
  ## 변경 사항                                                                                                                                                                     
                                                                                                                                                                                   
  - AWS SDK v2(S3) 의존성 추가                                                                                                                                                                                         
    - `store`: SSE(AES256) 암호화로 S3에 업로드, `IntegrityHasher`로 SHA-256 무결성 해시 생성                                                                                      
    - `load`: storageKey로 원본 바이트 조회                                                                               
    - `delete`: storageKey로 원본 삭제                                                                                                                                             
  - `StorageKeyGenerator` 추가: `evidence/{caseId}/{UUID}.{ext}` 형태의 저장 키 생성 (원본 파일명은 키에 포함하지 않음)                                                            
  - `IntegrityHasher` 추가: SHA-256 해시 유틸                                                                                                                                      
  - `EvidenceUpload`(요청) / `StoredEvidence`(저장 결과) record 추가                                                                                                               
  - `ErrorCode = EVIDENCE_STORAGE_FAILED` 추가                                                                                                                                       
                                                                                                                                                                                   
  ## 범위                                                                                                                                                                          
                                                                                                                                                                                   
  ### 포함                                                                                                                                                                         
                                                                                                                                                                                   
  - S3 연동 설정 및 `EvidenceStorageClient` 구현                                                                                                                                   
  - 저장 키 생성, 무결성 해시 유틸                                                                                                                                                 
  - 실제 버킷에 store→load→delete 왕복 확인, SSE 암호화 표시 확인 

### 제외

- 업로드 파일 MIME·크기 검증 
- 접근 권한 스코프, 접근 감사 로그
- 30일 삭제 스케줄 훅 
- 추후 phase 6에서 진행 

## 스크린샷 / 미리보기
<img width="1565" height="546" alt="image" src="https://github.com/user-attachments/assets/5bf6ffc6-d1ec-4acf-9547-5275d9c9b2c6" />
<img width="1518" height="350" alt="image" src="https://github.com/user-attachments/assets/a7a91f07-8929-42d9-8ac0-74c881693793" />
