### PR TITLE
[Feat/#18]:지정확인자 등록 

### DIFF
--- a/src/main/java/com/mamoki/ieojuda/domain/confirmer/controller/ConfirmerController.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/confirmer/controller/ConfirmerController.java
@@ -1,0 +1,39 @@
+package com.mamoki.ieojuda.domain.confirmer.controller;
+
+import com.mamoki.ieojuda.domain.confirmer.dto.ConfirmerBulkRegisterRequest;
+import com.mamoki.ieojuda.domain.confirmer.dto.ConfirmerBulkRegisterResponse;
+import com.mamoki.ieojuda.domain.confirmer.service.ConfirmerService;
+import com.mamoki.ieojuda.global.rsdata.RsData;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+// "지정확인자 등록" 화면 - 확인자를 한 번에 등록하고 수락 이메일을 발송
+@Tag(name = "Confirmer", description = "지정 확인자 등록 / 수락 이메일 발송")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/plans/{planId}/confirmers")
+public class ConfirmerController {
+
+    private final ConfirmerService confirmerService;
+
+    @Operation(summary = "지정 확인자 일괄 등록", description = "입력한 확인자 정보를 한 번에 등록하고, 등록 즉시 수락 이메일을 발송합니다. 일부 발송이 실패해도 확인자 저장은 유지되며 건별 발송 결과가 응답에 담깁니다.")
+    @PostMapping
+    public ResponseEntity<RsData<ConfirmerBulkRegisterResponse>> registerAll(
+            @AuthenticationPrincipal Long userId, // 현재 로그인한 사용자 ID 식별
+            @Parameter(description = "계획 ID") @PathVariable Long planId,
+            @Valid @RequestBody ConfirmerBulkRegisterRequest request
+    ) {
+        ConfirmerBulkRegisterResponse result = confirmerService.registerAll(userId, planId, request);
+        return ResponseEntity.ok(RsData.success(result));
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/confirmer/dto/ConfirmerBulkRegisterRequest.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/confirmer/dto/ConfirmerBulkRegisterRequest.java
@@ -1,0 +1,15 @@
+package com.mamoki.ieojuda.domain.confirmer.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+// "지정 확인자 등록" 화면 - "확인자 등록하기"로 늘린 폼 전체를 한 번에 등록하고 수락 이메일을 발송
+public record ConfirmerBulkRegisterRequest(
+        @Schema(description = "등록할 확인자 목록")
+        @NotEmpty(message = "등록할 확인자를 한 명 이상 입력해 주세요.")
+        @Valid List<ConfirmerRegisterRequest> confirmers
+) {
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/confirmer/dto/ConfirmerBulkRegisterResponse.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/confirmer/dto/ConfirmerBulkRegisterResponse.java
@@ -1,0 +1,10 @@
+package com.mamoki.ieojuda.domain.confirmer.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record ConfirmerBulkRegisterResponse(
+        @Schema(description = "등록 + 발송 결과 목록") List<ConfirmerRegisterResponse> confirmers
+) {
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/confirmer/dto/ConfirmerRegisterRequest.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/confirmer/dto/ConfirmerRegisterRequest.java
@@ -1,0 +1,16 @@
+package com.mamoki.ieojuda.domain.confirmer.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+// "지정 확인자 등록" 화면 - 이름/이메일 입력 폼 한 줄에 대응
+public record ConfirmerRegisterRequest(
+        @Schema(description = "확인자 이름", example = "김민수")
+        @NotBlank(message = "확인자 이름을 입력해 주세요.") String name,
+
+        @Schema(description = "확인자 이메일", example = "confirmer@example.com")
+        @NotBlank(message = "확인자 이메일을 입력해 주세요.")
+        @Email(message = "이메일 형식이 올바르지 않습니다.") String email
+) {
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/confirmer/dto/ConfirmerRegisterResponse.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/confirmer/dto/ConfirmerRegisterResponse.java
@@ -1,0 +1,25 @@
+package com.mamoki.ieojuda.domain.confirmer.dto;
+
+import com.mamoki.ieojuda.domain.confirmer.entity.Confirmer;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+// 확인자 등록 + 수락 이메일 발송 결과 하나
+public record ConfirmerRegisterResponse(
+        @Schema(description = "확인자 ID") Long confirmId,
+        @Schema(description = "확인자 이름") String name,
+        @Schema(description = "확인자 이메일") String email,
+        @Schema(description = "수락 상태", example = "PENDING", allowableValues = {"PENDING", "ACCEPTED", "DECLINED", "EXPIRED"}) String acceptanceStatus,
+        @Schema(description = "역할 수락 이메일 발송 성공 여부") boolean emailSent,
+        @Schema(description = "발송 실패 시 반송 유형 (성공 시 null)", example = "TEMPORARY", allowableValues = {"NONE", "TEMPORARY", "PERMANENT"}) String bounceType
+) {
+    public static ConfirmerRegisterResponse of(Confirmer confirmer, boolean emailSent, String bounceType) {
+        return new ConfirmerRegisterResponse(
+                confirmer.getConfirmId(),
+                confirmer.getName(),
+                confirmer.getEmail(),
+                confirmer.getAcceptanceStatus().name(),
+                emailSent,
+                bounceType
+        );
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/confirmer/entity/Confirmer.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/confirmer/entity/Confirmer.java
@@ -53,6 +53,9 @@ public class Confirmer {
     @Column(name = "invite_token", length = 255)
     private String inviteToken;
 
+    @Column(name = "invite_token_expires_at")
+    private LocalDateTime inviteTokenExpiresAt;
+
     @Builder
     public Confirmer(Plan plan, String name, Relationship relationship, String email) {
         this.plan = plan;
@@ -63,8 +66,10 @@ public class Confirmer {
         this.reportStatus = ReportStatus.NOT_REPORTED;
     }
 
-    public void issueInviteToken(String inviteToken) {
-        this.inviteToken = inviteToken;
+    // 초대 이메일 토큰 저장 (평문이 아닌 해시값만 저장, 만료 시각 함께 기록)
+    public void issueInviteToken(String inviteTokenHash, LocalDateTime expiresAt) {
+        this.inviteToken = inviteTokenHash;
+        this.inviteTokenExpiresAt = expiresAt;
     }
 
     //  수락 상태

--- a/src/main/java/com/mamoki/ieojuda/domain/confirmer/repository/ConfirmerRepository.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/confirmer/repository/ConfirmerRepository.java
@@ -1,0 +1,8 @@
+package com.mamoki.ieojuda.domain.confirmer.repository;
+
+import com.mamoki.ieojuda.domain.confirmer.entity.Confirmer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ConfirmerRepository extends JpaRepository<Confirmer, Long> {
+    boolean existsByPlan_PlanIdAndEmail(Long planId, String email);
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/confirmer/service/ConfirmerService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/confirmer/service/ConfirmerService.java
@@ -1,0 +1,111 @@
+package com.mamoki.ieojuda.domain.confirmer.service;
+
+import com.mamoki.ieojuda.domain.confirmer.dto.ConfirmerBulkRegisterRequest;
+import com.mamoki.ieojuda.domain.confirmer.dto.ConfirmerBulkRegisterResponse;
+import com.mamoki.ieojuda.domain.confirmer.dto.ConfirmerRegisterRequest;
+import com.mamoki.ieojuda.domain.confirmer.dto.ConfirmerRegisterResponse;
+import com.mamoki.ieojuda.domain.confirmer.entity.Confirmer;
+import com.mamoki.ieojuda.domain.confirmer.repository.ConfirmerRepository;
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.plan.repository.PlanRepository;
+import com.mamoki.ieojuda.global.config.AppProperties;
+import com.mamoki.ieojuda.global.email.contract.EmailContent;
+import com.mamoki.ieojuda.global.email.contract.EmailSendResult;
+import com.mamoki.ieojuda.global.email.sender.EmailSender;
+import com.mamoki.ieojuda.global.email.template.EmailBuilder;
+import com.mamoki.ieojuda.global.email.token.TokenProvider;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+// "지정 확인자 등록" 화면 - 확인자 이름/이메일을 한 번에 등록하고, 등록과 동시에 수락 이메일을 발송
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ConfirmerService {
+
+    private final PlanRepository planRepository;
+    private final ConfirmerRepository confirmerRepository;
+    private final EmailSender emailSender;
+    private final AppProperties appProperties;
+
+    @Transactional
+    // 특정 계획에 여러 명의 확인자를 한번에 등록하는 함수
+    public ConfirmerBulkRegisterResponse registerAll(Long userId, Long planId, ConfirmerBulkRegisterRequest request) {
+        Plan plan = findOwnedPlan(userId, planId);
+        validateAll(planId, request.confirmers());
+
+        List<ConfirmerRegisterResponse> responses = new ArrayList<>();
+        for (ConfirmerRegisterRequest confirmerRequest : request.confirmers()) {
+            responses.add(registerOne(plan, confirmerRequest));
+        }
+
+        return new ConfirmerBulkRegisterResponse(responses);
+    }
+
+    // 이메일은 발송 후 되돌릴 수 없으므로, 저장·발송을 시작하기 전에 요청 전체를 먼저 검증한다
+    private void validateAll(Long planId, List<ConfirmerRegisterRequest> requests) {
+        Set<String> requestedEmails = new HashSet<>();
+
+        for (ConfirmerRegisterRequest request : requests) {
+            // 같은 사람이 두 번 등록되면 "독립된 2인 확인" 원칙이 무력화되므로 이메일 중복을 차단
+            if (!requestedEmails.add(request.email())
+                    || confirmerRepository.existsByPlan_PlanIdAndEmail(planId, request.email())) {
+                throw new CustomException(ErrorCode.CONFIRMER_ALREADY_REGISTERED);
+            }
+        }
+    }
+
+    // 확인자 저장 + 초대 토큰 발급 + 수락 이메일 발송
+    // 이메일 발송 실패는 예외로 던지지 않는다 - 확인자 저장은 유지하고 건별 결과만 응답에 담는다
+    private ConfirmerRegisterResponse registerOne(Plan plan, ConfirmerRegisterRequest request) {
+        Confirmer confirmer = confirmerRepository.save(Confirmer.builder()
+                .plan(plan)
+                .name(request.name())
+                .email(request.email())
+                .build());
+
+        String plainToken = TokenProvider.generatePlainToken();
+        LocalDateTime expiresAt = LocalDateTime.now().plusHours(appProperties.getInviteTokenTtlHours());
+        confirmer.issueInviteToken(TokenProvider.hashToken(plainToken), expiresAt);
+
+        EmailSendResult sendResult = sendAcceptanceEmail(confirmer, plainToken, expiresAt);
+
+        return ConfirmerRegisterResponse.of(
+                confirmer,
+                sendResult.success(),
+                sendResult.bounceType() == null ? null : sendResult.bounceType().name()
+        );
+    }
+
+    private EmailSendResult sendAcceptanceEmail(Confirmer confirmer, String plainToken, LocalDateTime expiresAt) {
+        String secureLink = appProperties.getBaseUrl() + "/confirmer-acceptances/" + plainToken;
+        EmailContent content = EmailBuilder.build(
+                "지정 확인자",
+                "지정 확인자 역할 수락 여부를 확인해 주세요.",
+                expiresAt.atZone(ZoneId.systemDefault()),
+                secureLink,
+                appProperties.getContactEmail()
+        );
+        return emailSender.send(confirmer.getEmail(), content);
+    }
+
+    // 로그인한 사용자가 자신의 계획에만 확인자를 등록할 수 있도록 검증 (불일치 시 존재 노출 방지를 위해 NOT_FOUND로 응답)
+    private Plan findOwnedPlan(Long userId, Long planId) {
+        Plan plan = planRepository.findById(planId)
+                .orElseThrow(() -> new CustomException(ErrorCode.PLAN_NOT_FOUND));
+        if (!plan.getUser().getUserId().equals(userId)) {
+            throw new CustomException(ErrorCode.PLAN_NOT_FOUND);
+        }
+        return plan;
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/global/exception/ErrorCode.java
+++ b/src/main/java/com/mamoki/ieojuda/global/exception/ErrorCode.java
@@ -72,6 +72,7 @@ public enum ErrorCode {
     RELEASE_CASE_FROZEN(HttpStatus.CONFLICT, "RELEASE_CASE_FROZEN", "사건이 동결되어 있어 처리할 수 없습니다."),
     ACTIVE_RELEASE_CASE_EXISTS(HttpStatus.CONFLICT, "ACTIVE_RELEASE_CASE_EXISTS", "진행 중인 사후 인계 사건이 있어 계정을 삭제할 수 없습니다."),
     RECIPIENT_ALREADY_ASSIGNED(HttpStatus.CONFLICT, "RECIPIENT_ALREADY_ASSIGNED", "해당 항목에는 이미 담당자가 등록되어 있습니다."),
+    CONFIRMER_ALREADY_REGISTERED(HttpStatus.CONFLICT, "CONFIRMER_ALREADY_REGISTERED", "이미 등록된 지정 확인자 이메일입니다."),
 
     // 서버 에러 (500)
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR","서버 오류가 발생했습니다.");


### PR DESCRIPTION
## 연관 Issue

- Closes #{Issue 번호}

## 요약

지정확인자 등록:  이름·이메일을 입력해 확인자를 여러 명 추가한 뒤 한 번에 일괄 저장하고 수락 이메일을 발송합니다.

## 변경 사항

  - POST /api/plans/{planId}/confirmers 지정 확인자 일괄 등록 API 추가                                                                                                             
  - Confirmer 엔티티에 invite_token_expires_at 컬럼 및 토큰 발급 메서드 확장 (Recipient와 동일 패턴)                                                                               
  - 계획 소유권 검증 추가 — 로그인한 사용자가 자신의 계획에만 등록 가능 (불일치 시 404)                                                                                            
  - 같은 계획 내 이메일 중복 등록 차단 (CONFIRMER_ALREADY_REGISTERED, 409)

## 범위

### 포함

  - ConfirmerRepository, DTO(요청/응답, 일괄 포함), ConfirmerService, ConfirmerController 신규 작성                                                                                
  - ErrorCode에 CONFIRMER_ALREADY_REGISTERED 추가                                                                                                                                  
  - 요청 전체 검증 후 저장·발송 (중복 시 저장/메일 0건 보장)

### 제외

  - POST /api/confirmers/{id}/acceptance-email (수락 이메일 재발송) — 별도 이슈로 진행                                                                                             
  - relationship(관계) 필드 — 와이어프레임에 없어  제외                                                                                                            
  - 최소 2명 강제 검증 — Phase 5 계획 봉인 시점의 INSUFFICIENT_CONFIRMERS가 담당                                                                                                   
                                                                                  

## 스크린샷 / 미리 보기
<img width="1692" height="603" alt="image" src="https://github.com/user-attachments/assets/bbe9352c-4bac-487f-ac97-892c80a7de4e" />
- 지정확인자 메일 전송 성공
<img width="1431" height="952" alt="image" src="https://github.com/user-attachments/assets/bd05fe92-2ef6-4cab-baab-a4ee6028956d" />
- 응답 결과 