### PR TITLE
[Feat/#35]: 생계 인계점검 조회 api 구현

### DIFF
--- a/src/main/java/com/mamoki/ieojuda/domain/handoffcheck/controller/HandoffCheckController.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/handoffcheck/controller/HandoffCheckController.java
@@ -1,0 +1,35 @@
+package com.mamoki.ieojuda.domain.handoffcheck.controller;
+
+import com.mamoki.ieojuda.domain.handoffcheck.dto.HandoffCheckStatusResponse;
+import com.mamoki.ieojuda.domain.handoffcheck.service.HandoffCheckService;
+import com.mamoki.ieojuda.global.rsdata.RsData;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+// "선택형 생전 인계 점검" 화면 - 역할 담당자/지정 확인자 준비 상태 조회
+@Tag(name = "HandoffCheck", description = "선택형 생전 인계 점검 - 담당자/확인자 준비 상태 조회")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/plans/{planId}/handoff-checks")
+public class HandoffCheckController {
+
+    private final HandoffCheckService handoffCheckService;
+
+    @Operation(summary = "인계 점검 화면 조회", description = "역할 담당자와 지정 확인자의 이메일 발송, 역할 수락, 대체 담당자, 문의 사항, 준비 완료 여부를 함께 조회합니다.")
+    @GetMapping
+    public ResponseEntity<RsData<HandoffCheckStatusResponse>> getHandoffCheck(
+            @AuthenticationPrincipal Long userId, // 현재 로그인한 사용자 ID 식별
+            @Parameter(description = "계획 ID") @PathVariable Long planId
+    ) {
+        HandoffCheckStatusResponse result = handoffCheckService.getHandoffCheck(userId, planId);
+        return ResponseEntity.ok(RsData.success(result));
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/handoffcheck/dto/HandoffCheckAssigneeResponse.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/handoffcheck/dto/HandoffCheckAssigneeResponse.java
@@ -1,0 +1,39 @@
+package com.mamoki.ieojuda.domain.handoffcheck.dto;
+
+import com.mamoki.ieojuda.domain.recipient.entity.AcceptanceStatus;
+import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+// "선택형 생전 인계 점검" 화면 - 역할 담당자 한 명당 박스 하나
+public record HandoffCheckAssigneeResponse(
+        @Schema(description = "담당자 ID") Long assigneeId,
+        @Schema(description = "담당자 이름") String name,
+        @Schema(description = "역할 유형", example = "RELATIONSHIP_MANAGER", allowableValues = {"FAMILY_MANAGER", "WORK_MANAGER", "RELATIONSHIP_MANAGER"}) String roleType,
+        @Schema(description = "수락 요청 이메일 발송 완료 여부") boolean isEmailSent,
+        @Schema(description = "역할 수락 완료 여부") boolean isRoleAccepted,
+        @Schema(description = "대체 담당자 이름 - 등록되지 않았으면 null") String backupName,
+        @Schema(description = "대체 담당자의 역할 수락 완료 여부 - 대체 담당자가 없으면 false") boolean isBackupAccepted,
+        @Schema(description = "담당자가 수락/거절 시 남긴 문의 사항 - 없으면 null") String inquiry,
+        @Schema(description = "준비 완료 여부 - 이메일 발송, 역할 수락이 끝나야 하고, 대체 담당자가 있다면 그 수락까지 끝나야 true") boolean isReady
+) {
+    public static HandoffCheckAssigneeResponse of(Recipient recipient, Recipient backup) {
+        // 초대 토큰이 발급됐다는 것은 수락 요청 이메일이 나갔다는 뜻 (별도 발송 이력 컬럼이 없음)
+        boolean isEmailSent = recipient.getInviteToken() != null;
+        boolean isRoleAccepted = recipient.getAcceptanceStatus() == AcceptanceStatus.ACCEPTED;
+        boolean isBackupAccepted = backup != null && backup.getAcceptanceStatus() == AcceptanceStatus.ACCEPTED;
+        // 대체 담당자는 필수가 아니므로 없으면 판정에서 제외하고, 있으면 그 수락 여부까지 조건에 포함한다
+        boolean isReady = isEmailSent && isRoleAccepted && (backup == null || isBackupAccepted);
+
+        return new HandoffCheckAssigneeResponse(
+                recipient.getAssigneeId(),
+                recipient.getName(),
+                recipient.getRoleType().name(),
+                isEmailSent,
+                isRoleAccepted,
+                backup == null ? null : backup.getName(),
+                isBackupAccepted,
+                recipient.getInquiry(),
+                isReady
+        );
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/handoffcheck/dto/HandoffCheckConfirmerResponse.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/handoffcheck/dto/HandoffCheckConfirmerResponse.java
@@ -1,0 +1,30 @@
+package com.mamoki.ieojuda.domain.handoffcheck.dto;
+
+import com.mamoki.ieojuda.domain.confirmer.entity.Confirmer;
+import com.mamoki.ieojuda.domain.recipient.entity.AcceptanceStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+// "선택형 생전 인계 점검" 화면 - 지정 확인자 한 명당 박스 하나
+public record HandoffCheckConfirmerResponse(
+        @Schema(description = "확인자 ID") Long confirmId,
+        @Schema(description = "확인자 이름") String name,
+        @Schema(description = "수락 요청 이메일 발송 완료 여부") boolean isEmailSent,
+        @Schema(description = "역할 수락 완료 여부") boolean isRoleAccepted,
+        @Schema(description = "확인자가 수락/거절 시 남긴 문의 사항 - 없으면 null") String inquiry,
+        @Schema(description = "준비 완료 여부 - 이메일 발송과 역할 수락이 모두 끝나면 true") boolean isReady
+) {
+    public static HandoffCheckConfirmerResponse from(Confirmer confirmer) {
+        // 초대 토큰이 발급됐다는 것은 수락 요청 이메일이 나갔다는 뜻 (별도 발송 이력 컬럼이 없음)
+        boolean isEmailSent = confirmer.getInviteToken() != null;
+        boolean isRoleAccepted = confirmer.getAcceptanceStatus() == AcceptanceStatus.ACCEPTED;
+
+        return new HandoffCheckConfirmerResponse(
+                confirmer.getConfirmId(),
+                confirmer.getName(),
+                isEmailSent,
+                isRoleAccepted,
+                confirmer.getInquiry(),
+                isEmailSent && isRoleAccepted
+        );
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/handoffcheck/dto/HandoffCheckStatusResponse.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/handoffcheck/dto/HandoffCheckStatusResponse.java
@@ -1,0 +1,30 @@
+package com.mamoki.ieojuda.domain.handoffcheck.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+// "선택형 생전 인계 점검" 화면 전체 - 담당자 박스 목록 + 확인자 박스 목록 + 헤더 카운트
+public record HandoffCheckStatusResponse(
+        @Schema(description = "역할 담당자 총 인원 (대체 담당자 제외)") long assigneeTotalCount,
+        @Schema(description = "역할 담당자 중 준비 완료 인원") long assigneeReadyCount,
+        @Schema(description = "역할 담당자 박스 목록") List<HandoffCheckAssigneeResponse> assignees,
+        @Schema(description = "지정 확인자 총 인원") long confirmerTotalCount,
+        @Schema(description = "지정 확인자 중 준비 완료 인원") long confirmerReadyCount,
+        @Schema(description = "지정 확인자 박스 목록") List<HandoffCheckConfirmerResponse> confirmers
+) {
+    public static HandoffCheckStatusResponse of(List<HandoffCheckAssigneeResponse> assignees,
+                                                 List<HandoffCheckConfirmerResponse> confirmers) {
+        long assigneeReadyCount = assignees.stream().filter(HandoffCheckAssigneeResponse::isReady).count();
+        long confirmerReadyCount = confirmers.stream().filter(HandoffCheckConfirmerResponse::isReady).count();
+
+        return new HandoffCheckStatusResponse(
+                assignees.size(),
+                assigneeReadyCount,
+                assignees,
+                confirmers.size(),
+                confirmerReadyCount,
+                confirmers
+        );
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/handoffcheck/service/HandoffCheckService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/handoffcheck/service/HandoffCheckService.java
@@ -1,0 +1,71 @@
+package com.mamoki.ieojuda.domain.handoffcheck.service;
+
+import com.mamoki.ieojuda.domain.confirmer.entity.Confirmer;
+import com.mamoki.ieojuda.domain.confirmer.repository.ConfirmerRepository;
+import com.mamoki.ieojuda.domain.handoffcheck.dto.HandoffCheckAssigneeResponse;
+import com.mamoki.ieojuda.domain.handoffcheck.dto.HandoffCheckConfirmerResponse;
+import com.mamoki.ieojuda.domain.handoffcheck.dto.HandoffCheckStatusResponse;
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.plan.repository.PlanRepository;
+import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
+import com.mamoki.ieojuda.domain.recipient.repository.RecipientRepository;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+// "선택형 생전 인계 점검" 화면 - 역할 담당자와 지정 확인자의 준비 상태를 함께 조회
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class HandoffCheckService {
+
+    private final PlanRepository planRepository;
+    private final RecipientRepository recipientRepository;
+    private final ConfirmerRepository confirmerRepository;
+
+    public HandoffCheckStatusResponse getHandoffCheck(Long userId, Long planId) {
+        findOwnedPlan(userId, planId);
+
+        List<HandoffCheckAssigneeResponse> assignees = buildAssignees(planId);
+        List<HandoffCheckConfirmerResponse> confirmers = confirmerRepository.findByPlan_PlanIdOrderByConfirmIdAsc(planId).stream()
+                .map(HandoffCheckConfirmerResponse::from)
+                .toList();
+
+        return HandoffCheckStatusResponse.of(assignees, confirmers);
+    }
+
+    // 대체 담당자는 별도 박스가 아니라 주 담당자 박스 안에 표시되므로, 대체 담당자를 주 담당자 ID로 매핑해 함께 조회한다 (N+1 방지)
+    private List<HandoffCheckAssigneeResponse> buildAssignees(Long planId) {
+        List<Recipient> recipients = recipientRepository.findByPlan_PlanId(planId);
+
+        Map<Long, Recipient> backupByPrimaryId = new HashMap<>();
+        for (Recipient recipient : recipients) {
+            if (Boolean.TRUE.equals(recipient.getIsBackup()) && recipient.getBackupFor() != null) {
+                backupByPrimaryId.put(recipient.getBackupFor().getAssigneeId(), recipient);
+            }
+        }
+
+        return recipients.stream()
+                .filter(recipient -> !Boolean.TRUE.equals(recipient.getIsBackup()))
+                .sorted(Comparator.comparing(Recipient::getAssigneeId))
+                .map(recipient -> HandoffCheckAssigneeResponse.of(recipient, backupByPrimaryId.get(recipient.getAssigneeId())))
+                .toList();
+    }
+
+    // 로그인한 사용자가 자신의 계획만 조회할 수 있도록 검증 (불일치 시 존재 노출 방지를 위해 NOT_FOUND로 응답)
+    private Plan findOwnedPlan(Long userId, Long planId) {
+        Plan plan = planRepository.findById(planId)
+                .orElseThrow(() -> new CustomException(ErrorCode.PLAN_NOT_FOUND));
+        if (!plan.getUser().getUserId().equals(userId)) {
+            throw new CustomException(ErrorCode.PLAN_NOT_FOUND);
+        }
+        return plan;
+    }
+}


### PR DESCRIPTION
## 연관 Issue

- Closes #35 

## 요약

"선택형 생전 인계 점검" 화면(점검 > 인계 점검 탭)을 그릴 수 있도록, 역할 담당자와 지정 확인자의 준비 상태를 한 번에 조회하는 GET API를 추가했다.

## 변경 사항

- GET /api/plans/{planId}/handoff-checks 엔드포인트 신규 추가
- HandoffCheckAssigneeResponse / HandoffCheckConfirmerResponse / HandoffCheckStatusResponse DTO 작성
- HandoffCheckService: 소유권 검증 후 담당자·확인자 목록 조회, 대체 담당자는 Map으로 매핑해 N+1 없이 준비완료 여부 판정
- HandoffCheckController: Swagger 문서화 포함
- 준비완료 판정 규칙: 이메일 발송 + 역할 수락 (+ 대체 담당자가 있으면 그 수락 여부까

## 범위

### 포함

- 담당자/확인자 박스 데이터 조회 (이름, 역할, 이메일 발송 여부, 역할 수락 여부, 문의 사항)                                                                                       
- 담당자 박스의 대체 담당자 정보(이름 + 수락 여부)                                                                                                                               
- 헤더용 총 인원 / 점검 완료 인원 카운트

### 제외

- 점검 이메일 발송 API (POST /api/plans/{planId}/handoff-checks)                                                                                                                 
- 점검 응답 API (POST /api/handoff-checks/{token}/respond)

## 스크린샷 / 미리 보기
<img width="1424" height="986" alt="image" src="https://github.com/user-attachments/assets/e7c29910-6383-4562-9137-eb5fc81212ff" />
- 생전 인계점검: 역할담당자, 지정확인자 수락 전 
<img width="1404" height="979" alt="image" src="https://github.com/user-attachments/assets/332cda4e-08e9-4b39-977c-590ec74dd947" />
- 지정확인자 수락 ->  준비 완료 변경 
<img width="1417" height="988" alt="image" src="https://github.com/user-attachments/assets/c2e2596b-25b4-4c15-beab-ed87337e47f3" />
- 역할 담당자 수락 -> 대체 담당자 까지 수락해야지 준비완료 변경됨
<img width="1421" height="981" alt="image" src="https://github.com/user-attachments/assets/e37c3892-b599-4db5-bbdc-1f037296656a" />
- 역할 담당자, 대체 담당자 모두 수락 -> 준비완료 변경 