### PR TITLE
[Feat/#22]: 대체 담당자 저장 및 메일 전송

### DIFF
--- a/src/main/java/com/mamoki/ieojuda/domain/recipient/controller/RecipientController.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/recipient/controller/RecipientController.java
@@ -25,7 +25,7 @@ public class RecipientController {
 
     private final RecipientService recipientService;
 
-    @Operation(summary = "역할 담당자 일괄 등록", description = "승인된 항목 개수만큼 담당자 정보를 한 번에 등록하고, 등록 즉시 역할 수락 이메일을 발송합니다. 일부 발송이 실패해도 담당자 저장은 유지되며 건별 발송 결과가 응답에 담깁니다.")
+    @Operation(summary = "역할 담당자 일괄 등록", description = "승인된 항목 개수만큼 담당자 정보를 한 번에 등록하고, 등록 즉시 역할 수락 이메일을 발송합니다. 각 담당자는 대체 담당자(backup)를 선택적으로 1명 함께 등록할 수 있으며, 등록 시 대체 담당자에게도 수락 이메일이 발송됩니다. 일부 발송이 실패해도 담당자 저장은 유지되며 건별 발송 결과가 응답에 담깁니다.")
     @PostMapping
     public ResponseEntity<RsData<RecipientBulkRegisterResponse>> registerAll(
             @Parameter(description = "계획 ID") @PathVariable Long planId,

--- a/src/main/java/com/mamoki/ieojuda/domain/recipient/dto/BackupRegisterRequest.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/recipient/dto/BackupRegisterRequest.java
@@ -1,0 +1,16 @@
+package com.mamoki.ieojuda.domain.recipient.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+// "역할 담당자 등록" 화면 - [대체 담당자 등록하기] 버튼으로 여는 폼(이름/이메일만 입력)
+public record BackupRegisterRequest(
+        @Schema(description = "대체 담당자 이름", example = "박지훈")
+        @NotBlank(message = "대체 담당자 이름을 입력해 주세요.") String name,
+
+        @Schema(description = "대체 담당자 이메일", example = "backup@example.com")
+        @NotBlank(message = "대체 담당자 이메일을 입력해 주세요.")
+        @Email(message = "이메일 형식이 올바르지 않습니다.") String email
+) {
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/recipient/dto/BackupRegisterResponse.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/recipient/dto/BackupRegisterResponse.java
@@ -1,0 +1,25 @@
+package com.mamoki.ieojuda.domain.recipient.dto;
+
+import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+// 대체 담당자 등록 + 수락 이메일 발송 결과
+public record BackupRegisterResponse(
+        @Schema(description = "대체 담당자 ID") Long recipientId,
+        @Schema(description = "대체 담당자 이름") String name,
+        @Schema(description = "대체 담당자 이메일") String email,
+        @Schema(description = "수락 상태", example = "PENDING", allowableValues = {"PENDING", "ACCEPTED", "DECLINED", "EXPIRED"}) String acceptanceStatus,
+        @Schema(description = "역할 수락 이메일 발송 성공 여부") boolean emailSent,
+        @Schema(description = "발송 실패 시 반송 유형 (성공 시 null)", example = "TEMPORARY", allowableValues = {"NONE", "TEMPORARY", "PERMANENT"}) String bounceType
+) {
+    public static BackupRegisterResponse of(Recipient backup, boolean emailSent, String bounceType) {
+        return new BackupRegisterResponse(
+                backup.getAssigneeId(),
+                backup.getName(),
+                backup.getEmail(),
+                backup.getAcceptanceStatus().name(),
+                emailSent,
+                bounceType
+        );
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/recipient/dto/RecipientRegisterRequest.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/recipient/dto/RecipientRegisterRequest.java
@@ -1,6 +1,7 @@
 package com.mamoki.ieojuda.domain.recipient.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -18,6 +19,9 @@ public record RecipientRegisterRequest(
         @Email(message = "이메일 형식이 올바르지 않습니다.") String email,
 
         @Schema(description = "최대 단계 대기 시간(시간 단위, 7/14/21일에 대응)", example = "168", allowableValues = {"168", "336", "504"})
-        @NotNull(message = "대기 기간을 선택해 주세요.") Integer maxWaitHours
+        @NotNull(message = "대기 기간을 선택해 주세요.") Integer maxWaitHours,
+
+        @Schema(description = "대체 담당자 (선택). [대체 담당자 등록하기]로 입력한 경우에만 전달")
+        @Valid BackupRegisterRequest backup
 ) {
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/recipient/dto/RecipientRegisterResponse.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/recipient/dto/RecipientRegisterResponse.java
@@ -14,9 +14,11 @@ public record RecipientRegisterResponse(
         @Schema(description = "최대 단계 대기 시간(시간 단위)") Integer maxWaitHours,
         @Schema(description = "수락 상태", example = "PENDING", allowableValues = {"PENDING", "ACCEPTED", "DECLINED", "EXPIRED"}) String acceptanceStatus,
         @Schema(description = "역할 수락 이메일 발송 성공 여부") boolean emailSent,
-        @Schema(description = "발송 실패 시 반송 유형 (성공 시 null)", example = "TEMPORARY", allowableValues = {"NONE", "TEMPORARY", "PERMANENT"}) String bounceType
+        @Schema(description = "발송 실패 시 반송 유형 (성공 시 null)", example = "TEMPORARY", allowableValues = {"NONE", "TEMPORARY", "PERMANENT"}) String bounceType,
+        @Schema(description = "대체 담당자 등록 결과 (미등록 시 null)") BackupRegisterResponse backup
 ) {
-    public static RecipientRegisterResponse of(Recipient recipient, Long itemId, boolean emailSent, String bounceType) {
+    public static RecipientRegisterResponse of(Recipient recipient, Long itemId, boolean emailSent, String bounceType,
+                                                BackupRegisterResponse backup) {
         return new RecipientRegisterResponse(
                 recipient.getAssigneeId(),
                 itemId,
@@ -27,7 +29,8 @@ public record RecipientRegisterResponse(
                 recipient.getMaxWaitHours(),
                 recipient.getAcceptanceStatus().name(),
                 emailSent,
-                bounceType
+                bounceType,
+                backup
         );
     }
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/recipient/service/RecipientService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/recipient/service/RecipientService.java
@@ -6,6 +6,8 @@ import com.mamoki.ieojuda.domain.plan.entity.ItemStatus;
 import com.mamoki.ieojuda.domain.plan.entity.LifeArea;
 import com.mamoki.ieojuda.domain.plan.entity.Plan;
 import com.mamoki.ieojuda.domain.plan.repository.ItemRepository;
+import com.mamoki.ieojuda.domain.recipient.dto.BackupRegisterRequest;
+import com.mamoki.ieojuda.domain.recipient.dto.BackupRegisterResponse;
 import com.mamoki.ieojuda.domain.recipient.dto.RecipientBulkRegisterRequest;
 import com.mamoki.ieojuda.domain.recipient.dto.RecipientBulkRegisterResponse;
 import com.mamoki.ieojuda.domain.recipient.dto.RecipientRegisterRequest;
@@ -80,6 +82,10 @@ public class RecipientService {
             if (!ALLOWED_WAIT_HOURS.contains(request.maxWaitHours())) {
                 throw new CustomException(ErrorCode.INVALID_WAITING_PERIOD);
             }
+            // 대체 담당자가 주 담당자와 동일 이메일이면 실제 대체 전환 시 의미가 없으므로 차단
+            if (request.backup() != null && request.backup().email().equals(request.email())) {
+                throw new CustomException(ErrorCode.BACKUP_RECIPIENT_EMAIL_DUPLICATED);
+            }
 
             items.add(item);
         }
@@ -107,25 +113,58 @@ public class RecipientService {
 
         item.assignRecipient(recipient);
 
-        String plainToken = TokenProvider.generatePlainToken();
-        LocalDateTime expiresAt = LocalDateTime.now().plusHours(appProperties.getInviteTokenTtlHours());
-        recipient.issueInviteToken(TokenProvider.hashToken(plainToken), expiresAt);
+        EmailSendResult sendResult = issueInviteAndSend(recipient, toRoleName(disclosureScope));
 
-        EmailSendResult sendResult = sendAcceptanceEmail(recipient, disclosureScope, plainToken, expiresAt);
+        BackupRegisterResponse backupResponse = request.backup() == null
+                ? null
+                : registerBackup(plan, lifeArea, disclosureScope, recipient, request.backup());
 
         return RecipientRegisterResponse.of(
                 recipient,
                 item.getItemId(),
                 sendResult.success(),
+                sendResult.bounceType() == null ? null : sendResult.bounceType().name(),
+                backupResponse
+        );
+    }
+
+    // 대체 담당자 저장 + 초대 토큰 발급 + 수락 이메일 발송
+    // 항목(Item)에는 배정하지 않는다 - 박스당 활성(주) 담당자 1명 규칙은 backupFor 관계로만 표현한다
+    private BackupRegisterResponse registerBackup(Plan plan, LifeArea lifeArea, DisclosureScope disclosureScope,
+                                                   Recipient primary, BackupRegisterRequest backupRequest) {
+        Recipient backup = recipientRepository.save(Recipient.builder()
+                .plan(plan)
+                .lifeArea(lifeArea)
+                .name(backupRequest.name())
+                .email(backupRequest.email())
+                .roleType(toRoleType(disclosureScope))
+                .isBackup(true)
+                .disclosureScope(disclosureScope)
+                .maxWaitHours(null)
+                .backupFor(primary)
+                .build());
+
+        EmailSendResult sendResult = issueInviteAndSend(backup, toRoleName(disclosureScope) + " (대체 담당자)");
+
+        return BackupRegisterResponse.of(
+                backup,
+                sendResult.success(),
                 sendResult.bounceType() == null ? null : sendResult.bounceType().name()
         );
     }
 
-    private EmailSendResult sendAcceptanceEmail(Recipient recipient, DisclosureScope disclosureScope,
+    private EmailSendResult issueInviteAndSend(Recipient recipient, String roleName) {
+        String plainToken = TokenProvider.generatePlainToken();
+        LocalDateTime expiresAt = LocalDateTime.now().plusHours(appProperties.getInviteTokenTtlHours());
+        recipient.issueInviteToken(TokenProvider.hashToken(plainToken), expiresAt);
+        return sendAcceptanceEmail(recipient, roleName, plainToken, expiresAt);
+    }
+
+    private EmailSendResult sendAcceptanceEmail(Recipient recipient, String roleName,
                                                  String plainToken, LocalDateTime expiresAt) {
         String secureLink = appProperties.getBaseUrl() + "/recipient-acceptances/" + plainToken;
         EmailContent content = EmailBuilder.build(
-                toRoleName(disclosureScope),
+                roleName,
                 "역할 수락 여부를 확인해 주세요.",
                 expiresAt.atZone(ZoneId.systemDefault()),
                 secureLink,

--- a/src/main/java/com/mamoki/ieojuda/global/exception/ErrorCode.java
+++ b/src/main/java/com/mamoki/ieojuda/global/exception/ErrorCode.java
@@ -73,6 +73,7 @@ public enum ErrorCode {
     ACTIVE_RELEASE_CASE_EXISTS(HttpStatus.CONFLICT, "ACTIVE_RELEASE_CASE_EXISTS", "진행 중인 사후 인계 사건이 있어 계정을 삭제할 수 없습니다."),
     RECIPIENT_ALREADY_ASSIGNED(HttpStatus.CONFLICT, "RECIPIENT_ALREADY_ASSIGNED", "해당 항목에는 이미 담당자가 등록되어 있습니다."),
     CONFIRMER_ALREADY_REGISTERED(HttpStatus.CONFLICT, "CONFIRMER_ALREADY_REGISTERED", "이미 등록된 지정 확인자 이메일입니다."),
+    BACKUP_RECIPIENT_EMAIL_DUPLICATED(HttpStatus.CONFLICT, "BACKUP_RECIPIENT_EMAIL_DUPLICATED", "대체 담당자 이메일은 주 담당자와 같을 수 없습니다."),
 
     // 서버 에러 (500)
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR","서버 오류가 발생했습니다.");


### PR DESCRIPTION
## 연관 Issue

- Closes #22 

## 요약

역할 담당자 등록 API(POST /api/plans/{planId}/recipients)에 대체 담당자(1명, 선택) 등록 기능을 추가했다. 요청에 backup 필드를 포함하면 주 담당자와 함께 저장되고 수락 이메일도   
  함께 발송된다

## 변경 사항

  - BackupRegisterRequest, BackupRegisterResponse DTO 신규 추가                                                                                                                    
  - RecipientRegisterRequest에 선택 필드 backup 추가, RecipientRegisterResponse에 backup 결과 필드 추가                                                                            
  - RecipientService: 대체 담당자 저장(isBackup=true, backupFor=주담당자, maxWaitHours=null) 및 초대 토큰 발급·수락 이메일 발송 로직 추가, 토큰 발급/발송 공통 로직을              
  issueInviteAndSend로 통합                                                                                                                                                        
  - 대체 담당자 이메일이 주 담당자와 동일하면 등록 전체를 막는 검증 추가 (BACKUP_RECIPIENT_EMAIL_DUPLICATED, 409)                                                                  
  - ErrorCode에 BACKUP_RECIPIENT_EMAIL_DUPLICATED 추가                                                                                                                             
  - RecipientController Swagger 설명 업데이트

## 범위

### 포함
  - 대체 담당자 등록 + 수락 이메일 발송                                                                                                                                            
  - 주/대체 담당자 이메일 중복 검증


### 제외

  - 대체 담당자로의 실제 전환 로직 (7-3 단계, POST /stages/{stageId}/fallback)                                                                                                     
  - RecipientController의 계획 소유권(인증) 검증 추가 (기존부터 없던 부분, 별도 이슈로 분리 권장)

## 스크린샷 / 미리 보기
<img width="1435" height="641" alt="image" src="https://github.com/user-attachments/assets/0d91de95-7447-4c29-bb53-73e56fd134ec" />
- Request 
<img width="1317" height="737" alt="image" src="https://github.com/user-attachments/assets/fcc59215-9c67-4215-96fd-851619852a55" />
-Response
<img width="1597" height="650" alt="image" src="https://github.com/user-attachments/assets/3e15a5d7-db58-41f7-bd51-be997e1e454c" />
- 이메일 발송 