### PR TITLE
[Feat/#9] JWT 및 로그인 기능 구현

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,0 +1,80 @@
+# 이어주다(늑대와 함께 춤을) 백엔드 — 세션 인계 문서
+
+작성 기준: 2026-08-09. 이전 세션에서 진행한 작업과 결정사항, 남은 일을 정리합니다.
+
+## 1. 프로젝트가 뭔지
+
+사용자가 생전에 가족/업무/관계 처리 의도를 계획으로 남겨두면, 사망이 안전하게 확인된 뒤(확인자 2명 독립 신고 + 외부 파트너 승인 + 7~30일 대기 + 이의 제기 없음, 4중 검증) 관련자들에게 정해진 순서로 이메일을 보내는 서비스. Next.js + Spring Boot + PostgreSQL + OpenAI. 기능명세서는 Notion에 있음(30개 페이지, 팀에서 계속 갱신 중이니 재확인 필요하면 다시 읽을 것).
+
+## 2. 지금 실제로 동작하는 API (라이브로 검증 완료)
+
+**Plan / LifeArea / AI 구조화 / Item 검토** (`domain/plan`)
+| Method | Path | 설명 |
+|---|---|---|
+| POST | `/api/plans` | 계획 생성. `familyMessage`(자유텍스트) + `snsAction`/`snsOtherDetail`/`obituaryDelivery`/`workAccountAction`/`ongoingWorkHandover`(버튼값)를 한 번에 받아서, **AI가 내용을 읽고** 가족/관계정리/업무연속성 3구역에 자동 분류 + Item(PROPOSED)까지 생성. 응답에 `lifeAreas[].items[]`까지 포함 |
+| GET | `/api/plans/{planId}` | 계획 조회 |
+| PUT | `/api/plans/{planId}` | 계획 수정(이름/대기기간) |
+| POST | `/api/plans/{planId}/deactivate` | 계획 비활성화 |
+| GET | `/api/plans/{planId}/life-areas` | 구역 목록 (⚠️ 버그 있음, 아래 5번 참고) |
+| GET | `/api/plans/{planId}/life-areas/{lifeAreaId}` | 구역 단건 (⚠️ 동일 버그) |
+| GET | `.../life-areas/{lifeAreaId}/messages` | AI 대화 이력 조회 |
+| POST | `.../life-areas/{lifeAreaId}/send/message` | 사용자 발화 → AI 구조화(QUESTION/RESULT) |
+| POST | `/api/plans/{planId}/items/review` | 항목 승인/기각 (`{"itemId":1,"decision":"APPROVE"}`) |
+| PUT | `/api/plans/{planId}/items/{itemId}` | 항목 인라인 수정 |
+
+**Auth** (`domain/account`)
+| Method | Path | 설명 |
+|---|---|---|
+| POST | `/auth/signup` | 회원가입 (email/password/passwordConfirm/name) |
+| POST | `/auth/login` | 로그인 → AT(1시간)/RT(14일) 발급 |
+| POST | `/auth/refresh` | RT로 AT+RT 재발급 (RT도 매번 회전) |
+
+Swagger UI: `http://localhost:8080/swagger-ui/index.html`
+
+## 3. 핵심 설계 결정 (왜 이렇게 만들었는지)
+
+- **계획 생성 = AI 분류 방식.** 처음엔 "어느 입력 필드에 썼는지"로 구역을 고정 배정했는데(`familyMessage`→FAMILY 등), 가족 칸에 업무 얘기를 써도 무조건 FAMILY로 들어가는 문제가 있어서, **AI가 실제 내용을 읽고 판단**하는 방식으로 바꿈. `OpenAIClient.getInitialStructure()` + `PlanService.createInitialItems()`. 라이브 테스트로 검증 완료(가족 칸에 업무 얘기 섞어 써도 정확히 WORK_CONTINUITY로 분류됨).
+- **LifeArea.rawText**는 새 컬럼 안 만들고 기존 필드를 재사용 — 3구역 모두에 입력값 전체(JSON)를 동일하게 저장해서, 나중에 "삶의 구역 생성" 채팅에서도 AI가 전체 맥락을 계속 참고하게 함(`OpenAIClient.getChatCompletion(history, seedContext)`의 seedContext).
+- **PROPOSED 항목 교체 로직**: 화면 전환 없이 같은 대화창에서 계속 대화하는 구조라, AI가 계획을 다시 짤 때마다 이전 PROPOSED 항목은 지우고 새로 교체함(`LifeAreaConversationService.createItems()`). APPROVED/REJECTED는 안 건드림.
+- **Item.targetName**: AI 구조화 결과 검토 화면에 "대상 이름"(예: 김민수, 아내)을 보여주려고 추가한 필드. AI 프롬프트에서 항상 같이 뽑도록 지시함.
+- **PlanCreateRequest.userId는 임시 필드.** 로그인 기능이 없어서 어쩔 수 없이 직접 받고 있음. **나중에 SecurityConfig 손볼 때 이 필드를 로그인한 사용자로 대체하기로 사용자와 합의됨.**
+- **SecurityConfig는 의도적으로 전체 permitAll 유지.** JWT는 발급/검증 로직(`JwtTokenProvider`)과 회원가입/로그인 API까지만 만들었고, `JwtAuthenticationFilter`로 실제 요청을 막는 건 아직 안 함 — 나중에 한 번에 정리하기로 함(위 userId 이슈랑 같이).
+
+## 4. 알려진 문제 / 미해결 이슈
+
+1. **`GET .../life-areas`, `GET .../life-areas/{id}`가 항상 `items: []`를 반환함.** `LifeAreaService.getLifeArea()`가 `LifeAreaResponse.from(lifeArea)`(items 없는 오버로드)만 써서 그럼. 계획 생성 직후 응답에서만 items가 채워지고, 그 뒤 재조회하면 못 봄. **고치기로 얘기만 하고 아직 안 고침.**
+2. **관계정리/업무정리 구역 버튼값만 있고 텍스트가 없으면 AI가 항목을 아예 안 만드는 경우가 있음.** 예: `snsAction: "PRIVATE"`만 있으면 "누가 이걸 해야 하는지(targetName)" 정보가 없어서 AI가 항목화를 포기함. `PlanCreateRequest`에 담당자 이름 받는 필드 자체가 없음(그건 "역할 담당자 등록" 화면 몫인데 미구현). **결론 안 남, 사용자한테 다시 물어봐야 함.**
+3. **`snsOtherDetail` 필드가 사실상 안 쓰임.** "기타" 선택 옵션은 안 쓰기로 했는데 DTO 필드는 아직 안 지움.
+4. **AI 질문에 빠른 답변 버튼(quick-reply, 예: 삭제/비공개) 기능 없음.** `LifeAreaTurnResponse`에 `options` 필드 없음. **사용자가 명시적으로 "나중에 하자"고 보류함.**
+5. **충돌 점검/발송 순서(AI 순서 제안) 기능은 한 번 만들었다가 전부 롤백함.** 사용자가 "이거 피그마에 있던 화면이었어?"라고 물었는데 없었다고 확인되자 삭제 요청. `domain/stage`의 `Dependency`/`HandoverStage` 엔티티만 남아있고, 관련 Service/Controller/DTO는 없음.
+6. **OpenAI(`gpt-3.5-turbo`)가 간헐적으로 500 에러를 냄** (테스트 중 3번에 1번꼴 확인). 재시도 로직 없음.
+7. **로그인(`LoginRequest`)엔 `@Email` 형식 검증이 없고, 회원가입(`SignupRequest`)엔 있음.** 일관성 맞출지 논의만 하고 결론 안 남.
+8. **Repository가 5개뿐**(`User`, `Plan`, `LifeArea`, `LifeAreaMessage`, `Item`). 나머지 12개 엔티티(`Recipient`, `Confirmer`, `DisputeContact`, `Evidence`, `ExternalPartner`, `PartnerReviewer`, `ReleaseCase`, `Objection`, `Dependency`, `HandoverStage`, `AccessToken`, `PackageIssue`, `EmailLog`, `HandoffCheck`, `HandoffCheckResponse`, `Consent`)는 JPA 엔티티만 있고 Repository/Service/Controller가 아예 없음.
+9. **팀원이 만든 인프라 유틸리티는 완성도 있는데 아무데서도 안 씀**: `global/email`(GmailSender, RetryPolicy, FailureAnalyzer, EmailBuilder — 실제 SMTP 발송·반송분류·재시도판단 로직 다 있음), `global/email/token`(TokenProvider/TokenValidator — 초대 링크용, 내가 만든 `global/jwt`와는 다른 것, 이름 헷갈리지 말 것), `global/storage`(S3EvidenceStorageClient — 실제 S3 업로드/다운로드 구현체). 이걸 실제로 호출하는 도메인 서비스가 없음.
+10. **`.env`에 `AWS_S3_BUCKET`/`AWS_S3_REGION`/`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`MAIL_USERNAME`/`MAIL_PASSWORD`가 원래 없어서 앱 부팅 자체가 실패했었음.** AWS는 사용자가 실제 IAM 액세스 키를 발급받아 `.env`에 넣어서 **진짜 값으로 채워짐**(버킷 `ieoduda2026-311752058218-ap-northeast-2-an`, 리전 `ap-northeast-2`). 단, `EvidenceStorageClient`를 실제로 호출하는 도메인 서비스가 아직 없어서 저장/조회 기능 자체는 미구현 상태(키만 준비됨). **`MAIL_USERNAME`/`MAIL_PASSWORD`는 아직 더미값** — 실제 메일 발송 기능 붙일 때 교체 필요.
+11. **보안 유의**: 사용자가 대화 중 AWS 콘솔 로그인 비밀번호를 실수로 채팅에 붙여넣은 적 있음 → 비밀번호 재설정을 권장드렸음(대화 로그에 남으니). 이 문서엔 실제 값 안 적음.
+
+## 5. 다음에 하면 좋을 것 (우선순위 제안)
+
+1. 위 4-1 (`GET life-areas` items 버그) — 작은 수정
+2. 담당자 등록(`Recipient`) / 확인자 등록(`Confirmer`) API — Repository/Service/Controller부터 신설. 이게 있어야 4-2 문제(버튼값만 있으면 항목 안 만들어지는 것)도 자연스럽게 풀릴 가능성 있음 (담당자를 먼저 등록해두면 AI가 targetName을 거기서 가져올 수 있음)
+3. `JwtAuthenticationFilter` 신설 + `SecurityConfig` 잠그기 + `PlanCreateRequest.userId` 제거하고 로그인 사용자로 대체 (3번 항목에서 이미 이렇게 하기로 합의됨)
+4. 이의제기 연락처(`DisputeContact`) API
+5. 그 외 명세서 52개 API 중 나머지 (충돌탐지/발송순서, 사망확인~발송 전체 플로우 등)
+
+## 6. 개발 환경
+
+- **DB**: PostgreSQL 18 (Homebrew 아님, `/Library/PostgreSQL/18/bin`), `localhost:5432/ieoduda`, 계정정보는 `.env`
+- **컴파일 확인 시 JDK 21 경로를 명시해야 함** (로컬 gradle이 기본으로 못 찾음):
+  ```bash
+  JAVA_HOME=/opt/homebrew/Cellar/openjdk@21/21.0.7/libexec/openjdk.jdk/Contents/Home \
+    bash gradlew clean compileJava \
+    -Dorg.gradle.java.home=/opt/homebrew/Cellar/openjdk@21/21.0.7/libexec/openjdk.jdk/Contents/Home
+  ```
+- **서버 실행**: 사용자가 IntelliJ로 직접 실행/재시작함 (Run 버튼). 포트 8080.
+- **Postman 컬렉션**: 대화 중 2개(Plan/LifeArea/AI용, Auth용) 만들어서 전달했으나 세션 스크래치패드에 있어 다음 세션에선 접근 불가 — 필요하면 다시 요청받아 만들 것.
+
+## 7. 참고
+
+- Notion 기능명세서: 워크스페이스 내 "늑대와 함께 춤을" 프로젝트 페이지 하위 "기능 명세서" 데이터베이스 (30개 항목). Notion MCP 연결 필요.
+- Figma: 사용자가 스크린샷 5장(계획 홈/새 계획 만들기/새 계획 만들기(기타)/삶의 구역 생성/AI 구조화 결과 검토) 공유함. 실제 Figma 파일 링크는 아직 못 받음 — "충돌 점검/발송 순서" 같은 다른 화면들은 본 적 없음.

--- a/src/main/java/com/mamoki/ieojuda/domain/account/controller/AuthController.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/account/controller/AuthController.java
@@ -1,0 +1,46 @@
+package com.mamoki.ieojuda.domain.account.controller;
+
+import com.mamoki.ieojuda.domain.account.dto.LoginRequest;
+import com.mamoki.ieojuda.domain.account.dto.RefreshRequest;
+import com.mamoki.ieojuda.domain.account.dto.SignupRequest;
+import com.mamoki.ieojuda.domain.account.dto.SignupResponse;
+import com.mamoki.ieojuda.domain.account.dto.TokenResponse;
+import com.mamoki.ieojuda.domain.account.service.AuthService;
+import com.mamoki.ieojuda.global.rsdata.RsData;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+// 명세서 "회원가입 / 로그인" 화면
+@Tag(name = "Auth", description = "회원가입 / 로그인 / 토큰 재발급")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @Operation(summary = "회원가입", description = "이메일/비밀번호/비밀번호 확인/이름으로 계정을 생성합니다.")
+    @PostMapping("/signup")
+    public ResponseEntity<RsData<SignupResponse>> signup(@Valid @RequestBody SignupRequest request) {
+        return ResponseEntity.ok(RsData.success(authService.signup(request)));
+    }
+
+    @Operation(summary = "로그인", description = "이메일/비밀번호로 로그인하고 Access/Refresh Token을 발급합니다.")
+    @PostMapping("/login")
+    public ResponseEntity<RsData<TokenResponse>> login(@Valid @RequestBody LoginRequest request) {
+        return ResponseEntity.ok(RsData.success(authService.login(request)));
+    }
+
+    @Operation(summary = "토큰 재발급", description = "Refresh Token으로 Access/Refresh Token을 새로 발급합니다 (재발급마다 Refresh Token도 회전).")
+    @PostMapping("/refresh")
+    public ResponseEntity<RsData<TokenResponse>> refresh(@Valid @RequestBody RefreshRequest request) {
+        return ResponseEntity.ok(RsData.success(authService.refresh(request)));
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/account/controller/AuthController.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/account/controller/AuthController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -42,5 +43,12 @@ public class AuthController {
     @PostMapping("/refresh")
     public ResponseEntity<RsData<TokenResponse>> refresh(@Valid @RequestBody RefreshRequest request) {
         return ResponseEntity.ok(RsData.success(authService.refresh(request)));
+    }
+
+    @Operation(summary = "로그아웃", description = "저장된 Refresh Token을 무효화해 재발급을 막습니다. 이미 발급된 Access Token은 만료 전까지 계속 유효합니다. Authorization 헤더의 Access Token으로 사용자를 식별합니다.")
+    @PostMapping("/logout")
+    public ResponseEntity<RsData<Void>> logout(@AuthenticationPrincipal Long userId) {
+        authService.logout(userId);
+        return ResponseEntity.ok(RsData.success(null));
     }
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/account/dto/LoginRequest.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/account/dto/LoginRequest.java
@@ -1,0 +1,13 @@
+package com.mamoki.ieojuda.domain.account.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+        @Schema(description = "이메일", example = "user@example.com")
+        @NotBlank(message = "이메일을 입력해 주세요.") String email,
+
+        @Schema(description = "비밀번호", example = "password1234")
+        @NotBlank(message = "비밀번호를 입력해 주세요.") String password
+) {
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/account/dto/RefreshRequest.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/account/dto/RefreshRequest.java
@@ -1,0 +1,10 @@
+package com.mamoki.ieojuda.domain.account.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record RefreshRequest(
+        @Schema(description = "로그인 시 발급받은 Refresh Token")
+        @NotBlank(message = "Refresh Token이 필요합니다.") String refreshToken
+) {
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/account/dto/SignupRequest.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/account/dto/SignupRequest.java
@@ -1,0 +1,20 @@
+package com.mamoki.ieojuda.domain.account.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record SignupRequest(
+        @Schema(description = "이메일", example = "user@example.com")
+        @NotBlank(message = "이메일을 입력해 주세요.") @Email(message = "이메일 형식이 올바르지 않습니다.") String email,
+
+        @Schema(description = "비밀번호", example = "password1234")
+        @NotBlank(message = "비밀번호를 입력해 주세요.") String password,
+
+        @Schema(description = "비밀번호 확인", example = "password1234")
+        @NotBlank(message = "비밀번호 확인을 입력해 주세요.") String passwordConfirm,
+
+        @Schema(description = "이름", example = "홍길동")
+        @NotBlank(message = "이름을 입력해 주세요.") String name
+) {
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/account/dto/SignupResponse.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/account/dto/SignupResponse.java
@@ -1,0 +1,14 @@
+package com.mamoki.ieojuda.domain.account.dto;
+
+import com.mamoki.ieojuda.domain.account.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record SignupResponse(
+        @Schema(description = "사용자 ID") Long userId,
+        @Schema(description = "이메일") String email,
+        @Schema(description = "이름") String name
+) {
+    public static SignupResponse from(User user) {
+        return new SignupResponse(user.getUserId(), user.getEmail(), user.getName());
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/account/dto/TokenResponse.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/account/dto/TokenResponse.java
@@ -1,0 +1,9 @@
+package com.mamoki.ieojuda.domain.account.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record TokenResponse(
+        @Schema(description = "Access Token (1시간 유효)") String accessToken,
+        @Schema(description = "Refresh Token (14일 유효)") String refreshToken
+) {
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/account/repository/UserRepository.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/account/repository/UserRepository.java
@@ -3,5 +3,10 @@ package com.mamoki.ieojuda.domain.account.repository;
 import com.mamoki.ieojuda.domain.account.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/account/service/AuthService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/account/service/AuthService.java
@@ -78,6 +78,19 @@ public class AuthService {
         return issueTokens(user);
     }
 
+    // /auth/**는 SecurityConfig에서 permitAll이라 토큰 없이도 요청 자체는 통과되므로, userId가 비어 있으면
+    // (=Authorization 헤더 없이 호출한 경우) 여기서 직접 막는다.
+    // AT는 만료 전까지 계속 유효하지만(블랙리스트 없음), 저장된 RT를 지워서 재발급은 더 이상 못 하게 막는다.
+    @Transactional
+    public void logout(Long userId) {
+        if (userId == null) {
+            throw new CustomException(ErrorCode.TOKEN_INVALID);
+        }
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        user.updateRefreshToken(null);
+    }
+
     // AT/RT 새로 발급하고 RT는 DB에 갱신 저장 (재발급마다 RT도 회전)
     private TokenResponse issueTokens(User user) {
         String accessToken = jwtTokenProvider.generateAccessToken(user.getUserId(), user.getEmail());

--- a/src/main/java/com/mamoki/ieojuda/domain/account/service/AuthService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/account/service/AuthService.java
@@ -1,0 +1,88 @@
+package com.mamoki.ieojuda.domain.account.service;
+
+import com.mamoki.ieojuda.domain.account.dto.LoginRequest;
+import com.mamoki.ieojuda.domain.account.dto.RefreshRequest;
+import com.mamoki.ieojuda.domain.account.dto.SignupRequest;
+import com.mamoki.ieojuda.domain.account.dto.SignupResponse;
+import com.mamoki.ieojuda.domain.account.dto.TokenResponse;
+import com.mamoki.ieojuda.domain.account.entity.User;
+import com.mamoki.ieojuda.domain.account.repository.UserRepository;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import com.mamoki.ieojuda.global.jwt.component.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+// 명세서 "회원가입 / 로그인" 화면 - 계정 생성, 로그인(AT/RT 발급), RT로 AT 재발급
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Transactional
+    public SignupResponse signup(SignupRequest request) {
+        if (!request.password().equals(request.passwordConfirm())) {
+            throw new CustomException(ErrorCode.PASSWORD_CONFIRMATION_MISMATCH);
+        }
+        if (userRepository.existsByEmail(request.email())) {
+            throw new CustomException(ErrorCode.DUPLICATE_EMAIL);
+        }
+
+        User user = userRepository.save(User.builder()
+                .email(request.email())
+                .password(passwordEncoder.encode(request.password()))
+                .name(request.name())
+                .build());
+
+        return SignupResponse.from(user);
+    }
+
+    @Transactional
+    public TokenResponse login(LoginRequest request) {
+        // 계정 존재 여부가 드러나지 않도록 이메일 불일치/비밀번호 불일치 둘 다 같은 에러코드로 응답
+        User user = userRepository.findByEmail(request.email())
+                .orElseThrow(() -> new CustomException(ErrorCode.INVALID_CREDENTIALS));
+
+        if (!passwordEncoder.matches(request.password(), user.getPassword())) {
+            throw new CustomException(ErrorCode.INVALID_CREDENTIALS);
+        }
+
+        return issueTokens(user);
+    }
+
+    @Transactional
+    public TokenResponse refresh(RefreshRequest request) {
+        String refreshToken = request.refreshToken();
+
+        // 서명/만료 검증은 JwtTokenProvider가 파싱하면서 자동으로 함 - 실패 시 ExpiredJwtException/JwtException이
+        // 그대로 던져지고 GlobalExceptionHandler가 TOKEN_EXPIRED/TOKEN_INVALID로 응답한다.
+        if (!jwtTokenProvider.isRefreshToken(refreshToken)) {
+            throw new CustomException(ErrorCode.TOKEN_INVALID);
+        }
+        Long userId = jwtTokenProvider.getUserId(refreshToken);
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.INVALID_CREDENTIALS));
+
+        // DB에 저장된 RT와 요청으로 들어온 RT가 달라졌다면(로그아웃/재로그인 등으로 이미 교체됨) 재사용 불가
+        if (user.getRefreshToken() == null || !user.getRefreshToken().equals(refreshToken)) {
+            throw new CustomException(ErrorCode.REFRESH_TOKEN_REVOKED);
+        }
+
+        return issueTokens(user);
+    }
+
+    // AT/RT 새로 발급하고 RT는 DB에 갱신 저장 (재발급마다 RT도 회전)
+    private TokenResponse issueTokens(User user) {
+        String accessToken = jwtTokenProvider.generateAccessToken(user.getUserId(), user.getEmail());
+        String refreshToken = jwtTokenProvider.generateRefreshToken(user.getUserId());
+        user.updateRefreshToken(refreshToken);
+        return new TokenResponse(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/controller/PlanController.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/controller/PlanController.java
@@ -1,8 +1,10 @@
 package com.mamoki.ieojuda.domain.plan.controller;
 
+import com.mamoki.ieojuda.domain.plan.dto.CompilationResponse;
 import com.mamoki.ieojuda.domain.plan.dto.PlanCreateRequest;
 import com.mamoki.ieojuda.domain.plan.dto.PlanResponse;
 import com.mamoki.ieojuda.domain.plan.dto.PlanUpdateRequest;
+import com.mamoki.ieojuda.domain.plan.service.LifeAreaService;
 import com.mamoki.ieojuda.domain.plan.service.PlanService;
 import com.mamoki.ieojuda.global.rsdata.RsData;
 import io.swagger.v3.oas.annotations.Operation;
@@ -28,6 +30,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class PlanController {
 
     private final PlanService planService;
+    private final LifeAreaService lifeAreaService;
 
     @Operation(summary = "계획 생성", description = "계획 이름과 대기 기간(7~30일)을 입력받아 계획을 생성합니다. 동시에 기본 삶의 구역(가족/관계 정리/업무 연속성) 3개가 자동 생성됩니다. 작성자는 Authorization 헤더의 Access Token으로 식별합니다.")
     @PostMapping
@@ -53,6 +56,16 @@ public class PlanController {
             @Valid @RequestBody PlanUpdateRequest request
     ) {
         return ResponseEntity.ok(RsData.success(planService.update(planId, request)));
+    }
+
+    // 명세서 "AI 구조화 결과 검토" 화면 - 구역별 AI 구조화 결과 재조회 (id는 lifeAreaId)
+    @Operation(summary = "AI 구조화 결과 조회", description = "삶의 구역별로 가장 최근 AI 구조화 원문 결과를 다시 조회합니다. 대화가 계속되어 재구조화될 때마다 최신 결과로 덮어써지므로 이전 이력은 조회할 수 없습니다.")
+    @GetMapping("/{planId}/compilations/{lifeAreaId}")
+    public ResponseEntity<RsData<CompilationResponse>> getCompilation(
+            @Parameter(description = "계획 ID") @PathVariable Long planId,
+            @Parameter(description = "삶의 구역 ID") @PathVariable Long lifeAreaId
+    ) {
+        return ResponseEntity.ok(RsData.success(lifeAreaService.getCompilation(planId, lifeAreaId)));
     }
 
     // 명세서 "마이페이지" API 호출: 계획 비활성화 POST /api/plans/{planId}/deactivate

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/controller/PlanController.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/controller/PlanController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -28,10 +29,13 @@ public class PlanController {
 
     private final PlanService planService;
 
-    @Operation(summary = "계획 생성", description = "계획 이름과 대기 기간(7~30일)을 입력받아 계획을 생성합니다. 동시에 기본 삶의 구역(가족/관계 정리/업무 연속성) 3개가 자동 생성됩니다.")
+    @Operation(summary = "계획 생성", description = "계획 이름과 대기 기간(7~30일)을 입력받아 계획을 생성합니다. 동시에 기본 삶의 구역(가족/관계 정리/업무 연속성) 3개가 자동 생성됩니다. 작성자는 Authorization 헤더의 Access Token으로 식별합니다.")
     @PostMapping
-    public ResponseEntity<RsData<PlanResponse>> create(@Valid @RequestBody PlanCreateRequest request) {
-        return ResponseEntity.ok(RsData.success(planService.create(request)));
+    public ResponseEntity<RsData<PlanResponse>> create(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody PlanCreateRequest request
+    ) {
+        return ResponseEntity.ok(RsData.success(planService.create(userId, request)));
     }
 
     @Operation(summary = "계획 조회")

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/dto/CompilationResponse.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/dto/CompilationResponse.java
@@ -1,0 +1,16 @@
+package com.mamoki.ieojuda.domain.plan.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+// 명세서 "AI 구조화 결과 검토" 화면 - GET /api/plans/{planId}/compilations/{lifeAreaId}
+// 새 엔티티 없이 LifeArea.aiStructuredResult(구역별 최신 AI 구조화 원문)를 재조회한다.
+// 대화가 계속되어 다시 구조화될 때마다 덮어써지므로 항상 "최신" 결과만 볼 수 있다(이전 이력 조회는 불가).
+public record CompilationResponse(
+        @Schema(description = "삶의 구역 ID") Long lifeAreaId,
+        @Schema(description = "구역 분류", example = "FAMILY", allowableValues = {"FAMILY", "RELATIONSHIP_CLEANUP", "WORK_CONTINUITY"}) String category,
+        @Schema(description = "아직 AI 구조화가 한 번도 실행되지 않았으면 true") boolean empty,
+        @Schema(description = "AI가 구조화한 항목 목록 (empty=true면 빈 목록)") List<AiStructuredItemDto> items
+) {
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/dto/PlanCreateRequest.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/dto/PlanCreateRequest.java
@@ -4,11 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
-// 명세서 "새 계획 만들기" 화면 - 계획 이름/대기기간과 구역별 초기 선택값을 "세부사항 대화하기" 버튼 한 번에 같이 제출
 public record PlanCreateRequest(
-        // TODO: 로그인/JWT 인증이 붙으면 인증된 사용자로 대체하고 이 필드는 제거한다.
-        @Schema(description = "작성자 user_id (임시 - 인증 붙으면 제거 예정)", example = "1")
-        @NotNull(message = "작성자 정보가 필요합니다.") Long userId,
         @Schema(description = "계획 이름", example = "내 유고 계획")
         @NotBlank(message = "계획 이름을 입력해 주세요.") String name,
         @Schema(description = "사후 공개 대기 기간(일), 7~30 사이", example = "14")

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/service/LifeAreaService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/service/LifeAreaService.java
@@ -1,5 +1,8 @@
 package com.mamoki.ieojuda.domain.plan.service;
 
+import tools.jackson.databind.ObjectMapper;
+import com.mamoki.ieojuda.domain.plan.dto.AiTurnResult;
+import com.mamoki.ieojuda.domain.plan.dto.CompilationResponse;
 import com.mamoki.ieojuda.domain.plan.dto.LifeAreaResponse;
 import com.mamoki.ieojuda.domain.plan.entity.LifeArea;
 import com.mamoki.ieojuda.domain.plan.repository.LifeAreaRepository;
@@ -19,6 +22,7 @@ import java.util.List;
 public class LifeAreaService {
 
     private final LifeAreaRepository lifeAreaRepository;
+    private final ObjectMapper objectMapper;
 
     public List<LifeAreaResponse> getLifeAreas(Long planId) {
         return lifeAreaRepository.findByPlan_PlanIdOrderByLifeIdAsc(planId).stream()
@@ -27,11 +31,36 @@ public class LifeAreaService {
     }
 
     public LifeAreaResponse getLifeArea(Long planId, Long lifeAreaId) {
+        return LifeAreaResponse.from(findLifeArea(planId, lifeAreaId));
+    }
+
+    // 명세서 "AI 구조화 결과 검토" 화면 - 새 엔티티 없이 LifeArea.aiStructuredResult(구역별 최신 AI 구조화 원문)를 재조회
+    public CompilationResponse getCompilation(Long planId, Long lifeAreaId) {
+        LifeArea lifeArea = findLifeArea(planId, lifeAreaId);
+        String raw = lifeArea.getAiStructuredResult();
+
+        if (raw == null || raw.isBlank()) {
+            return new CompilationResponse(lifeArea.getLifeId(), lifeArea.getCategory().name(), true, List.of());
+        }
+
+        AiTurnResult result = parseAiTurnResult(raw);
+        return new CompilationResponse(lifeArea.getLifeId(), lifeArea.getCategory().name(), false, result.items());
+    }
+
+    private AiTurnResult parseAiTurnResult(String rawContent) {
+        try {
+            return objectMapper.readValue(rawContent, AiTurnResult.class);
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private LifeArea findLifeArea(Long planId, Long lifeAreaId) {
         LifeArea lifeArea = lifeAreaRepository.findById(lifeAreaId)
                 .orElseThrow(() -> new CustomException(ErrorCode.LIFE_AREA_NOT_FOUND));
         if (!lifeArea.getPlan().getPlanId().equals(planId)) {
             throw new CustomException(ErrorCode.LIFE_AREA_NOT_FOUND);
         }
-        return LifeAreaResponse.from(lifeArea);
+        return lifeArea;
     }
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/service/PlanService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/service/PlanService.java
@@ -51,10 +51,10 @@ public class PlanService {
     private final ObjectMapper objectMapper;
 
     @Transactional
-    public PlanResponse create(PlanCreateRequest request) {
+    public PlanResponse create(Long userId, PlanCreateRequest request) {
         validateWaitingDays(request.waitingDays());
 
-        User user = userRepository.findById(request.userId())
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         Plan plan = planRepository.save(Plan.builder()

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/service/PlanService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/service/PlanService.java
@@ -4,6 +4,7 @@ import tools.jackson.databind.ObjectMapper;
 import com.mamoki.ieojuda.domain.account.entity.User;
 import com.mamoki.ieojuda.domain.account.repository.UserRepository;
 import com.mamoki.ieojuda.domain.plan.dto.AiStructuredItemDto;
+import com.mamoki.ieojuda.domain.plan.dto.AiTurnResult;
 import com.mamoki.ieojuda.domain.plan.dto.InitialStructureResult;
 import com.mamoki.ieojuda.domain.plan.dto.LifeAreaResponse;
 import com.mamoki.ieojuda.domain.plan.dto.LifeAreaTurnResponse;
@@ -114,6 +115,7 @@ public class PlanService {
         InitialStructureResult result = parseInitialStructure(rawContent);
 
         Map<LifeAreaCategory, List<LifeAreaTurnResponse.ItemResponse>> itemsByCategory = new EnumMap<>(LifeAreaCategory.class);
+        Map<LifeAreaCategory, List<AiStructuredItemDto>> dtosByCategory = new EnumMap<>(LifeAreaCategory.class);
         for (AiStructuredItemDto dto : result.items()) {
             // 명세서 "AI 구조화 결과 검토" 예외 처리: 근거 없는 항목은 승인 불가 (여기선 생성 자체를 차단)
             if (dto.sourceExcerpt() == null || dto.sourceExcerpt().isBlank()) {
@@ -143,7 +145,17 @@ public class PlanService {
 
             itemsByCategory.computeIfAbsent(category, key -> new ArrayList<>())
                     .add(LifeAreaTurnResponse.ItemResponse.from(saved));
+            dtosByCategory.computeIfAbsent(category, key -> new ArrayList<>()).add(dto);
         }
+
+        // GET /api/plans/{planId}/compilations/{lifeAreaId}(구역별 AI 구조화 결과 재조회)에서 쓸 수 있도록
+        // 구역별로 이번에 구조화된 원문을 LifeArea.aiStructuredResult에 저장 (대화 턴에서 저장하는 것과 동일한 형태)
+        for (LifeAreaCategory category : LifeAreaCategory.values()) {
+            LifeArea lifeArea = lifeAreasByCategory.get(category);
+            List<AiStructuredItemDto> dtos = dtosByCategory.getOrDefault(category, List.of());
+            lifeArea.applyAiStructuredResult(toJson(new AiTurnResult("RESULT", null, dtos)));
+        }
+
         return itemsByCategory;
     }
 

--- a/src/main/java/com/mamoki/ieojuda/global/config/SecurityConfig.java
+++ b/src/main/java/com/mamoki/ieojuda/global/config/SecurityConfig.java
@@ -4,12 +4,19 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 // 로그인/JWT 필터가 아직 없어서 spring-boot-starter-security 기본 설정이 전체 API를 401로 막던 문제를 임시로 푼다.
-// 추후 회원가입/로그인 + JWT 인증 필터가 붙으면 permitAll 범위를 좁혀야 한다.
+// 추후 JwtAuthenticationFilter가 붙으면 permitAll 범위를 좁혀야 한다 (지금은 회원가입/로그인 기능만 우선 구현).
 @Configuration
 public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {

--- a/src/main/java/com/mamoki/ieojuda/global/config/SecurityConfig.java
+++ b/src/main/java/com/mamoki/ieojuda/global/config/SecurityConfig.java
@@ -1,33 +1,81 @@
 package com.mamoki.ieojuda.global.config;
 
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import com.mamoki.ieojuda.global.jwt.component.JwtTokenProvider;
+import com.mamoki.ieojuda.global.jwt.filter.JwtAuthenticationFilter;
+import com.mamoki.ieojuda.global.jwt.filter.SecurityErrorResponseWriter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-// 로그인/JWT 필터가 아직 없어서 spring-boot-starter-security 기본 설정이 전체 API를 401로 막던 문제를 임시로 푼다.
-// 추후 JwtAuthenticationFilter가 붙으면 permitAll 범위를 좁혀야 한다 (지금은 회원가입/로그인 기능만 우선 구현).
+import java.util.List;
+
 @Configuration
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private static final String[] PERMIT_ALL_PATHS = {
+            "/auth/**",
+            "/swagger-ui/**",
+            "/v3/api-docs/**",
+            "/swagger-ui.html"
+    };
+
+    private final JwtTokenProvider jwtTokenProvider;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
 
+    // 토큰이 아예 없거나(익명) SecurityContext에 인증이 안 채워진 채로 보호된 API에 접근한 경우.
+    // 토큰이 있었지만 만료/위조된 경우는 JwtAuthenticationFilter가 여기까지 오기 전에 직접 응답하고 끝낸다.
+    @Bean
+    public AuthenticationEntryPoint authenticationEntryPoint() {
+        return (request, response, authException) ->
+                SecurityErrorResponseWriter.write(response, ErrorCode.TOKEN_INVALID);
+    }
+
+    // 프론트엔드가 아직 정해진 도메인 없이 여러 환경(로컬/배포)에서 접근하는 개발 단계라 전체 origin을 허용.
+    // Authorization 헤더에 Bearer 토큰을 담아 보내는 방식이라 쿠키 기반 인증(allowCredentials)은 쓰지 않으므로
+    // origin을 "*"로 열어도 자격 증명 노출 문제가 없다.
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOriginPatterns(List.of("*"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(false);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(csrf -> csrf.disable())
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .httpBasic(httpBasic -> httpBasic.disable())
                 .formLogin(formLogin -> formLogin.disable())
                 .authorizeHttpRequests(auth -> auth
-                        .anyRequest().permitAll()
-                );
+                        .requestMatchers(PERMIT_ALL_PATHS).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .exceptionHandling(exception -> exception.authenticationEntryPoint(authenticationEntryPoint()))
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/mamoki/ieojuda/global/exception/ErrorCode.java
+++ b/src/main/java/com/mamoki/ieojuda/global/exception/ErrorCode.java
@@ -8,6 +8,9 @@ public enum ErrorCode {
     // 요청 값 검증 예외 (400) -> @Valid 검증 실패, JSON 파싱 실패, 파라미터 타입 불일치 등
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "INVALID_INPUT", "입력값이 올바르지 않습니다."),
 
+    // 회원가입 / 로그인 관련 예외 (400)
+    PASSWORD_CONFIRMATION_MISMATCH(HttpStatus.BAD_REQUEST, "PASSWORD_CONFIRMATION_MISMATCH", "비밀번호와 비밀번호 확인이 일치하지 않습니다."),
+
     // 계획 / 삶의 구역 / AI 구조화 관련 예외 (400)
     INVALID_WAITING_PERIOD(HttpStatus.BAD_REQUEST, "INVALID_WAITING_PERIOD", "대기 기간은 7~30일 사이여야 합니다."),
     CONSENT_REQUIRED(HttpStatus.BAD_REQUEST, "CONSENT_REQUIRED", "사후 인계 조건과 안전 범위를 확인해 주세요."),

--- a/src/main/java/com/mamoki/ieojuda/global/jwt/component/JwtTokenProvider.java
+++ b/src/main/java/com/mamoki/ieojuda/global/jwt/component/JwtTokenProvider.java
@@ -1,0 +1,78 @@
+package com.mamoki.ieojuda.global.jwt.component;
+
+import com.mamoki.ieojuda.global.jwt.config.JwtProperties;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+// 회원가입/로그인 - Access/Refresh 토큰 발급과 파싱을 담당.
+// 여기서 던지는 io.jsonwebtoken.ExpiredJwtException / JwtException은
+// GlobalExceptionHandler가 이미 TOKEN_EXPIRED / TOKEN_INVALID로 잡아서 응답하므로 별도 try-catch 없이 그대로 던진다.
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    private static final String CLAIM_TOKEN_TYPE = "tokenType";
+    private static final String TOKEN_TYPE_ACCESS = "ACCESS";
+    private static final String TOKEN_TYPE_REFRESH = "REFRESH";
+
+    private final JwtProperties jwtProperties;
+
+    private SecretKey key;
+
+    @PostConstruct
+    void init() {
+        this.key = Keys.hmacShaKeyFor(jwtProperties.getSecret().getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String generateAccessToken(Long userId, String email) {
+        return generateToken(userId, email, TOKEN_TYPE_ACCESS, jwtProperties.getAccessTokenExpirationMs());
+    }
+
+    public String generateRefreshToken(Long userId) {
+        return generateToken(userId, null, TOKEN_TYPE_REFRESH, jwtProperties.getRefreshTokenExpirationMs());
+    }
+
+    //토큰 -> 사용자 ID 추출
+    public Long getUserId(String token) {
+        return Long.valueOf(parseClaims(token).getSubject());
+    }
+
+    public boolean isRefreshToken(String token) { // RT 검증
+        return TOKEN_TYPE_REFRESH.equals(parseClaims(token).get(CLAIM_TOKEN_TYPE, String.class));
+    }
+
+    //토큰 열기
+    private Claims parseClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+
+    //토큰 생성
+    private String generateToken(Long userId, String email, String tokenType, long expirationMs) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + expirationMs);
+
+        var builder = Jwts.builder()
+                .subject(String.valueOf(userId))
+                .claim(CLAIM_TOKEN_TYPE, tokenType)
+                .issuedAt(now)
+                .expiration(expiry);
+
+        if (email != null) {
+            builder.claim("email", email);
+        }
+
+        return builder.signWith(key).compact();
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/global/jwt/component/JwtTokenProvider.java
+++ b/src/main/java/com/mamoki/ieojuda/global/jwt/component/JwtTokenProvider.java
@@ -49,6 +49,10 @@ public class JwtTokenProvider {
         return TOKEN_TYPE_REFRESH.equals(parseClaims(token).get(CLAIM_TOKEN_TYPE, String.class));
     }
 
+    public boolean isAccessToken(String token) { // AT 검증 - JwtAuthenticationFilter에서 사용
+        return TOKEN_TYPE_ACCESS.equals(parseClaims(token).get(CLAIM_TOKEN_TYPE, String.class));
+    }
+
     //토큰 열기
     private Claims parseClaims(String token) {
         return Jwts.parser()

--- a/src/main/java/com/mamoki/ieojuda/global/jwt/config/JwtProperties.java
+++ b/src/main/java/com/mamoki/ieojuda/global/jwt/config/JwtProperties.java
@@ -1,0 +1,21 @@
+package com.mamoki.ieojuda.global.jwt.config;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Getter
+@NoArgsConstructor
+@Component
+public class JwtProperties {
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    @Value("${jwt.access-token-expiration-ms}")
+    private long accessTokenExpirationMs;
+
+    @Value("${jwt.refresh-token-expiration-ms}")
+    private long refreshTokenExpirationMs;
+}

--- a/src/main/java/com/mamoki/ieojuda/global/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/mamoki/ieojuda/global/jwt/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,65 @@
+package com.mamoki.ieojuda.global.jwt.filter;
+
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import com.mamoki.ieojuda.global.jwt.component.JwtTokenProvider;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+// Authorization: Bearer {AT} 헤더를 검증해서 SecurityContext에 인증 정보(principal = userId)를 채운다.
+// 여기서 던져지는 ExpiredJwtException/JwtException은 GlobalExceptionHandler(컨트롤러 이후 계층)가 못 잡으므로
+// SecurityErrorResponseWriter로 직접 같은 포맷(RsData)의 401 응답을 만든다.
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String HEADER_NAME = "Authorization";
+    private static final String TOKEN_PREFIX = "Bearer ";
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String token = resolveToken(request);
+
+        if (token != null) {
+            try {
+                if (!jwtTokenProvider.isAccessToken(token)) {
+                    SecurityErrorResponseWriter.write(response, ErrorCode.TOKEN_INVALID);
+                    return;
+                }
+                Long userId = jwtTokenProvider.getUserId(token);
+                SecurityContextHolder.getContext().setAuthentication(
+                        new UsernamePasswordAuthenticationToken(userId, null, List.of()));
+            } catch (ExpiredJwtException e) {
+                SecurityErrorResponseWriter.write(response, ErrorCode.TOKEN_EXPIRED);
+                return;
+            } catch (JwtException e) {
+                SecurityErrorResponseWriter.write(response, ErrorCode.TOKEN_INVALID);
+                return;
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String header = request.getHeader(HEADER_NAME);
+        if (header != null && header.startsWith(TOKEN_PREFIX)) {
+            return header.substring(TOKEN_PREFIX.length());
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/global/jwt/filter/SecurityErrorResponseWriter.java
+++ b/src/main/java/com/mamoki/ieojuda/global/jwt/filter/SecurityErrorResponseWriter.java
@@ -1,0 +1,27 @@
+package com.mamoki.ieojuda.global.jwt.filter;
+
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+// JwtAuthenticationFilter와 SecurityConfig의 AuthenticationEntryPoint가 공유하는 401 응답 작성 유틸.
+// 둘 다 DispatcherServlet보다 앞단(필터 체인)에서 동작해서 GlobalExceptionHandler(@RestControllerAdvice)를
+// 타지 않기 때문에, 같은 RsData 형태로 직접 응답을 만들어야 다른 API들과 에러 응답 포맷이 일관된다.
+public class SecurityErrorResponseWriter {
+
+    private SecurityErrorResponseWriter() {
+    }
+
+    public static void write(HttpServletResponse response, ErrorCode errorCode) throws IOException {
+        response.setStatus(errorCode.getHttpStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        String body = """
+                {"success":false,"data":null,"error":{"code":"%s","message":"%s"},"timestamp":"%s"}""".formatted(
+                errorCode.getCode(), errorCode.getMessage(), LocalDateTime.now());
+        response.getWriter().write(body);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -31,3 +31,8 @@ aws.s3.bucket=${AWS_S3_BUCKET}
 aws.s3.region=${AWS_S3_REGION}
 aws.s3.access-key=${AWS_ACCESS_KEY_ID}
 aws.s3.secret-key=${AWS_SECRET_ACCESS_KEY}
+
+#JWT 설정 - Access 1시간, Refresh 14일
+jwt.secret=${JWT_SECRET}
+jwt.access-token-expiration-ms=3600000
+jwt.refresh-token-expiration-ms=1209600000


### PR DESCRIPTION
## 연관 Issue
close #9 


## 요약
JWT 생성 기능 구현 및 로그인 관련 api 구현

## 작업 내용
- jwt 토큰 생성, 갱신, 조회 로직 구현
- 회원가입, 로그인, 로그아웃, RT갱신 API 구현

## 범위
### 포함:
- 기존 계획, AI관련 api jwt인증 확인
- 접근경로 설정 및 cors 설정
- 회원가입, 로그인, 로그아웃, RT갱신 api 구현
- jwt 토큰 생성, 조회, 재발급 기능 구현
- AT 만료시간 1시간, RT 만료시간 14일로 설정

### 제외:
- 회원 탈퇴 기능 미구현 (추후 필요 시 구현 예정)
- 토큰 파기 기능 미구현 (추후 필요 시 구현 예정)

## 스크린샷 / 미리 보기
<img width="1772" height="1288" alt="image" src="https://github.com/user-attachments/assets/d40e5ce7-04ac-4da3-8d73-02e27a9b7a45" />
회원가입 API

<img width="1778" height="1288" alt="image" src="https://github.com/user-attachments/assets/cfe82a47-cec2-450e-bc32-ea3e7ec0af1f" />
로그인 API

<img width="1776" height="1292" alt="image" src="https://github.com/user-attachments/assets/a20d90ce-ec2d-46ce-97b9-77b198716dfd" />
토큰 갱신 API

<img width="1780" height="1272" alt="image" src="https://github.com/user-attachments/assets/e7e412b0-a42d-431f-a306-d50cee419d2d" />
로그아웃 API