### PR TITLE
[Feat#13]DB 변경에 의한 entity 수정 

### DIFF
--- a/src/main/java/com/mamoki/ieojuda/domain/plan/entity/Conversation.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/entity/Conversation.java
@@ -1,0 +1,29 @@
+package com.mamoki.ieojuda.domain.plan.entity;
+
+import com.mamoki.ieojuda.global.entity.BaseCreatedAtEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "conversation")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Conversation extends BaseCreatedAtEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "conversation_id")
+    private Long conversationId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "plan_id", nullable = false)
+    private Plan plan;
+
+    @Builder
+    public Conversation(Plan plan) {
+        this.plan = plan;
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/entity/Item.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/entity/Item.java
@@ -54,9 +54,13 @@ public class Item {
     @Column(name = "reviewed_at")
     private LocalDateTime reviewedAt;
 
+    @Column(name = "sort_order")
+    private Integer sortOrder;
+
     @Builder
     public Item(LifeArea lifeArea, String targetName, String locationType, String action,
-                String precondition, DisclosureScope disclosureScope, String sourceExcerpt) {
+                String precondition, DisclosureScope disclosureScope, String sourceExcerpt,
+                Integer sortOrder) {
         this.lifeArea = lifeArea;
         this.targetName = targetName;
         this.locationType = locationType;
@@ -64,6 +68,7 @@ public class Item {
         this.precondition = precondition;
         this.disclosureScope = disclosureScope;
         this.sourceExcerpt = sourceExcerpt;
+        this.sortOrder = sortOrder;
         this.status = ItemStatus.PROPOSED;
     }
 

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/entity/LifeArea.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/entity/LifeArea.java
@@ -1,19 +1,16 @@
 package com.mamoki.ieojuda.domain.plan.entity;
 
-import com.mamoki.ieojuda.global.entity.BaseUpdatedAtEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
-
 @Entity
 @Table(name = "life_areas")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class LifeArea extends BaseUpdatedAtEntity {
+public class LifeArea {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -24,41 +21,18 @@ public class LifeArea extends BaseUpdatedAtEntity {
     @JoinColumn(name = "plan_id", nullable = false)
     private Plan plan;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "conversation_id", nullable = false)
+    private Conversation conversation;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "category", length = 30)
     private LifeAreaCategory category;
 
-    @Column(name = "raw_text", columnDefinition = "TEXT")
-    private String rawText;
-
-    @Column(name = "ai_structured_result", columnDefinition = "TEXT")
-    private String aiStructuredResult;
-
-    @Column(name = "reviewed_at")
-    private LocalDateTime reviewedAt;
-
-
-    // 명세서 삶의 구역 재작성에서 사용자가 처음 원문저장에서 AI 구조조화 결과, 검토 완료 시각 없어서 우선 제외 시킴
     @Builder
-    public LifeArea(Plan plan, LifeAreaCategory category, String rawText) {
+    public LifeArea(Plan plan, Conversation conversation, LifeAreaCategory category) {
         this.plan = plan;
+        this.conversation = conversation;
         this.category = category;
-        this.rawText = rawText;
-    }
-
-    // AI 구조화 요청 시점에서 호출하기 위해 설정
-    public void applyAiStructuredResult(String aiStructuredResult) {
-        this.aiStructuredResult = aiStructuredResult;
-    }
-
-    // 새 계획 만들기 화면의 "세부사항 대화하기" 버튼 - 구역별 초기 입력(자유 텍스트 또는 선택값 JSON)을 저장
-    // 대화 턴마다 이 값을 다시 함께 보내야 AI가 초기 선택값을 계속 기억함
-    public void applyRawText(String rawText) {
-        this.rawText = rawText;
-    }
-
-    // AI 구조화 검토에서 호출되게 설정
-    public void review() {
-        this.reviewedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/entity/LifeAreaMessage.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/entity/LifeAreaMessage.java
@@ -19,8 +19,8 @@ public class LifeAreaMessage extends BaseCreatedAtEntity {
     private Long messageId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "life_id", nullable = false)
-    private LifeArea lifeArea;
+    @JoinColumn(name = "conversation_id", nullable = false)
+    private Conversation conversation;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "role", length = 20)
@@ -31,8 +31,8 @@ public class LifeAreaMessage extends BaseCreatedAtEntity {
 
     // 삶의 구역 작성 대화(말풍선) 한 턴을 저장 - 사용자 발화/AI 응답이 순서대로 쌓임
     @Builder
-    public LifeAreaMessage(LifeArea lifeArea, MessageRole role, String content) {
-        this.lifeArea = lifeArea;
+    public LifeAreaMessage(Conversation conversation, MessageRole role, String content) {
+        this.conversation = conversation;
         this.role = role;
         this.content = content;
     }

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/entity/Plan.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/entity/Plan.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "plans")
+@Table(name = "plans", uniqueConstraints = @UniqueConstraint(name = "UQ_plans_user_id", columnNames = "user_id"))
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Plan extends BaseCreatedAtEntity {
@@ -23,27 +23,14 @@ public class Plan extends BaseCreatedAtEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Column(name = "name", length = 100)
-    private String name;
-
-    @Column(name = "waiting_days")
-    private Integer waitingDays;
-
     @Enumerated(EnumType.STRING)
     @Column(name = "status", length = 30)
     private PlanStatus status;
 
     @Builder
-    public Plan(User user, String name, Integer waitingDays) {
+    public Plan(User user) {
         this.user = user;
-        this.name = name;
-        this.waitingDays = waitingDays;
         this.status = PlanStatus.DRAFT; // plan 생성하면 '작성중' 적용하기 위해
-    }
-
-    public void updateInfo(String name, Integer waitingDays) {
-        this.name = name;
-        this.waitingDays = waitingDays;
     }
 
     public void deactivate() {

--- a/src/main/java/com/mamoki/ieojuda/domain/recipient/entity/Recipient.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/recipient/entity/Recipient.java
@@ -1,6 +1,7 @@
 package com.mamoki.ieojuda.domain.recipient.entity;
 
 import com.mamoki.ieojuda.domain.plan.entity.DisclosureScope;
+import com.mamoki.ieojuda.domain.plan.entity.LifeArea;
 import com.mamoki.ieojuda.domain.plan.entity.Plan;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -24,6 +25,10 @@ public class Recipient {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "plan_id", nullable = false)
     private Plan plan;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "life_id", nullable = false)
+    private LifeArea lifeArea;
 
     @Column(name = "name", length = 100)
     private String name;
@@ -68,10 +73,11 @@ public class Recipient {
 
     // 담당자 등록 시점 - 역할명, 담당자 이름, 이메일, 공개 범주, 최대 단계 대기 시간, 대체 담당자 입력
     @Builder
-    public Recipient(Plan plan, String name, String email, RoleType roleType,
+    public Recipient(Plan plan, LifeArea lifeArea, String name, String email, RoleType roleType,
                      Boolean isBackup, DisclosureScope disclosureScope,
                      Integer maxWaitHours, Recipient backupFor) {
         this.plan = plan;
+        this.lifeArea = lifeArea;
         this.name = name;
         this.email = email;
         this.roleType = roleType;


### PR DESCRIPTION

## 연관 Issue
- Closes #13 

## 요약
화면 플로우(대화 작성 → AI 구조화 결과 검토 → 역할별 담당자 등록)와 맞지 않던 DB 스키마를 실제 흐름에 맞게 수정했습니다.

## 변경 사항
- `plans.user_id`에 UNIQUE 제약 추가 (유저당 plan 1개 강제)
- `plans`에서 미사용 컬럼 `name`, `waiting_days` 제거
- `conversation` 테이블 신설, `plan_id` FK 연결
- `LifeAreaMessage`가 `life_id` 대신 `conversation_id`를 참조하도록 변경 (대화 진행 중에도 메시지 저장 가능하도록 순서 모순 해소)
- `life_areas`에서 실 데이터 컬럼(`raw_text`, `ai_structured_result`, `reviewed_at`, `updated_at`) 제거, `conversation_id` 추가 (박스 내용은 `items`가 전담하도록 역할 이관)
- `items.assigne_id`를 nullable로 변경, `sort_order` 컬럼 추가
- `role_assigness`에 `life_id` 컬럼 및 FK 추가 (담당자를 박스 단위로 직접 연결)

## 범위

### 포함
- 위 6개 테이블(`plans`, `conversation`, `LifeAreaMessage`, `life_areas`, `items`, `role_assigness`)의 컬럼/제약 변경
- 변경된 스키마 기준 ERD 갱신
