### PR TITLE
[Setting/#54] 해커톤 DB 연결 설정 정리

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# PostgreSQL
+DB_URL=jdbc:postgresql://localhost:5432/ieojuda
+DB_USERNAME=ieojuda
+DB_PASSWORD=replace-with-local-password
+
+# Application dependencies required at startup
+OPENAI_API_KEY=replace-with-openai-api-key
+MAIL_USERNAME=replace-with-mail-username
+MAIL_PASSWORD=replace-with-mail-password
+AWS_S3_BUCKET=replace-with-s3-bucket
+AWS_S3_REGION=ap-northeast-2
+AWS_ACCESS_KEY_ID=replace-with-aws-access-key
+AWS_SECRET_ACCESS_KEY=replace-with-aws-secret-key
+JWT_SECRET=replace-with-at-least-32-random-characters
+APP_BASE_URL=http://localhost:3000
+APP_CONTACT_EMAIL=support@example.com

--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,4 @@ out/
 
 .env
 
-application.properties
 Docs


### PR DESCRIPTION
## 연관 Issue
Closes #54

## 요약
해커톤 시연 환경에서 필요한 PostgreSQL 및 애플리케이션 환경 변수 예시를 추가하고, 공유 설정 파일의 추적 정책을 현재 저장소 상태와 일치시켰습니다.

## 작업 내용
- PostgreSQL 연결값과 애플리케이션 필수 환경 변수의 `.env.example` 추가
- 실제 `.env` 무시 규칙 유지
- 이미 추적 중인 `application.properties`의 불필요한 ignore 규칙 제거
- 빈 PostgreSQL 16에서 `ddl-auto=update` 기반 애플리케이션 기동 검증

## 범위
### 포함:
- 환경 변수 예시 파일
- 단일 Hibernate `ddl-auto=update` 정책 검증
- 빈 PostgreSQL 연결 및 스키마 생성 검증

### 제외:
- Spring 프로필 분리
- Flyway·Liquibase
- 운영 DB 마이그레이션·백업·고가용성

## 스크린샷 / 미리 보기
백엔드 설정 변경으로 해당 없음