### PR TITLE
[Feat/#18] 역할 담당자 등록

### DIFF
--- a/src/main/java/com/mamoki/ieojuda/domain/recipient/controller/RecipientController.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/recipient/controller/RecipientController.java
@@ -1,0 +1,37 @@
+package com.mamoki.ieojuda.domain.recipient.controller;
+
+import com.mamoki.ieojuda.domain.recipient.dto.RecipientBulkRegisterRequest;
+import com.mamoki.ieojuda.domain.recipient.dto.RecipientBulkRegisterResponse;
+import com.mamoki.ieojuda.domain.recipient.service.RecipientService;
+import com.mamoki.ieojuda.global.rsdata.RsData;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+// 명세서 "역할 담당자 등록" 화면 - 승인된 항목(박스)마다 담당자를 배정하고 수락 이메일을 발송
+@Tag(name = "Recipient", description = "역할 담당자 등록 / 수락 이메일 발송")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/plans/{planId}/recipients")
+public class RecipientController {
+
+    private final RecipientService recipientService;
+
+    @Operation(summary = "역할 담당자 일괄 등록", description = "승인된 항목 개수만큼 담당자 정보를 한 번에 등록하고, 등록 즉시 역할 수락 이메일을 발송합니다. 일부 발송이 실패해도 담당자 저장은 유지되며 건별 발송 결과가 응답에 담깁니다.")
+    @PostMapping
+    public ResponseEntity<RsData<RecipientBulkRegisterResponse>> registerAll(
+            @Parameter(description = "계획 ID") @PathVariable Long planId,
+            @Valid @RequestBody RecipientBulkRegisterRequest request
+    ) {
+        RecipientBulkRegisterResponse result = recipientService.registerAll(planId, request);
+        return ResponseEntity.ok(RsData.success(result));
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/recipient/dto/RecipientBulkRegisterRequest.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/recipient/dto/RecipientBulkRegisterRequest.java
@@ -1,0 +1,15 @@
+package com.mamoki.ieojuda.domain.recipient.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+// "역할 담당자 등록" 화면 - 승인된 항목 개수만큼 담당자를 한 번에 등록하고 수락 이메일을 발송
+public record RecipientBulkRegisterRequest(
+        @Schema(description = "등록할 담당자 목록 (승인된 항목 개수만큼)")
+        @NotEmpty(message = "등록할 담당자를 한 명 이상 입력해 주세요.")
+        @Valid List<RecipientRegisterRequest> recipients
+) {
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/recipient/dto/RecipientBulkRegisterResponse.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/recipient/dto/RecipientBulkRegisterResponse.java
@@ -1,0 +1,10 @@
+package com.mamoki.ieojuda.domain.recipient.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record RecipientBulkRegisterResponse(
+        @Schema(description = "등록 + 발송 결과 목록") List<RecipientRegisterResponse> recipients
+) {
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/recipient/dto/RecipientRegisterRequest.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/recipient/dto/RecipientRegisterRequest.java
@@ -1,0 +1,23 @@
+package com.mamoki.ieojuda.domain.recipient.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+// "AI 구조화 결과 검토"에서 승인된 항목 하나에 배정할 역할 담당자 입력
+public record RecipientRegisterRequest(
+        @Schema(description = "담당자를 배정할 승인된 항목 ID", example = "1")
+        @NotNull(message = "항목을 선택해 주세요.") Long itemId,
+
+        @Schema(description = "담당자 이름", example = "김민수")
+        @NotBlank(message = "담당자 이름을 입력해 주세요.") String name,
+
+        @Schema(description = "담당자 이메일", example = "recipient@example.com")
+        @NotBlank(message = "담당자 이메일을 입력해 주세요.")
+        @Email(message = "이메일 형식이 올바르지 않습니다.") String email,
+
+        @Schema(description = "최대 단계 대기 시간(시간 단위, 7/14/21일에 대응)", example = "168", allowableValues = {"168", "336", "504"})
+        @NotNull(message = "대기 기간을 선택해 주세요.") Integer maxWaitHours
+) {
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/recipient/dto/RecipientRegisterResponse.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/recipient/dto/RecipientRegisterResponse.java
@@ -1,0 +1,33 @@
+package com.mamoki.ieojuda.domain.recipient.dto;
+
+import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+// 담당자 등록 + 수락 이메일 발송 결과 하나
+public record RecipientRegisterResponse(
+        @Schema(description = "담당자 ID") Long recipientId,
+        @Schema(description = "배정된 항목 ID") Long itemId,
+        @Schema(description = "역할 유형", example = "FAMILY_MANAGER", allowableValues = {"FAMILY_MANAGER", "WORK_MANAGER", "RELATIONSHIP_MANAGER"}) String roleType,
+        @Schema(description = "공개 범위", example = "FAMILY", allowableValues = {"FAMILY", "WORK", "RELATIONSHIP"}) String disclosureScope,
+        @Schema(description = "담당자 이름") String name,
+        @Schema(description = "담당자 이메일") String email,
+        @Schema(description = "최대 단계 대기 시간(시간 단위)") Integer maxWaitHours,
+        @Schema(description = "수락 상태", example = "PENDING", allowableValues = {"PENDING", "ACCEPTED", "DECLINED", "EXPIRED"}) String acceptanceStatus,
+        @Schema(description = "역할 수락 이메일 발송 성공 여부") boolean emailSent,
+        @Schema(description = "발송 실패 시 반송 유형 (성공 시 null)", example = "TEMPORARY", allowableValues = {"NONE", "TEMPORARY", "PERMANENT"}) String bounceType
+) {
+    public static RecipientRegisterResponse of(Recipient recipient, Long itemId, boolean emailSent, String bounceType) {
+        return new RecipientRegisterResponse(
+                recipient.getAssigneeId(),
+                itemId,
+                recipient.getRoleType().name(),
+                recipient.getDisclosureScope() == null ? null : recipient.getDisclosureScope().name(),
+                recipient.getName(),
+                recipient.getEmail(),
+                recipient.getMaxWaitHours(),
+                recipient.getAcceptanceStatus().name(),
+                emailSent,
+                bounceType
+        );
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/recipient/entity/Recipient.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/recipient/entity/Recipient.java
@@ -67,6 +67,9 @@ public class Recipient {
     @Column(name = "invite_token", length = 255)
     private String inviteToken;
 
+    @Column(name = "invite_token_expires_at")
+    private LocalDateTime inviteTokenExpiresAt;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "backup_for_id")
     private Recipient backupFor;
@@ -88,9 +91,10 @@ public class Recipient {
         this.acceptanceStatus = AcceptanceStatus.PENDING;
     }
 
-    // 초대 이메일 토큰 저장
-    public void issueInviteToken(String inviteToken) {
-        this.inviteToken = inviteToken;
+    // 초대 이메일 토큰 저장 (평문이 아닌 해시값만 저장, 만료 시각 함께 기록)
+    public void issueInviteToken(String inviteTokenHash, LocalDateTime expiresAt) {
+        this.inviteToken = inviteTokenHash;
+        this.inviteTokenExpiresAt = expiresAt;
     }
 
     // 담당자 수락
@@ -115,6 +119,7 @@ public class Recipient {
         this.acceptanceStatus = AcceptanceStatus.PENDING;
         this.acceptedAt = null;
         this.inviteToken = null;
+        this.inviteTokenExpiresAt = null;
     }
 
     // 사후 인계 단계에서 담당자에게 이메일을 보낸 시간 기록

--- a/src/main/java/com/mamoki/ieojuda/domain/recipient/repository/RecipientRepository.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/recipient/repository/RecipientRepository.java
@@ -1,0 +1,7 @@
+package com.mamoki.ieojuda.domain.recipient.repository;
+
+import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RecipientRepository extends JpaRepository<Recipient, Long> {
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/recipient/service/RecipientService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/recipient/service/RecipientService.java
@@ -1,0 +1,161 @@
+package com.mamoki.ieojuda.domain.recipient.service;
+
+import com.mamoki.ieojuda.domain.plan.entity.DisclosureScope;
+import com.mamoki.ieojuda.domain.plan.entity.Item;
+import com.mamoki.ieojuda.domain.plan.entity.ItemStatus;
+import com.mamoki.ieojuda.domain.plan.entity.LifeArea;
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.plan.repository.ItemRepository;
+import com.mamoki.ieojuda.domain.recipient.dto.RecipientBulkRegisterRequest;
+import com.mamoki.ieojuda.domain.recipient.dto.RecipientBulkRegisterResponse;
+import com.mamoki.ieojuda.domain.recipient.dto.RecipientRegisterRequest;
+import com.mamoki.ieojuda.domain.recipient.dto.RecipientRegisterResponse;
+import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
+import com.mamoki.ieojuda.domain.recipient.entity.RoleType;
+import com.mamoki.ieojuda.domain.recipient.repository.RecipientRepository;
+import com.mamoki.ieojuda.global.config.AppProperties;
+import com.mamoki.ieojuda.global.email.contract.EmailContent;
+import com.mamoki.ieojuda.global.email.contract.EmailSendResult;
+import com.mamoki.ieojuda.global.email.sender.EmailSender;
+import com.mamoki.ieojuda.global.email.template.EmailBuilder;
+import com.mamoki.ieojuda.global.email.token.TokenProvider;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+// "역할 담당자 등록" 화면 - 승인된 항목(박스) 하나당 담당자 한 명을 배정하고, 등록과 동시에 역할 수락 이메일을 발송
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RecipientService {
+
+    private static final Set<Integer> ALLOWED_WAIT_HOURS = Set.of(168, 336, 504); // 7일/14일/21일
+
+    private final ItemRepository itemRepository;
+    private final RecipientRepository recipientRepository;
+    private final EmailSender emailSender;
+    private final AppProperties appProperties;
+
+    @Transactional
+    public RecipientBulkRegisterResponse registerAll(Long planId, RecipientBulkRegisterRequest request) {
+        List<Item> items = validateAll(planId, request.recipients());
+
+        List<RecipientRegisterResponse> responses = new ArrayList<>();
+        for (int i = 0; i < request.recipients().size(); i++) {
+            responses.add(registerOne(items.get(i), request.recipients().get(i)));
+        }
+
+        return new RecipientBulkRegisterResponse(responses);
+    }
+
+    // 이메일은 발송 후 되돌릴 수 없으므로, 저장·발송을 시작하기 전에 요청 전체를 먼저 검증한다
+    private List<Item> validateAll(Long planId, List<RecipientRegisterRequest> requests) {
+        Set<Long> requestedItemIds = new HashSet<>();
+        List<Item> items = new ArrayList<>();
+
+        for (RecipientRegisterRequest request : requests) {
+            if (!requestedItemIds.add(request.itemId())) {
+                throw new CustomException(ErrorCode.RECIPIENT_ALREADY_ASSIGNED);
+            }
+
+            Item item = findItem(planId, request.itemId());
+
+            //  진입 조건: "구조화 항목이 승인된 후 진입"
+            if (item.getStatus() != ItemStatus.APPROVED) {
+                throw new CustomException(ErrorCode.ITEM_NOT_APPROVED);
+            }
+            // 항목(박스) 하나당 담당자 한 명 규칙
+            if (item.getRecipient() != null) {
+                throw new CustomException(ErrorCode.RECIPIENT_ALREADY_ASSIGNED);
+            }
+            if (!ALLOWED_WAIT_HOURS.contains(request.maxWaitHours())) {
+                throw new CustomException(ErrorCode.INVALID_WAITING_PERIOD);
+            }
+
+            items.add(item);
+        }
+
+        return items;
+    }
+
+    // 담당자 저장 + 항목 배정 + 초대 토큰 발급 + 수락 이메일 발송
+    // 이메일 발송 실패는 예외로 던지지 않는다 - 담당자 저장은 유지하고 건별 결과만 응답에 담는다
+    private RecipientRegisterResponse registerOne(Item item, RecipientRegisterRequest request) {
+        LifeArea lifeArea = item.getLifeArea();
+        Plan plan = lifeArea.getPlan();
+        DisclosureScope disclosureScope = item.getDisclosureScope();
+
+        Recipient recipient = recipientRepository.save(Recipient.builder()
+                .plan(plan)
+                .lifeArea(lifeArea)
+                .name(request.name())
+                .email(request.email())
+                .roleType(toRoleType(disclosureScope))
+                .isBackup(false)
+                .disclosureScope(disclosureScope)
+                .maxWaitHours(request.maxWaitHours())
+                .build());
+
+        item.assignRecipient(recipient);
+
+        String plainToken = TokenProvider.generatePlainToken();
+        LocalDateTime expiresAt = LocalDateTime.now().plusHours(appProperties.getInviteTokenTtlHours());
+        recipient.issueInviteToken(TokenProvider.hashToken(plainToken), expiresAt);
+
+        EmailSendResult sendResult = sendAcceptanceEmail(recipient, disclosureScope, plainToken, expiresAt);
+
+        return RecipientRegisterResponse.of(
+                recipient,
+                item.getItemId(),
+                sendResult.success(),
+                sendResult.bounceType() == null ? null : sendResult.bounceType().name()
+        );
+    }
+
+    private EmailSendResult sendAcceptanceEmail(Recipient recipient, DisclosureScope disclosureScope,
+                                                 String plainToken, LocalDateTime expiresAt) {
+        String secureLink = appProperties.getBaseUrl() + "/recipient-acceptances/" + plainToken;
+        EmailContent content = EmailBuilder.build(
+                toRoleName(disclosureScope),
+                "역할 수락 여부를 확인해 주세요.",
+                expiresAt.atZone(ZoneId.systemDefault()),
+                secureLink,
+                appProperties.getContactEmail()
+        );
+        return emailSender.send(recipient.getEmail(), content);
+    }
+
+    private RoleType toRoleType(DisclosureScope disclosureScope) {
+        return switch (disclosureScope) {
+            case FAMILY -> RoleType.FAMILY_MANAGER;
+            case WORK -> RoleType.WORK_MANAGER;
+            case RELATIONSHIP -> RoleType.RELATIONSHIP_MANAGER;
+        };
+    }
+
+    private String toRoleName(DisclosureScope disclosureScope) {
+        return switch (disclosureScope) {
+            case FAMILY -> "가족 담당자";
+            case WORK -> "업무 처리 담당자";
+            case RELATIONSHIP -> "관계 정리 담당자";
+        };
+    }
+
+    private Item findItem(Long planId, Long itemId) {
+        Item item = itemRepository.findById(itemId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ITEM_NOT_FOUND));
+        if (!item.getLifeArea().getPlan().getPlanId().equals(planId)) {
+            throw new CustomException(ErrorCode.ITEM_NOT_FOUND);
+        }
+        return item;
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/global/config/AppProperties.java
+++ b/src/main/java/com/mamoki/ieojuda/global/config/AppProperties.java
@@ -1,0 +1,21 @@
+package com.mamoki.ieojuda.global.config;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Getter
+@NoArgsConstructor
+@Component
+public class AppProperties {
+
+    @Value("${app.base-url}")
+    private String baseUrl;
+
+    @Value("${app.contact-email}")
+    private String contactEmail;
+
+    @Value("${app.invite-token-ttl-hours}")
+    private long inviteTokenTtlHours;
+}

--- a/src/main/java/com/mamoki/ieojuda/global/exception/ErrorCode.java
+++ b/src/main/java/com/mamoki/ieojuda/global/exception/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
     CONSENT_REQUIRED(HttpStatus.BAD_REQUEST, "CONSENT_REQUIRED", "사후 인계 조건과 안전 범위를 확인해 주세요."),
     SUSPECTED_CREDENTIAL_INPUT(HttpStatus.BAD_REQUEST, "SUSPECTED_CREDENTIAL_INPUT", "비밀번호 등 자격증명으로 의심되는 내용은 저장할 수 없습니다."),
     UNGROUNDED_ITEM_NOT_APPROVABLE(HttpStatus.BAD_REQUEST, "UNGROUNDED_ITEM_NOT_APPROVABLE", "원문 근거가 없는 항목은 승인할 수 없습니다."),
+    ITEM_NOT_APPROVED(HttpStatus.BAD_REQUEST, "ITEM_NOT_APPROVED", "승인되지 않은 항목에는 담당자를 등록할 수 없습니다."),
     PROHIBITED_ACTION_DETECTED(HttpStatus.BAD_REQUEST, "PROHIBITED_ACTION_DETECTED", "AI가 처리할 수 없는 금지 행동이 포함되어 있습니다."),
     PACKAGE_SEAL_BLOCKED(HttpStatus.BAD_REQUEST, "PACKAGE_SEAL_BLOCKED", "금지 정보나 근거 없는 항목이 있어 패키지를 봉인할 수 없습니다."),
     CIRCULAR_DEPENDENCY_DETECTED(HttpStatus.BAD_REQUEST, "CIRCULAR_DEPENDENCY_DETECTED", "발송 단계에 순환 의존 관계가 존재합니다."),
@@ -70,6 +71,7 @@ public enum ErrorCode {
     DISPUTE_RAISED(HttpStatus.CONFLICT, "DISPUTE_RAISED", "이의 제기가 접수되어 자동 발송이 중지되었습니다."),
     RELEASE_CASE_FROZEN(HttpStatus.CONFLICT, "RELEASE_CASE_FROZEN", "사건이 동결되어 있어 처리할 수 없습니다."),
     ACTIVE_RELEASE_CASE_EXISTS(HttpStatus.CONFLICT, "ACTIVE_RELEASE_CASE_EXISTS", "진행 중인 사후 인계 사건이 있어 계정을 삭제할 수 없습니다."),
+    RECIPIENT_ALREADY_ASSIGNED(HttpStatus.CONFLICT, "RECIPIENT_ALREADY_ASSIGNED", "해당 항목에는 이미 담당자가 등록되어 있습니다."),
 
     // 서버 에러 (500)
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR","서버 오류가 발생했습니다.");

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -36,3 +36,11 @@ aws.s3.secret-key=${AWS_SECRET_ACCESS_KEY}
 jwt.secret=${JWT_SECRET}
 jwt.access-token-expiration-ms=3600000
 jwt.refresh-token-expiration-ms=1209600000
+
+#역할 수락 링크 / 문의 주소 설정
+#프론트 주소
+app.base-url=${APP_BASE_URL}
+#문의 주소( HTML 형식으로 바꿀 떄  삭제 예정)
+app.contact-email=${APP_CONTACT_EMAIL}
+# 초대 링크 토큰 시간
+app.invite-token-ttl-hours=72


### PR DESCRIPTION
## 연관 Issue

- Closes #{Issue 번호}

## 요약

 AI 구조화 결과 검토에서 승인된 항목(박스) 하나당 역할 담당자 한 명을 등록하고, 등록과 동시에 역할 수락 이메일을 발송하는 API를 구현

## 변경 사항

 - domain/recipient 패키지에 controller/service/repository/dto 신규 구현                                                                                                          
  - POST /api/plans/{planId}/recipients — 승인된 항목 배열을 받아 한 번에 담당자 등록 + 수락 이메일 발송                                                                           
  - Recipient 엔티티에 초대 토큰 만료 시각 컬럼(inviteTokenExpiresAt) 추가                                                                                                         
  - 역할 수락 링크·문의 주소 설정값(app.base-url, app.contact-email, app.invite-token-ttl-hours) 추가                                                                              
  - ErrorCode에 ITEM_NOT_APPROVED(400), RECIPIENT_ALREADY_ASSIGNED(409) 추가                                                                                                       
  - 기존 미사용 상태였던 Item.assignRecipient()를 처음으로 연결해서 사용

## 범위

### 포함

- 승인된 항목(status=APPROVED) 단위로 담당자 1명 배정, 요청 배열/기존 배정 기준 중복 방지                                                                                        
- 일부 이메일 발송이 실패해도 담당자 저장은 유지하고, 건별 발송 결과를 응답에 반환                                                                        
- 초대 토큰은 SHA-256 해시로만 저장(평문은 링크 전달용으로만 사용, DB 미저장)

### 제외
- 담당자 수정/삭제 API
- 역할 수락 이메일/화면
- 대체(백업) 담당자 등록 -> wireframe 나오면 다시 수정 예정 

## 스크린샷 / 미리 보기
<img width="1438" height="1001" alt="image" src="https://github.com/user-attachments/assets/022c0391-b84c-48d3-93b7-56230d09f911" />
-이름, 이메일, 대기 시간 입력 등록과 동시에 이메일 전송
<img width="1482" height="685" alt="image" src="https://github.com/user-attachments/assets/37193bcb-d5c4-417b-8da6-624cbdd03d7e" />
- 전송 결과 (이메일 두건 이상 동시 전송 테스트 통과) 


