### PR TITLE
[Feat/#29]:역할 수락 이메일 화면 조회/수락/거절 API 추가

### DIFF
--- a/src/main/java/com/mamoki/ieojuda/domain/recipient/controller/RecipientInviteController.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/recipient/controller/RecipientInviteController.java
@@ -1,0 +1,56 @@
+package com.mamoki.ieojuda.domain.recipient.controller;
+
+import com.mamoki.ieojuda.domain.recipient.dto.RecipientInviteDecisionRequest;
+import com.mamoki.ieojuda.domain.recipient.dto.RecipientInviteDecisionResponse;
+import com.mamoki.ieojuda.domain.recipient.dto.RecipientInviteResponse;
+import com.mamoki.ieojuda.domain.recipient.service.RecipientInviteService;
+import com.mamoki.ieojuda.global.rsdata.RsData;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+// 명세서 "역할 수락 이메일/화면" - 담당자가 초대 이메일의 링크로 접근하는 엔드포인트라 로그인이 필요 없다(토큰 자체가 증명)
+@Tag(name = "RecipientInvite", description = "역할 담당자 - 초대 조회 / 수락 / 거절 (이메일 링크 클릭)")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/recipient-acceptances")
+public class RecipientInviteController {
+
+    private final RecipientInviteService recipientInviteService;
+
+    @Operation(summary = "초대 조회", description = "역할 수락 이메일의 링크로 진입했을 때 작성자 이름, 역할명, 할 일 목록, 공개 범주를 조회합니다. 만료된 링크는 차단됩니다.")
+    @GetMapping("/{token}")
+    public ResponseEntity<RsData<RecipientInviteResponse>> getInvite(
+            @Parameter(description = "초대 토큰") @PathVariable String token
+    ) {
+        return ResponseEntity.ok(RsData.success(recipientInviteService.getInvite(token)));
+    }
+
+    // 문의 사항은 선택 입력이라 바디 자체를 생략해도 받아야 하므로 required = false
+    @Operation(summary = "역할 수락", description = "담당자가 역할을 수락합니다. 문의 사항은 선택 입력이라 요청 바디를 생략할 수 있습니다. 만료·재사용 링크는 차단됩니다.")
+    @PostMapping("/{token}/accept")
+    public ResponseEntity<RsData<RecipientInviteDecisionResponse>> accept(
+            @Parameter(description = "초대 토큰") @PathVariable String token,
+            @Valid @RequestBody(required = false) RecipientInviteDecisionRequest request
+    ) {
+        return ResponseEntity.ok(RsData.success(recipientInviteService.accept(token, request)));
+    }
+
+    @Operation(summary = "역할 거절", description = "담당자가 역할을 거절합니다. 문의 사항은 선택 입력이라 요청 바디를 생략할 수 있습니다. 만료·재사용 링크는 차단됩니다.")
+    @PostMapping("/{token}/decline")
+    public ResponseEntity<RsData<RecipientInviteDecisionResponse>> decline(
+            @Parameter(description = "초대 토큰") @PathVariable String token,
+            @Valid @RequestBody(required = false) RecipientInviteDecisionRequest request
+    ) {
+        return ResponseEntity.ok(RsData.success(recipientInviteService.decline(token, request)));
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/recipient/dto/RecipientInviteDecisionRequest.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/recipient/dto/RecipientInviteDecisionRequest.java
@@ -1,0 +1,11 @@
+package com.mamoki.ieojuda.domain.recipient.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
+
+// "역할 수락 이메일" 화면 - 수락/거절 시 문의 사항은 선택 입력
+public record RecipientInviteDecisionRequest(
+        @Schema(description = "문의 사항 (선택 입력)", example = "부고 전달 범위가 궁금해요.")
+        @Size(max = 1000, message = "문의 사항은 1000자 이하로 입력해 주세요.") String inquiry
+) {
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/recipient/dto/RecipientInviteDecisionResponse.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/recipient/dto/RecipientInviteDecisionResponse.java
@@ -1,0 +1,23 @@
+package com.mamoki.ieojuda.domain.recipient.dto;
+
+import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+// "역할 수락 이메일" 화면 - 수락/거절 처리 결과
+public record RecipientInviteDecisionResponse(
+        @Schema(description = "담당자 ID") Long assigneeId,
+        @Schema(description = "수락 상태", example = "ACCEPTED", allowableValues = {"ACCEPTED", "DECLINED"}) String acceptanceStatus,
+        @Schema(description = "수락 시각 (거절 시 null)") LocalDateTime acceptedAt,
+        @Schema(description = "문의 사항") String inquiry
+) {
+    public static RecipientInviteDecisionResponse from(Recipient recipient) {
+        return new RecipientInviteDecisionResponse(
+                recipient.getAssigneeId(),
+                recipient.getAcceptanceStatus().name(),
+                recipient.getAcceptedAt(),
+                recipient.getInquiry()
+        );
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/recipient/dto/RecipientInviteResponse.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/recipient/dto/RecipientInviteResponse.java
@@ -1,0 +1,37 @@
+package com.mamoki.ieojuda.domain.recipient.dto;
+
+import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+// "역할 수락 이메일" 화면 - 초대 링크로 진입했을 때 보여줄 내용
+public record RecipientInviteResponse(
+        @Schema(description = "담당자 이름", example = "이지수") String assigneeName,
+        @Schema(description = "작성자(계획 소유자) 이름", example = "김나무") String ownerName,
+        @Schema(description = "역할 유형", example = "RELATIONSHIP_MANAGER", allowableValues = {"FAMILY_MANAGER", "WORK_MANAGER", "RELATIONSHIP_MANAGER"}) String roleType,
+        @Schema(description = "이 담당자에게 배정된 항목의 제목/할 일 목록") List<RecipientInviteTaskResponse> tasks,
+        @Schema(description = "공개 범위", example = "RELATIONSHIP", allowableValues = {"FAMILY", "WORK", "RELATIONSHIP"}) String disclosureScope,
+        @Schema(description = "대체 담당자 여부") boolean isBackup,
+        @Schema(description = "수락 상태", example = "PENDING", allowableValues = {"PENDING", "ACCEPTED", "DECLINED", "EXPIRED"}) String acceptanceStatus,
+        @Schema(description = "초대 이메일이 발송된 주소") String email,
+        @Schema(description = "초대 링크 만료 시각") LocalDateTime expiresAt,
+        @Schema(description = "문의 주소") String contactEmail
+) {
+    public static RecipientInviteResponse of(Recipient recipient, String ownerName,
+                                              List<RecipientInviteTaskResponse> tasks, String contactEmail) {
+        return new RecipientInviteResponse(
+                recipient.getName(),
+                ownerName,
+                recipient.getRoleType().name(),
+                tasks,
+                recipient.getDisclosureScope() == null ? null : recipient.getDisclosureScope().name(),
+                Boolean.TRUE.equals(recipient.getIsBackup()),
+                recipient.getAcceptanceStatus().name(),
+                recipient.getEmail(),
+                recipient.getInviteTokenExpiresAt(),
+                contactEmail
+        );
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/recipient/dto/RecipientInviteTaskResponse.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/recipient/dto/RecipientInviteTaskResponse.java
@@ -1,0 +1,14 @@
+package com.mamoki.ieojuda.domain.recipient.dto;
+
+import com.mamoki.ieojuda.domain.plan.entity.Item;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+// "역할 수락 이메일" 화면 - 담당자에게 배정된 항목 한 건의 제목/할 일만 노출 (명세 "실제 패키지 전문은 공개하지 않습니다")
+public record RecipientInviteTaskResponse(
+        @Schema(description = "짧은 제목 - 대상 채널/계정명", example = "인스타그램") String title,
+        @Schema(description = "그 채널에 대해 할 일", example = "탈퇴 처리") String content
+) {
+    public static RecipientInviteTaskResponse from(Item item) {
+        return new RecipientInviteTaskResponse(item.getTitle(), item.getContent());
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/recipient/entity/Recipient.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/recipient/entity/Recipient.java
@@ -74,6 +74,10 @@ public class Recipient {
     @JoinColumn(name = "backup_for_id")
     private Recipient backupFor;
 
+    // "역할 수락 이메일" 화면 - 담당자가 수락/거절 시 남기는 문의 사항 (선택 입력)
+    @Column(name = "inquiry", columnDefinition = "TEXT")
+    private String inquiry;
+
     // 담당자 등록 시점 - 역할명, 담당자 이름, 이메일, 공개 범주, 최대 단계 대기 시간, 대체 담당자 입력
     @Builder
     public Recipient(Plan plan, LifeArea lifeArea, String name, String email, RoleType roleType,
@@ -98,14 +102,16 @@ public class Recipient {
     }
 
     // 담당자 수락
-    public void accept() {
+    public void accept(String inquiry) {
         this.acceptanceStatus = AcceptanceStatus.ACCEPTED;
         this.acceptedAt = LocalDateTime.now();
+        this.inquiry = inquiry;
     }
 
     // 담당자 거절
-    public void decline() {
+    public void decline(String inquiry) {
         this.acceptanceStatus = AcceptanceStatus.DECLINED;
+        this.inquiry = inquiry;
     }
 
     // 초대 링크 만료

--- a/src/main/java/com/mamoki/ieojuda/domain/recipient/repository/RecipientRepository.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/recipient/repository/RecipientRepository.java
@@ -16,4 +16,7 @@ public interface RecipientRepository extends JpaRepository<Recipient, Long> {
 
     // "단계 완료 / 대체 담당자" 화면 - 주 담당자에 대해 등록된 대체 담당자 조회
     Optional<Recipient> findByBackupFor_AssigneeId(Long primaryRecipientId);
+
+    // "역할 수락 이메일" 화면 진입 - 초대 링크의 토큰으로 담당자를 찾기 위한 조회
+    Optional<Recipient> findByInviteToken(String inviteToken);
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/recipient/service/RecipientInviteService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/recipient/service/RecipientInviteService.java
@@ -1,0 +1,99 @@
+package com.mamoki.ieojuda.domain.recipient.service;
+
+import com.mamoki.ieojuda.domain.recipient.dto.RecipientInviteDecisionRequest;
+import com.mamoki.ieojuda.domain.recipient.dto.RecipientInviteDecisionResponse;
+import com.mamoki.ieojuda.domain.recipient.dto.RecipientInviteResponse;
+import com.mamoki.ieojuda.domain.recipient.dto.RecipientInviteTaskResponse;
+import com.mamoki.ieojuda.domain.recipient.entity.AcceptanceStatus;
+import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
+import com.mamoki.ieojuda.domain.plan.repository.ItemRepository;
+import com.mamoki.ieojuda.domain.recipient.repository.RecipientRepository;
+import com.mamoki.ieojuda.global.config.AppProperties;
+import com.mamoki.ieojuda.global.email.token.TokenProvider;
+import com.mamoki.ieojuda.global.email.token.TokenValidator;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+
+// 명세서 "역할 수락 이메일/화면" - 담당자가 초대 링크로 진입해 역할을 확인하고 수락/거절 (로그인 불필요, 토큰이 곧 인증)
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RecipientInviteService {
+
+    private final RecipientRepository recipientRepository;
+    private final ItemRepository itemRepository;
+    private final AppProperties appProperties;
+
+    // 초대 조회 - 만료된 링크는 상태를 EXPIRED로 반영하고 차단, 이미 수락/거절한 경우는 현재 상태를 그대로 보여준다
+    @Transactional
+    public RecipientInviteResponse getInvite(String plainToken) {
+        Recipient recipient = findByToken(plainToken);
+        checkNotExpired(recipient);
+
+        Long itemOwnerId = Boolean.TRUE.equals(recipient.getIsBackup()) && recipient.getBackupFor() != null
+                ? recipient.getBackupFor().getAssigneeId()
+                : recipient.getAssigneeId();
+        List<RecipientInviteTaskResponse> tasks = itemRepository.findByRecipient_AssigneeIdOrderByItemIdAsc(itemOwnerId).stream()
+                .map(RecipientInviteTaskResponse::from)
+                .toList();
+
+        String ownerName = recipient.getPlan().getUser().getName();
+        return RecipientInviteResponse.of(recipient, ownerName, tasks, appProperties.getContactEmail());
+    }
+
+    // 역할 수락
+    @Transactional
+    public RecipientInviteDecisionResponse accept(String plainToken, RecipientInviteDecisionRequest request) {
+        Recipient recipient = findByToken(plainToken);
+        checkNotExpired(recipient);
+        checkPending(recipient);
+
+        recipient.accept(inquiryOf(request));
+        return RecipientInviteDecisionResponse.from(recipient);
+    }
+
+    // 역할 거절
+    @Transactional
+    public RecipientInviteDecisionResponse decline(String plainToken, RecipientInviteDecisionRequest request) {
+        Recipient recipient = findByToken(plainToken);
+        checkNotExpired(recipient);
+        checkPending(recipient);
+
+        recipient.decline(inquiryOf(request));
+        return RecipientInviteDecisionResponse.from(recipient);
+    }
+
+    // 문의 사항은 선택 입력이라 요청 바디 자체가 없을 수 있다
+    private String inquiryOf(RecipientInviteDecisionRequest request) {
+        return request == null ? null : request.inquiry();
+    }
+
+    private Recipient findByToken(String plainToken) {
+        return recipientRepository.findByInviteToken(TokenProvider.hashToken(plainToken))
+                .orElseThrow(() -> new CustomException(ErrorCode.TOKEN_INVALID));
+    }
+
+    private void checkNotExpired(Recipient recipient) {
+        Instant expiresAt = recipient.getInviteTokenExpiresAt() == null
+                ? null
+                : recipient.getInviteTokenExpiresAt().atZone(ZoneId.systemDefault()).toInstant();
+        if (TokenValidator.isExpired(expiresAt, Instant.now())) {
+            recipient.expire();
+            throw new CustomException(ErrorCode.ACCESS_LINK_EXPIRED);
+        }
+    }
+
+    // 수락/거절은 대기 중(PENDING) 상태에서만 가능 - 이미 처리된 링크의 재사용을 차단
+    private void checkPending(Recipient recipient) {
+        if (recipient.getAcceptanceStatus() != AcceptanceStatus.PENDING) {
+            throw new CustomException(ErrorCode.ACCESS_LINK_ALREADY_USED);
+        }
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/global/config/SecurityConfig.java
+++ b/src/main/java/com/mamoki/ieojuda/global/config/SecurityConfig.java
@@ -34,7 +34,8 @@ public class SecurityConfig {
             "/swagger-ui.html",
             // 이메일 링크를 클릭해서 접근하는 검증 엔드포인트 - 로그인 상태가 아니므로 인증 요구하지 않음
             "/api/self-warning-email/**",
-            "/api/dispute-contacts/*/verify"
+            "/api/dispute-contacts/*/verify",
+            "/api/recipient-acceptances/**"
     };
 
     // 운영관리자 전용 - 이메일 발송 감사/재시도/사건 동결/단계 조회·대체담당자 전환


### PR DESCRIPTION
## 연관 Issue

- Closes #29 

## 요약

담당자가 초대 메일 링크로 진입해 역할 내용을 확인하고 수락, 거절 할 수 있습니다. 

## 변경 사항

- 초대 조회
- 수락, 거절 처리, 문의사항은 선택입력이라 요청 바디 자체 생략 가능
- 대체 담당자가 진입하면 주 담당자와 동일한 할 일 목록을 보여줌
- role_assigness에 inquiry 칼럼 추가 - 문의사항 저장
- SecurityConfig.PERMIT_ALL_PATHS에 /api/recipient-acceptances/** 등록 (로그인 없이 접근하는 엔드포인트)

## 범위

### 포함

 - 수락 화면 조회/수락/거절 API 3종                                                                                                                                               
 - 문의 사항 저장 컬럼

### 제외

- email_logs 기록

## 스크린샷 / 미리 보기
<img width="1418" height="980" alt="image" src="https://github.com/user-attachments/assets/d071e31a-c41d-40b8-80ed-df0a814b7a9a" />
- 역할 담당자 외부 페이지 조회
<img width="1414" height="781" alt="image" src="https://github.com/user-attachments/assets/19cfc52f-dc72-476a-b3bf-9676b945cd32" />
- 역할 담당자 외부페이지 수락
<img width="1407" height="846" alt="image" src="https://github.com/user-attachments/assets/19b4cf11-416e-427c-92e1-7a2a298271d9" />
- 역할 담당자 외부페이지 거절 