### PR TITLE
[Setting/#60] 백엔드 Dockerfile 작성

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM eclipse-temurin:21-jdk-jammy AS builder
+
+WORKDIR /workspace
+
+COPY gradlew build.gradle settings.gradle ./
+COPY gradle ./gradle
+RUN chmod +x gradlew \
+    && ./gradlew dependencies --no-daemon
+
+COPY src ./src
+RUN ./gradlew bootJar --no-daemon
+
+FROM eclipse-temurin:21-jre-jammy AS runtime
+
+RUN groupadd --system app \
+    && useradd --system --gid app --home-dir /app app
+
+WORKDIR /app
+
+COPY --from=builder --chown=app:app /workspace/build/libs/*.jar ./app.jar
+
+USER app
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]


### PR DESCRIPTION
## 연관 Issue
Closes #60

## 요약
Java 21 기반 멀티스테이지 Dockerfile을 추가해 백엔드 애플리케이션을 컨테이너 이미지로 빌드하고 비루트 사용자로 실행할 수 있도록 구성했습니다.

## 작업 내용
- Java 21 JDK 빌드 단계에서 Gradle Wrapper로 Spring Boot JAR 생성
- Java 21 JRE 런타임 단계에 실행 JAR만 복사
- 비루트 `app` 사용자와 8080 포트 및 실행 명령 설정
- Docker 이미지 빌드와 런타임 사용자·Java 버전 검증

## 범위
### 포함:
- 저장소 루트 Dockerfile
- 멀티스테이지 JAR 빌드
- 런타임 이미지 및 애플리케이션 실행 설정

### 제외:
- Docker Compose
- GitHub Actions 및 CI
- SBOM과 운영 인프라 구성

## 스크린샷 / 미리 보기
백엔드 컨테이너 설정 변경으로 해당 없음