### PR TITLE
[Fix/#50] 대기 기간 7~30일 범위 적용

### DIFF
--- a/src/main/java/com/mamoki/ieojuda/domain/plan/controller/PlanController.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/controller/PlanController.java
@@ -55,7 +55,7 @@ public class PlanController {
         return ResponseEntity.ok(RsData.success(planService.getReleaseSettings(planId)));
     }
 
-    @Operation(summary = "대기 기간 설정", description = "증빙 승인 후 실제 발송까지 기다리는 대기 기간(7/14/21일)을 저장합니다.")
+    @Operation(summary = "대기 기간 설정", description = "증빙 승인 후 실제 발송까지 기다리는 대기 기간(7~30일)을 저장합니다.")
     @PutMapping("/{planId}/release-policy")
     public ResponseEntity<RsData<ReleasePolicyResponse>> updateReleasePolicy(
             @Parameter(description = "계획 ID") @PathVariable Long planId,

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/dto/ReleasePolicyRequest.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/dto/ReleasePolicyRequest.java
@@ -1,11 +1,16 @@
 package com.mamoki.ieojuda.domain.plan.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 // "대기 이의제기 설정" 화면 - 대기 기간 저장
 public record ReleasePolicyRequest(
-        @Schema(description = "대기 기간(일)", example = "7", allowableValues = {"7", "14", "21"})
-        @NotNull(message = "대기 기간을 선택해 주세요.") Integer waitingDays
+        @Schema(description = "대기 기간(일)", example = "7", minimum = "7", maximum = "30")
+        @NotNull(message = "대기 기간을 선택해 주세요.")
+        @Min(value = 7, message = "대기 기간은 7일 이상이어야 합니다.")
+        @Max(value = 30, message = "대기 기간은 30일 이하여야 합니다.")
+        Integer waitingDays
 ) {
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/entity/Plan.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/entity/Plan.java
@@ -29,7 +29,7 @@ public class Plan extends BaseCreatedAtEntity {
     @Column(name = "status", length = 30)
     private PlanStatus status;
 
-    // 명세서 "대기·이의 제기 설정" 화면 - 증빙 승인 후 실제 발송까지 기다리는 기간(7/14/21일)
+    // 명세서 "대기·이의 제기 설정" 화면 - 증빙 승인 후 실제 발송까지 기다리는 기간(7~30일)
     @Column(name = "waiting_days")
     private Integer waitingDays;
 

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/service/PlanService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/service/PlanService.java
@@ -25,7 +25,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.Set;
 
 // 계획(Plan)은 더 이상 사용자가 "만드는" 대상이 아니다 - 회원가입 시 자동으로 1개 생성되고(AuthService),
 // 사망확인/증빙검토/발송 파이프라인(death_confirmers, release_cases 등)이 매달리는 앵커 역할만 한다.
@@ -35,7 +34,8 @@ import java.util.Set;
 @Transactional(readOnly = true)
 public class PlanService {
 
-    private static final Set<Integer> ALLOWED_WAITING_DAYS = Set.of(7, 14, 21);
+    private static final int MIN_WAITING_DAYS = 7;
+    private static final int MAX_WAITING_DAYS = 30;
 
     private final PlanRepository planRepository;
     private final DisputeContactRepository disputeContactRepository;
@@ -70,7 +70,9 @@ public class PlanService {
     // "대기 이의제기 설정" 화면 - 대기 기간 저장
     @Transactional
     public ReleasePolicyResponse updateReleasePolicy(Long planId, ReleasePolicyRequest request) {
-        if (!ALLOWED_WAITING_DAYS.contains(request.waitingDays())) {
+        if (request.waitingDays() == null
+                || request.waitingDays() < MIN_WAITING_DAYS
+                || request.waitingDays() > MAX_WAITING_DAYS) {
             throw new CustomException(ErrorCode.INVALID_WAITING_PERIOD);
         }
         Plan plan = findPlan(planId);

--- a/src/main/java/com/mamoki/ieojuda/global/exception/ErrorCode.java
+++ b/src/main/java/com/mamoki/ieojuda/global/exception/ErrorCode.java
@@ -12,7 +12,7 @@ public enum ErrorCode {
     PASSWORD_CONFIRMATION_MISMATCH(HttpStatus.BAD_REQUEST, "PASSWORD_CONFIRMATION_MISMATCH", "비밀번호와 비밀번호 확인이 일치하지 않습니다."),
 
     // 계획 / 삶의 구역 / AI 구조화 관련 예외 (400)
-    INVALID_WAITING_PERIOD(HttpStatus.BAD_REQUEST, "INVALID_WAITING_PERIOD", "대기 기간은 7일, 14일, 21일 중 하나여야 합니다."),
+    INVALID_WAITING_PERIOD(HttpStatus.BAD_REQUEST, "INVALID_WAITING_PERIOD", "대기 기간은 7일 이상 30일 이하여야 합니다."),
     CONSENT_REQUIRED(HttpStatus.BAD_REQUEST, "CONSENT_REQUIRED", "사후 인계 조건과 안전 범위를 확인해 주세요."),
     SUSPECTED_CREDENTIAL_INPUT(HttpStatus.BAD_REQUEST, "SUSPECTED_CREDENTIAL_INPUT", "비밀번호 등 자격증명으로 의심되는 내용은 저장할 수 없습니다."),
     UNGROUNDED_ITEM_NOT_APPROVABLE(HttpStatus.BAD_REQUEST, "UNGROUNDED_ITEM_NOT_APPROVABLE", "원문 근거가 없는 항목은 승인할 수 없습니다."),

--- a/src/test/java/com/mamoki/ieojuda/domain/plan/controller/PlanControllerValidationTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/plan/controller/PlanControllerValidationTest.java
@@ -1,0 +1,36 @@
+package com.mamoki.ieojuda.domain.plan.controller;
+
+import com.mamoki.ieojuda.domain.plan.service.PlanService;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class PlanControllerValidationTest {
+
+    private final PlanService planService = mock(PlanService.class);
+    private final MockMvc mockMvc = MockMvcBuilders
+            .standaloneSetup(new PlanController(planService))
+            .build();
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "{\"waitingDays\":6}",
+            "{\"waitingDays\":31}",
+            "{\"waitingDays\":null}"
+    })
+    void updateReleasePolicyReturnsBadRequestForInvalidRange(String body) throws Exception {
+        mockMvc.perform(put("/api/plans/1/release-policy")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest());
+
+        verifyNoInteractions(planService);
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/domain/plan/service/PlanServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/plan/service/PlanServiceTest.java
@@ -1,0 +1,90 @@
+package com.mamoki.ieojuda.domain.plan.service;
+
+import com.mamoki.ieojuda.domain.confirmer.repository.DisputeContactRepository;
+import com.mamoki.ieojuda.domain.plan.dto.ReleasePolicyRequest;
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.plan.repository.PlanRepository;
+import com.mamoki.ieojuda.global.config.AppProperties;
+import com.mamoki.ieojuda.global.email.sender.EmailSender;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Optional;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class PlanServiceTest {
+
+    private PlanRepository planRepository;
+    private Plan plan;
+    private PlanService planService;
+    private Validator validator;
+
+    @BeforeEach
+    void setUp() {
+        planRepository = mock(PlanRepository.class);
+        plan = mock(Plan.class);
+        planService = new PlanService(
+                planRepository,
+                mock(DisputeContactRepository.class),
+                mock(EmailSender.class),
+                mock(AppProperties.class)
+        );
+        validator = Validation.buildDefaultValidatorFactory().getValidator();
+    }
+
+    @ParameterizedTest
+    @MethodSource("validWaitingDays")
+    void updateReleasePolicyAcceptsEveryDayWithinRange(int waitingDays) {
+        when(planRepository.findById(1L)).thenReturn(Optional.of(plan));
+
+        planService.updateReleasePolicy(1L, new ReleasePolicyRequest(waitingDays));
+
+        verify(plan).updateWaitingDays(waitingDays);
+    }
+
+    private static Stream<Integer> validWaitingDays() {
+        return IntStream.rangeClosed(7, 30).boxed();
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {6, 31})
+    void updateReleasePolicyRejectsDaysOutsideRange(int waitingDays) {
+        assertInvalidWaitingDays(waitingDays);
+    }
+
+    @Test
+    void updateReleasePolicyRejectsNull() {
+        assertInvalidWaitingDays(null);
+    }
+
+    private void assertInvalidWaitingDays(Integer waitingDays) {
+        assertThatThrownBy(() -> planService.updateReleasePolicy(1L, new ReleasePolicyRequest(waitingDays)))
+                .isInstanceOfSatisfying(CustomException.class,
+                        exception -> assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INVALID_WAITING_PERIOD));
+        verifyNoInteractions(planRepository);
+    }
+
+    @Test
+    void requestValidationMatchesSevenToThirtyDayRange() {
+        assertThat(validator.validate(new ReleasePolicyRequest(7))).isEmpty();
+        assertThat(validator.validate(new ReleasePolicyRequest(30))).isEmpty();
+        assertThat(validator.validate(new ReleasePolicyRequest(6))).isNotEmpty();
+        assertThat(validator.validate(new ReleasePolicyRequest(31))).isNotEmpty();
+        assertThat(validator.validate(new ReleasePolicyRequest(null))).isNotEmpty();
+    }
+}


### PR DESCRIPTION
## 연관 Issue
Closes #50

## 요약
대기 기간 정책을 기존의 7·14·21일 선택값에서 7일부터 30일까지의 연속 범위로 변경하고, DTO·서비스·API 문서와 경계값 테스트를 일치시켰습니다.

## 작업 내용
- 서비스 대기 기간 검증을 7~30일 범위로 변경
- DTO에 `@Min(7)`·`@Max(30)` 검증 추가
- Swagger 설명과 오류 메시지 갱신
- 7~30일 전체 허용 및 6·31·null 거절 테스트 추가
- 잘못된 HTTP 요청이 400이며 서비스를 호출하지 않는지 검증

## 범위
### 포함:
- 대기 기간 입력 검증
- DTO와 OpenAPI 계약
- 서비스·Bean Validation·HTTP 경계값 테스트

### 제외:
- 대기 종료 스케줄러 재설계
- 이의 제기 정책 변경

## 스크린샷 / 미리 보기
백엔드 API 검증 변경으로 해당 없음