### PR TITLE
[Fix/#58] 입력 크기 제한과 DB 스키마 검증 정합성 개선

### DIFF
--- a/src/main/java/com/mamoki/ieojuda/domain/account/dto/LoginRequest.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/account/dto/LoginRequest.java
@@ -5,9 +5,11 @@ import jakarta.validation.constraints.NotBlank;
 
 public record LoginRequest(
         @Schema(description = "이메일", example = "user@example.com")
-        @NotBlank(message = "이메일을 입력해 주세요.") String email,
+        @NotBlank(message = "이메일을 입력해 주세요.")
+        @jakarta.validation.constraints.Size(max = 255, message = "이메일은 255자 이하여야 합니다.") String email,
 
         @Schema(description = "비밀번호", example = "password1234")
-        @NotBlank(message = "비밀번호를 입력해 주세요.") String password
+        @NotBlank(message = "비밀번호를 입력해 주세요.")
+        @jakarta.validation.constraints.Size(max = 128, message = "비밀번호는 128자 이하여야 합니다.") String password
 ) {
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/account/dto/RefreshRequest.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/account/dto/RefreshRequest.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotBlank;
 
 public record RefreshRequest(
         @Schema(description = "로그인 시 발급받은 Refresh Token")
-        @NotBlank(message = "Refresh Token이 필요합니다.") String refreshToken
+        @NotBlank(message = "Refresh Token이 필요합니다.")
+        @jakarta.validation.constraints.Size(max = 255, message = "Refresh Token은 255자 이하여야 합니다.") String refreshToken
 ) {
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/account/dto/SignupRequest.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/account/dto/SignupRequest.java
@@ -6,15 +6,19 @@ import jakarta.validation.constraints.NotBlank;
 
 public record SignupRequest(
         @Schema(description = "이메일", example = "user@example.com")
-        @NotBlank(message = "이메일을 입력해 주세요.") @Email(message = "이메일 형식이 올바르지 않습니다.") String email,
+        @NotBlank(message = "이메일을 입력해 주세요.") @Email(message = "이메일 형식이 올바르지 않습니다.")
+        @jakarta.validation.constraints.Size(max = 255, message = "이메일은 255자 이하여야 합니다.") String email,
 
         @Schema(description = "비밀번호", example = "password1234")
-        @NotBlank(message = "비밀번호를 입력해 주세요.") String password,
+        @NotBlank(message = "비밀번호를 입력해 주세요.")
+        @jakarta.validation.constraints.Size(max = 128, message = "비밀번호는 128자 이하여야 합니다.") String password,
 
         @Schema(description = "비밀번호 확인", example = "password1234")
-        @NotBlank(message = "비밀번호 확인을 입력해 주세요.") String passwordConfirm,
+        @NotBlank(message = "비밀번호 확인을 입력해 주세요.")
+        @jakarta.validation.constraints.Size(max = 128, message = "비밀번호 확인은 128자 이하여야 합니다.") String passwordConfirm,
 
         @Schema(description = "이름", example = "홍길동")
-        @NotBlank(message = "이름을 입력해 주세요.") String name
+        @NotBlank(message = "이름을 입력해 주세요.")
+        @jakarta.validation.constraints.Size(max = 100, message = "이름은 100자 이하여야 합니다.") String name
 ) {
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/account/dto/UserUpdateRequest.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/account/dto/UserUpdateRequest.java
@@ -8,9 +8,11 @@ import jakarta.validation.constraints.NotBlank;
 public record UserUpdateRequest(
         @Schema(description = "새 이메일", example = "namu_k@gmail.com")
         @NotBlank(message = "이메일을 입력해 주세요.")
-        @Email(message = "이메일 형식이 올바르지 않습니다.") String email,
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        @jakarta.validation.constraints.Size(max = 255, message = "이메일은 255자 이하여야 합니다.") String email,
 
         @Schema(description = "새 이름", example = "홍길동")
-        @NotBlank(message = "이름을 입력해 주세요.") String name
+        @NotBlank(message = "이름을 입력해 주세요.")
+        @jakarta.validation.constraints.Size(max = 100, message = "이름은 100자 이하여야 합니다.") String name
 ) {
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/account/entity/User.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/account/entity/User.java
@@ -26,7 +26,7 @@ public class User extends BaseCreatedAtEntity {
     @Column(name = "password", length = 255, nullable = false)
     private String password;
 
-    @Column(name = "name", length = 50)
+    @Column(name = "name", length = 100)
     private String name;
 
     @Column(name = "refresh_token", length = 255)

--- a/src/main/java/com/mamoki/ieojuda/domain/confirmer/dto/ConfirmerRegisterRequest.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/confirmer/dto/ConfirmerRegisterRequest.java
@@ -7,10 +7,12 @@ import jakarta.validation.constraints.NotBlank;
 // "지정 확인자 등록" 화면 - 이름/이메일 입력 폼 한 줄에 대응
 public record ConfirmerRegisterRequest(
         @Schema(description = "확인자 이름", example = "김민수")
-        @NotBlank(message = "확인자 이름을 입력해 주세요.") String name,
+        @NotBlank(message = "확인자 이름을 입력해 주세요.")
+        @jakarta.validation.constraints.Size(max = 100, message = "확인자 이름은 100자 이하여야 합니다.") String name,
 
         @Schema(description = "확인자 이메일", example = "confirmer@example.com")
         @NotBlank(message = "확인자 이메일을 입력해 주세요.")
-        @Email(message = "이메일 형식이 올바르지 않습니다.") String email
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        @jakarta.validation.constraints.Size(max = 255, message = "확인자 이메일은 255자 이하여야 합니다.") String email
 ) {
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/confirmer/dto/ConfirmerUpdateRequest.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/confirmer/dto/ConfirmerUpdateRequest.java
@@ -7,10 +7,12 @@ import jakarta.validation.constraints.NotBlank;
 // "확인자 수정" 화면 - 이름/이메일 수정
 public record ConfirmerUpdateRequest(
         @Schema(description = "확인자 이름", example = "김민수")
-        @NotBlank(message = "확인자 이름을 입력해 주세요.") String name,
+        @NotBlank(message = "확인자 이름을 입력해 주세요.")
+        @jakarta.validation.constraints.Size(max = 100, message = "확인자 이름은 100자 이하여야 합니다.") String name,
 
         @Schema(description = "확인자 이메일", example = "confirmer@example.com")
         @NotBlank(message = "확인자 이메일을 입력해 주세요.")
-        @Email(message = "이메일 형식이 올바르지 않습니다.") String email
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        @jakarta.validation.constraints.Size(max = 255, message = "확인자 이메일은 255자 이하여야 합니다.") String email
 ) {
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/confirmer/dto/DisputeContactRegisterRequest.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/confirmer/dto/DisputeContactRegisterRequest.java
@@ -7,10 +7,12 @@ import jakarta.validation.constraints.NotBlank;
 // "대기 이의제기 설정" 화면 - 이의 제기 연락처 등록(검증 메일 발송)
 public record DisputeContactRegisterRequest(
         @Schema(description = "이의 제기 연락처 이름", example = "이지수")
-        @NotBlank(message = "이름을 입력해 주세요.") String name,
+        @NotBlank(message = "이름을 입력해 주세요.")
+        @jakarta.validation.constraints.Size(max = 100, message = "이름은 100자 이하여야 합니다.") String name,
 
         @Schema(description = "이의 제기 연락처 이메일", example = "jisoo@example.com")
         @NotBlank(message = "이메일을 입력해 주세요.")
-        @Email(message = "이메일 형식이 올바르지 않습니다.") String email
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        @jakarta.validation.constraints.Size(max = 255, message = "이메일은 255자 이하여야 합니다.") String email
 ) {
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/confirmer/entity/Confirmer.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/confirmer/entity/Confirmer.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
@@ -16,32 +17,120 @@ import java.time.LocalDateTime;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Confirmer {
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY) @Column(name = "confirm_id") private Long confirmId;
-    @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(name = "plan_id", nullable = false) private Plan plan;
-    @Column(name = "name", length = 100) private String name;
-    @Enumerated(EnumType.STRING) @Column(name = "relationship", length = 30) private Relationship relationship;
-    @Column(name = "email", length = 255) private String email;
-    @Enumerated(EnumType.STRING) @Column(name = "acceptance_status", length = 30) private AcceptanceStatus acceptanceStatus;
-    @Column(name = "accepted_at") private LocalDateTime acceptedAt;
-    @Enumerated(EnumType.STRING) @Column(name = "report_status", length = 30) private ReportStatus reportStatus;
-    @Column(name = "reported_at") private LocalDateTime reportedAt;
-    @Column(name = "reported_death_date") private LocalDate reportedDeathDate;
-    @Column(name = "invite_token", length = 255) private String inviteToken;
-    @Column(name = "invite_token_expires_at") private LocalDateTime inviteTokenExpiresAt;
-    @Column(name = "inquiry", length = 1000) private String inquiry;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "confirm_id")
+    private Long confirmId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "plan_id", nullable = false)
+    private Plan plan;
+
+    @Column(name = "name", length = 100)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "relationship", length = 30)
+    private Relationship relationship;
+
+    @Column(name = "email", length = 255)
+    private String email;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "acceptance_status", length = 30)
+    private AcceptanceStatus acceptanceStatus;
+
+    @Column(name = "accepted_at")
+    private LocalDateTime acceptedAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "report_status", length = 30)
+    private ReportStatus reportStatus;
+
+    @Column(name = "reported_at")
+    private LocalDateTime reportedAt;
+
+    // "사망 신고 이메일" 화면 - 확인자가 입력한 사망일 (모르는 경우 null)
+    @Column(name = "reported_death_date")
+    private LocalDate reportedDeathDate;
+
+    @Column(name = "invite_token", length = 255)
+    private String inviteToken;
+
+    @Column(name = "invite_token_expires_at")
+    private LocalDateTime inviteTokenExpiresAt;
+
+    // "지정확인자 수락 이메일" 화면 - 확인자가 수락/거절 시 남기는 문의 사항 (선택 입력)
+    @Column(name = "inquiry", length = 1000)
+    private String inquiry;
 
     @Builder
     public Confirmer(Plan plan, String name, Relationship relationship, String email) {
-        this.plan = plan; this.name = name; this.relationship = relationship; this.email = email;
-        this.acceptanceStatus = AcceptanceStatus.PENDING; this.reportStatus = ReportStatus.NOT_REPORTED;
+        this.plan = plan;
+        this.name = name;
+        this.relationship = relationship;
+        this.email = email;
+        this.acceptanceStatus = AcceptanceStatus.PENDING; // 처음 생성할떄 대기 상태
+        this.reportStatus = ReportStatus.NOT_REPORTED;
     }
-    public void issueInviteToken(String inviteTokenHash, LocalDateTime expiresAt) { this.inviteToken = inviteTokenHash; this.inviteTokenExpiresAt = expiresAt; }
-    public void resetAcceptance() { this.acceptanceStatus = AcceptanceStatus.PENDING; this.acceptedAt = null; }
-    public boolean updateContact(String name, String email) { this.name = name; boolean emailChanged = !this.email.equals(email); if (emailChanged) { this.email = email; this.acceptanceStatus = AcceptanceStatus.PENDING; this.acceptedAt = null; this.inviteToken = null; this.inviteTokenExpiresAt = null; } return emailChanged; }
-    public void accept(String inquiry) { this.acceptanceStatus = AcceptanceStatus.ACCEPTED; this.acceptedAt = LocalDateTime.now(); this.inquiry = inquiry; }
-    public void decline(String inquiry) { this.acceptanceStatus = AcceptanceStatus.DECLINED; this.inquiry = inquiry; }
-    public void expire() { this.acceptanceStatus = AcceptanceStatus.EXPIRED; }
-    public void report(LocalDate reportedDeathDate) { this.reportStatus = ReportStatus.REPORTED; this.reportedAt = LocalDateTime.now(); this.reportedDeathDate = reportedDeathDate; }
-    public void markMatched() { this.reportStatus = ReportStatus.MATCHED; }
-    public void markMismatched() { this.reportStatus = ReportStatus.MISMATCHED; }
+
+    // 초대 이메일 토큰 저장 (평문이 아닌 해시값만 저장, 만료 시각 함께 기록)
+    public void issueInviteToken(String inviteTokenHash, LocalDateTime expiresAt) {
+        this.inviteToken = inviteTokenHash;
+        this.inviteTokenExpiresAt = expiresAt;
+    }
+
+    // 수락 요청 재전송 - 새 토큰이 발급되므로 만료 상태를 수락 대기로 되돌린다
+    public void resetAcceptance() {
+        this.acceptanceStatus = AcceptanceStatus.PENDING;
+        this.acceptedAt = null;
+    }
+
+    // "확인자 수정하기" - 이름/이메일 수정. 이메일이 바뀌면 기존 수락 상태와 초대 토큰을 무효화한다
+    public boolean updateContact(String name, String email) {
+        this.name = name;
+        boolean emailChanged = !this.email.equals(email);
+        if (emailChanged) {
+            this.email = email;
+            this.acceptanceStatus = AcceptanceStatus.PENDING;
+            this.acceptedAt = null;
+            this.inviteToken = null;
+            this.inviteTokenExpiresAt = null;
+        }
+        return emailChanged;
+    }
+
+    //  수락 상태
+    public void accept(String inquiry) {
+        this.acceptanceStatus = AcceptanceStatus.ACCEPTED;
+        this.acceptedAt = LocalDateTime.now();
+        this.inquiry = inquiry;
+    }
+    // 거절 상태
+    public void decline(String inquiry) {
+        this.acceptanceStatus = AcceptanceStatus.DECLINED;
+        this.inquiry = inquiry;
+    }
+    // 만료 상태
+    public void expire() {
+        this.acceptanceStatus = AcceptanceStatus.EXPIRED;
+    }
+
+    // 사망 신고 접수 (각 확인자 독립 신고, 사망일은 모를 경우 null)
+    public void report(LocalDate reportedDeathDate) {
+        this.reportStatus = ReportStatus.REPORTED;
+        this.reportedAt = LocalDateTime.now();
+        this.reportedDeathDate = reportedDeathDate;
+    }
+
+    // 다른 확인자 신고와 대상·사건이 일치한다고 판정
+    public void markMatched() {
+        this.reportStatus = ReportStatus.MATCHED;
+    }
+
+    // 다른 확인자 신고와 불일치 → 절차 중지, 운영 검토 전환
+    public void markMismatched() {
+        this.reportStatus = ReportStatus.MISMATCHED;
+    }
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/confirmer/entity/Confirmer.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/confirmer/entity/Confirmer.java
@@ -8,7 +8,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
@@ -17,120 +16,32 @@ import java.time.LocalDateTime;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Confirmer {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "confirm_id")
-    private Long confirmId;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "plan_id", nullable = false)
-    private Plan plan;
-
-    @Column(name = "name", length = 100)
-    private String name;
-
-    @Enumerated(EnumType.STRING)
-    @Column(name = "relationship", length = 30)
-    private Relationship relationship;
-
-    @Column(name = "email", length = 255)
-    private String email;
-
-    @Enumerated(EnumType.STRING)
-    @Column(name = "acceptance_status", length = 30)
-    private AcceptanceStatus acceptanceStatus;
-
-    @Column(name = "accepted_at")
-    private LocalDateTime acceptedAt;
-
-    @Enumerated(EnumType.STRING)
-    @Column(name = "report_status", length = 30)
-    private ReportStatus reportStatus;
-
-    @Column(name = "reported_at")
-    private LocalDateTime reportedAt;
-
-    // "사망 신고 이메일" 화면 - 확인자가 입력한 사망일 (모르는 경우 null)
-    @Column(name = "reported_death_date")
-    private LocalDate reportedDeathDate;
-
-    @Column(name = "invite_token", length = 255)
-    private String inviteToken;
-
-    @Column(name = "invite_token_expires_at")
-    private LocalDateTime inviteTokenExpiresAt;
-
-    // "지정확인자 수락 이메일" 화면 - 확인자가 수락/거절 시 남기는 문의 사항 (선택 입력)
-    @Column(name = "inquiry", columnDefinition = "TEXT")
-    private String inquiry;
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY) @Column(name = "confirm_id") private Long confirmId;
+    @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(name = "plan_id", nullable = false) private Plan plan;
+    @Column(name = "name", length = 100) private String name;
+    @Enumerated(EnumType.STRING) @Column(name = "relationship", length = 30) private Relationship relationship;
+    @Column(name = "email", length = 255) private String email;
+    @Enumerated(EnumType.STRING) @Column(name = "acceptance_status", length = 30) private AcceptanceStatus acceptanceStatus;
+    @Column(name = "accepted_at") private LocalDateTime acceptedAt;
+    @Enumerated(EnumType.STRING) @Column(name = "report_status", length = 30) private ReportStatus reportStatus;
+    @Column(name = "reported_at") private LocalDateTime reportedAt;
+    @Column(name = "reported_death_date") private LocalDate reportedDeathDate;
+    @Column(name = "invite_token", length = 255) private String inviteToken;
+    @Column(name = "invite_token_expires_at") private LocalDateTime inviteTokenExpiresAt;
+    @Column(name = "inquiry", length = 1000) private String inquiry;
 
     @Builder
     public Confirmer(Plan plan, String name, Relationship relationship, String email) {
-        this.plan = plan;
-        this.name = name;
-        this.relationship = relationship;
-        this.email = email;
-        this.acceptanceStatus = AcceptanceStatus.PENDING; // 처음 생성할떄 대기 상태
-        this.reportStatus = ReportStatus.NOT_REPORTED;
+        this.plan = plan; this.name = name; this.relationship = relationship; this.email = email;
+        this.acceptanceStatus = AcceptanceStatus.PENDING; this.reportStatus = ReportStatus.NOT_REPORTED;
     }
-
-    // 초대 이메일 토큰 저장 (평문이 아닌 해시값만 저장, 만료 시각 함께 기록)
-    public void issueInviteToken(String inviteTokenHash, LocalDateTime expiresAt) {
-        this.inviteToken = inviteTokenHash;
-        this.inviteTokenExpiresAt = expiresAt;
-    }
-
-    // 수락 요청 재전송 - 새 토큰이 발급되므로 만료 상태를 수락 대기로 되돌린다
-    public void resetAcceptance() {
-        this.acceptanceStatus = AcceptanceStatus.PENDING;
-        this.acceptedAt = null;
-    }
-
-    // "확인자 수정하기" - 이름/이메일 수정. 이메일이 바뀌면 기존 수락 상태와 초대 토큰을 무효화한다
-    public boolean updateContact(String name, String email) {
-        this.name = name;
-        boolean emailChanged = !this.email.equals(email);
-        if (emailChanged) {
-            this.email = email;
-            this.acceptanceStatus = AcceptanceStatus.PENDING;
-            this.acceptedAt = null;
-            this.inviteToken = null;
-            this.inviteTokenExpiresAt = null;
-        }
-        return emailChanged;
-    }
-
-    //  수락 상태
-    public void accept(String inquiry) {
-        this.acceptanceStatus = AcceptanceStatus.ACCEPTED;
-        this.acceptedAt = LocalDateTime.now();
-        this.inquiry = inquiry;
-    }
-    // 거절 상태
-    public void decline(String inquiry) {
-        this.acceptanceStatus = AcceptanceStatus.DECLINED;
-        this.inquiry = inquiry;
-    }
-    // 만료 상태
-    public void expire() {
-        this.acceptanceStatus = AcceptanceStatus.EXPIRED;
-    }
-
-    // 사망 신고 접수 (각 확인자 독립 신고, 사망일은 모를 경우 null)
-    public void report(LocalDate reportedDeathDate) {
-        this.reportStatus = ReportStatus.REPORTED;
-        this.reportedAt = LocalDateTime.now();
-        this.reportedDeathDate = reportedDeathDate;
-    }
-
-    // 다른 확인자 신고와 대상·사건이 일치한다고 판정
-    public void markMatched() {
-        this.reportStatus = ReportStatus.MATCHED;
-    }
-
-    // 다른 확인자 신고와 불일치 → 절차 중지, 운영 검토 전환
-    public void markMismatched() {
-        this.reportStatus = ReportStatus.MISMATCHED;
-    }
+    public void issueInviteToken(String inviteTokenHash, LocalDateTime expiresAt) { this.inviteToken = inviteTokenHash; this.inviteTokenExpiresAt = expiresAt; }
+    public void resetAcceptance() { this.acceptanceStatus = AcceptanceStatus.PENDING; this.acceptedAt = null; }
+    public boolean updateContact(String name, String email) { this.name = name; boolean emailChanged = !this.email.equals(email); if (emailChanged) { this.email = email; this.acceptanceStatus = AcceptanceStatus.PENDING; this.acceptedAt = null; this.inviteToken = null; this.inviteTokenExpiresAt = null; } return emailChanged; }
+    public void accept(String inquiry) { this.acceptanceStatus = AcceptanceStatus.ACCEPTED; this.acceptedAt = LocalDateTime.now(); this.inquiry = inquiry; }
+    public void decline(String inquiry) { this.acceptanceStatus = AcceptanceStatus.DECLINED; this.inquiry = inquiry; }
+    public void expire() { this.acceptanceStatus = AcceptanceStatus.EXPIRED; }
+    public void report(LocalDate reportedDeathDate) { this.reportStatus = ReportStatus.REPORTED; this.reportedAt = LocalDateTime.now(); this.reportedDeathDate = reportedDeathDate; }
+    public void markMatched() { this.reportStatus = ReportStatus.MATCHED; }
+    public void markMismatched() { this.reportStatus = ReportStatus.MISMATCHED; }
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/evidence/controller/EvidenceSubmitController.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/evidence/controller/EvidenceSubmitController.java
@@ -24,7 +24,7 @@ public class EvidenceSubmitController {
 
     private final EvidenceSubmitService evidenceSubmitService;
 
-    @Operation(summary = "증빙 자료 제출", description = "PDF/JPG/PNG, 최대 10MB, 사건당 최대 3개까지 제출할 수 있습니다.")
+    @Operation(summary = "증빙 자료 제출", description = "PDF/JPG/PNG, 파일당 최대 25MB, 요청 전체 최대 30MB, 사건당 최대 3개까지 제출할 수 있습니다.")
     @PostMapping(value = "/evidences", consumes = "multipart/form-data")
     public ResponseEntity<RsData<EvidenceSubmitResponse>> submit(
             @Parameter(description = "초대 토큰") @PathVariable String token,

--- a/src/main/java/com/mamoki/ieojuda/domain/evidence/entity/Evidence.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/evidence/entity/Evidence.java
@@ -58,7 +58,7 @@ public class Evidence {
     @Column(name = "integrity_hash", length = 255)
     private String integrityHash;
 
-    @Column(name = "failure_reason", columnDefinition = "TEXT")
+    @Column(name = "failure_reason", length = 1000)
     private String failureReason;
 
     @Column(name = "storage_key", length = 500, nullable = false)

--- a/src/main/java/com/mamoki/ieojuda/domain/evidence/service/EvidenceSubmitService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/evidence/service/EvidenceSubmitService.java
@@ -31,7 +31,7 @@ import java.util.Set;
 public class EvidenceSubmitService {
 
     private static final Set<String> ALLOWED_MIME_TYPES = Set.of("application/pdf", "image/jpeg", "image/png");
-    private static final long MAX_FILE_SIZE = 10L * 1024 * 1024; // 10MB
+    private static final long MAX_FILE_SIZE = 25L * 1024 * 1024; // 25MB
     private static final long MAX_FILE_COUNT = 3;
 
     private final ConfirmerRepository confirmerRepository;
@@ -83,7 +83,7 @@ public class EvidenceSubmitService {
             throw new CustomException(ErrorCode.EVIDENCE_SUBMISSION_INVALID);
         }
         if (file.getSize() > MAX_FILE_SIZE) {
-            throw new CustomException(ErrorCode.EVIDENCE_SUBMISSION_INVALID);
+            throw new CustomException(ErrorCode.PAYLOAD_TOO_LARGE);
         }
     }
 

--- a/src/main/java/com/mamoki/ieojuda/domain/evidence/service/EvidenceSubmitService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/evidence/service/EvidenceSubmitService.java
@@ -79,6 +79,10 @@ public class EvidenceSubmitService {
         if (file == null || file.isEmpty()) {
             throw new CustomException(ErrorCode.EVIDENCE_SUBMISSION_INVALID);
         }
+        String originalFilename = file.getOriginalFilename();
+        if (originalFilename == null || originalFilename.isBlank() || originalFilename.length() > 255) {
+            throw new CustomException(ErrorCode.EVIDENCE_SUBMISSION_INVALID);
+        }
         if (!ALLOWED_MIME_TYPES.contains(file.getContentType())) {
             throw new CustomException(ErrorCode.EVIDENCE_SUBMISSION_INVALID);
         }

--- a/src/main/java/com/mamoki/ieojuda/domain/partner/dto/PartnerReviewDecisionRequest.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/partner/dto/PartnerReviewDecisionRequest.java
@@ -3,14 +3,11 @@ package com.mamoki.ieojuda.domain.partner.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
-// "외부 파트너 증빙 검토" 화면 - 승인/반려 요청/추가 자료 요청
-// 검토자는 요청 바디가 아니라 로그인한 계정(JWT principal)에서 식별한다.
 public record PartnerReviewDecisionRequest(
         @Schema(description = "결정", example = "APPROVE", allowableValues = {"APPROVE", "REJECT", "ADDITIONAL_INFO_REQUESTED"})
         @NotNull(message = "결정을 선택해 주세요.") PartnerReviewDecision decision,
-        @Schema(description = "반려 사유 (REJECT일 때 필수)") String failureReason
+        @Schema(description = "반려 사유 (REJECT일 때 필수)")
+        @jakarta.validation.constraints.Size(max = 1000, message = "반려 사유는 1,000자 이하여야 합니다.") String failureReason
 ) {
-    public enum PartnerReviewDecision {
-        APPROVE, REJECT, ADDITIONAL_INFO_REQUESTED
-    }
+    public enum PartnerReviewDecision { APPROVE, REJECT, ADDITIONAL_INFO_REQUESTED }
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/partner/dto/PartnerReviewDecisionRequest.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/partner/dto/PartnerReviewDecisionRequest.java
@@ -3,11 +3,15 @@ package com.mamoki.ieojuda.domain.partner.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
+// "외부 파트너 증빙 검토" 화면 - 승인/반려 요청/추가 자료 요청
+// 검토자는 요청 바디가 아니라 로그인한 계정(JWT principal)에서 식별한다.
 public record PartnerReviewDecisionRequest(
         @Schema(description = "결정", example = "APPROVE", allowableValues = {"APPROVE", "REJECT", "ADDITIONAL_INFO_REQUESTED"})
         @NotNull(message = "결정을 선택해 주세요.") PartnerReviewDecision decision,
         @Schema(description = "반려 사유 (REJECT일 때 필수)")
         @jakarta.validation.constraints.Size(max = 1000, message = "반려 사유는 1,000자 이하여야 합니다.") String failureReason
 ) {
-    public enum PartnerReviewDecision { APPROVE, REJECT, ADDITIONAL_INFO_REQUESTED }
+    public enum PartnerReviewDecision {
+        APPROVE, REJECT, ADDITIONAL_INFO_REQUESTED
+    }
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/dto/ItemUpdateRequest.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/dto/ItemUpdateRequest.java
@@ -4,13 +4,19 @@ import jakarta.validation.constraints.NotBlank;
 
 // 대화창 인라인 "수정" 버튼 - 항목 내용을 사용자가 직접 고쳐 저장
 public record ItemUpdateRequest(
-        @NotBlank(message = "대상 이름을 입력해 주세요.") String targetName,
-        @NotBlank(message = "위치 유형을 입력해 주세요.") String locationType,
-        @NotBlank(message = "행동을 입력해 주세요.") String action,
-        @NotBlank(message = "제목을 입력해 주세요.") String title,
-        @NotBlank(message = "내용을 입력해 주세요.") String content,
-        String precondition,
-        @NotBlank(message = "공개 범위를 선택해 주세요.") String disclosureScope,
-        String actionType
+        @NotBlank(message = "대상 이름을 입력해 주세요.")
+        @jakarta.validation.constraints.Size(max = 100, message = "대상 이름은 100자 이하여야 합니다.") String targetName,
+        @NotBlank(message = "위치 유형을 입력해 주세요.")
+        @jakarta.validation.constraints.Size(max = 100, message = "위치 유형은 100자 이하여야 합니다.") String locationType,
+        @NotBlank(message = "행동을 입력해 주세요.")
+        @jakarta.validation.constraints.Size(max = 2000, message = "행동은 2,000자 이하여야 합니다.") String action,
+        @NotBlank(message = "제목을 입력해 주세요.")
+        @jakarta.validation.constraints.Size(max = 200, message = "제목은 200자 이하여야 합니다.") String title,
+        @NotBlank(message = "내용을 입력해 주세요.")
+        @jakarta.validation.constraints.Size(max = 2000, message = "내용은 2,000자 이하여야 합니다.") String content,
+        @jakarta.validation.constraints.Size(max = 2000, message = "선행 조건은 2,000자 이하여야 합니다.") String precondition,
+        @NotBlank(message = "공개 범위를 선택해 주세요.")
+        @jakarta.validation.constraints.Size(max = 30, message = "공개 범위 값은 30자 이하여야 합니다.") String disclosureScope,
+        @jakarta.validation.constraints.Size(max = 30, message = "행동 유형 값은 30자 이하여야 합니다.") String actionType
 ) {
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/dto/SelfWarningEmailRequest.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/dto/SelfWarningEmailRequest.java
@@ -8,6 +8,7 @@ import jakarta.validation.constraints.NotBlank;
 public record SelfWarningEmailRequest(
         @Schema(description = "실행 신고가 오면 가장 먼저 경고 메일을 받을 본인 주소", example = "namu_k@gmail.com")
         @NotBlank(message = "이메일을 입력해 주세요.")
-        @Email(message = "이메일 형식이 올바르지 않습니다.") String email
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        @jakarta.validation.constraints.Size(max = 255, message = "이메일은 255자 이하여야 합니다.") String email
 ) {
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/entity/Item.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/entity/Item.java
@@ -34,23 +34,23 @@ public class Item {
     @Column(name = "location_type", length = 100)
     private String locationType;
 
-    @Column(name = "action", columnDefinition = "TEXT")
+    @Column(name = "action", length = 2000)
     private String action;
 
-    @Column(name = "title", length = 100)
+    @Column(name = "title", length = 200)
     private String title;
 
-    @Column(name = "content", columnDefinition = "TEXT")
+    @Column(name = "content", length = 2000)
     private String content;
 
-    @Column(name = "precondition", columnDefinition = "TEXT")
+    @Column(name = "precondition", length = 2000)
     private String precondition;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "disclosure_scope", length = 30)
     private DisclosureScope disclosureScope;
 
-    @Column(name = "source_excerpt", columnDefinition = "TEXT")
+    @Column(name = "source_excerpt", length = 2000)
     private String sourceExcerpt;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/mamoki/ieojuda/domain/recipient/dto/BackupRegisterRequest.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/recipient/dto/BackupRegisterRequest.java
@@ -7,10 +7,12 @@ import jakarta.validation.constraints.NotBlank;
 // "역할 담당자 등록" 화면 - [대체 담당자 등록하기] 버튼으로 여는 폼(이름/이메일만 입력)
 public record BackupRegisterRequest(
         @Schema(description = "대체 담당자 이름", example = "박지훈")
-        @NotBlank(message = "대체 담당자 이름을 입력해 주세요.") String name,
+        @NotBlank(message = "대체 담당자 이름을 입력해 주세요.")
+        @jakarta.validation.constraints.Size(max = 100, message = "대체 담당자 이름은 100자 이하여야 합니다.") String name,
 
         @Schema(description = "대체 담당자 이메일", example = "backup@example.com")
         @NotBlank(message = "대체 담당자 이메일을 입력해 주세요.")
-        @Email(message = "이메일 형식이 올바르지 않습니다.") String email
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        @jakarta.validation.constraints.Size(max = 255, message = "대체 담당자 이메일은 255자 이하여야 합니다.") String email
 ) {
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/recipient/dto/RecipientRegisterRequest.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/recipient/dto/RecipientRegisterRequest.java
@@ -12,11 +12,13 @@ public record RecipientRegisterRequest(
         @NotNull(message = "항목을 선택해 주세요.") Long itemId,
 
         @Schema(description = "담당자 이름", example = "김민수")
-        @NotBlank(message = "담당자 이름을 입력해 주세요.") String name,
+        @NotBlank(message = "담당자 이름을 입력해 주세요.")
+        @jakarta.validation.constraints.Size(max = 100, message = "담당자 이름은 100자 이하여야 합니다.") String name,
 
         @Schema(description = "담당자 이메일", example = "recipient@example.com")
         @NotBlank(message = "담당자 이메일을 입력해 주세요.")
-        @Email(message = "이메일 형식이 올바르지 않습니다.") String email,
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        @jakarta.validation.constraints.Size(max = 255, message = "담당자 이메일은 255자 이하여야 합니다.") String email,
 
         @Schema(description = "최대 단계 대기 시간(시간 단위, 7/14/21일에 대응)", example = "168", allowableValues = {"168", "336", "504"})
         @NotNull(message = "대기 기간을 선택해 주세요.") Integer maxWaitHours,

--- a/src/main/java/com/mamoki/ieojuda/domain/recipient/dto/RecipientUpdateRequest.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/recipient/dto/RecipientUpdateRequest.java
@@ -7,10 +7,12 @@ import jakarta.validation.constraints.NotBlank;
 // "담당자 수정" 화면 - 이름/이메일 수정
 public record RecipientUpdateRequest(
         @Schema(description = "담당자 이름", example = "김민수")
-        @NotBlank(message = "담당자 이름을 입력해 주세요.") String name,
+        @NotBlank(message = "담당자 이름을 입력해 주세요.")
+        @jakarta.validation.constraints.Size(max = 100, message = "담당자 이름은 100자 이하여야 합니다.") String name,
 
         @Schema(description = "담당자 이메일", example = "recipient@example.com")
         @NotBlank(message = "담당자 이메일을 입력해 주세요.")
-        @Email(message = "이메일 형식이 올바르지 않습니다.") String email
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        @jakarta.validation.constraints.Size(max = 255, message = "담당자 이메일은 255자 이하여야 합니다.") String email
 ) {
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/recipient/entity/Recipient.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/recipient/entity/Recipient.java
@@ -75,7 +75,7 @@ public class Recipient {
     private Recipient backupFor;
 
     // "역할 수락 이메일" 화면 - 담당자가 수락/거절 시 남기는 문의 사항 (선택 입력)
-    @Column(name = "inquiry", columnDefinition = "TEXT")
+    @Column(name = "inquiry", length = 1000)
     private String inquiry;
 
     // 담당자 등록 시점 - 역할명, 담당자 이름, 이메일, 공개 범주, 최대 단계 대기 시간, 대체 담당자 입력

--- a/src/main/java/com/mamoki/ieojuda/domain/releasecase/dto/ObjectionRequest.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/releasecase/dto/ObjectionRequest.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.NotBlank;
 // "무언가 잘못됐다면?" 카드 - 이의 제기 사유 입력
 public record ObjectionRequest(
         @Schema(description = "이의 제기 사유", example = "본인이 살아있는데 사망으로 잘못 확인되었습니다.")
-        @NotBlank(message = "이의 제기 사유를 입력해 주세요.") String reason
+        @NotBlank(message = "이의 제기 사유를 입력해 주세요.")
+        @jakarta.validation.constraints.Size(max = 1000, message = "이의 제기 사유는 1,000자 이하여야 합니다.") String reason
 ) {
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/releasecase/entity/Objection.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/releasecase/entity/Objection.java
@@ -36,7 +36,7 @@ public class Objection {
     @Column(name = "raised_at")
     private LocalDateTime raisedAt;
 
-    @Column(name = "reason", columnDefinition = "TEXT")
+    @Column(name = "reason", length = 1000)
     private String reason;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/mamoki/ieojuda/global/exception/ErrorCode.java
+++ b/src/main/java/com/mamoki/ieojuda/global/exception/ErrorCode.java
@@ -7,6 +7,7 @@ public enum ErrorCode {
 
     // 요청 값 검증 예외 (400) -> @Valid 검증 실패, JSON 파싱 실패, 파라미터 타입 불일치 등
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "INVALID_INPUT", "입력값이 올바르지 않습니다."),
+    PAYLOAD_TOO_LARGE(HttpStatus.PAYLOAD_TOO_LARGE, "PAYLOAD_TOO_LARGE", "업로드 파일 또는 요청 크기가 허용 범위를 초과했습니다."),
 
     // 회원가입 / 로그인 관련 예외 (400)
     PASSWORD_CONFIRMATION_MISMATCH(HttpStatus.BAD_REQUEST, "PASSWORD_CONFIRMATION_MISMATCH", "비밀번호와 비밀번호 확인이 일치하지 않습니다."),

--- a/src/main/java/com/mamoki/ieojuda/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/mamoki/ieojuda/global/exception/GlobalExceptionHandler.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 @Slf4j
 @RestControllerAdvice // 컨트롤러에 대해 전역적으로 예외 처리하기 위해 사용하는 어노테이션
@@ -47,6 +48,14 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(ErrorCode.INVALID_INPUT.getHttpStatus())
                 .body(RsData.fail(ErrorCode.INVALID_INPUT, "요청 파라미터 '" + exception.getName() + "' 값이 올바르지 않습니다."));
+    }
+
+    // multipart 파일 또는 요청 전체 크기 초과 (413)
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<RsData<Void>> handle(MaxUploadSizeExceededException exception) {
+        return ResponseEntity
+                .status(ErrorCode.PAYLOAD_TOO_LARGE.getHttpStatus())
+                .body(RsData.fail(ErrorCode.PAYLOAD_TOO_LARGE));
     }
 
     // 인증 관련 예외 처리 (401)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -26,9 +26,9 @@ spring.mail.password=${MAIL_PASSWORD}
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
 
-#공식 증빙 자료 제출 - 파일 최대 10MB (스펙상 제한과 동일하게 서버 단에서도 넉넉히 잡음)
-spring.servlet.multipart.max-file-size=10MB
-spring.servlet.multipart.max-request-size=10MB
+# 공식 증빙 자료 제출 - 파일당 25MB, 요청 전체 30MB
+spring.servlet.multipart.max-file-size=25MB
+spring.servlet.multipart.max-request-size=30MB
 
 #암호화 증빙 저장소(S3) 설정 - EC2 배포 전까지 로컬 자격증명 사용
 aws.s3.bucket=${AWS_S3_BUCKET}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -29,6 +29,7 @@ spring.mail.properties.mail.smtp.starttls.enable=true
 # 공식 증빙 자료 제출 - 파일당 25MB, 요청 전체 30MB
 spring.servlet.multipart.max-file-size=25MB
 spring.servlet.multipart.max-request-size=30MB
+server.tomcat.max-swallow-size=35MB
 
 #암호화 증빙 저장소(S3) 설정 - EC2 배포 전까지 로컬 자격증명 사용
 aws.s3.bucket=${AWS_S3_BUCKET}

--- a/src/test/java/com/mamoki/ieojuda/global/validation/InputLimitHttpIntegrationTest.java
+++ b/src/test/java/com/mamoki/ieojuda/global/validation/InputLimitHttpIntegrationTest.java
@@ -1,0 +1,148 @@
+package com.mamoki.ieojuda.global.validation;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.Flow;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class InputLimitHttpIntegrationTest {
+
+    private static final long MEBIBYTE = 1024L * 1024L;
+
+    @LocalServerPort
+    private int port;
+
+    private final HttpClient httpClient = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(5))
+            .build();
+
+    @Test
+    void oversizedJsonFieldReturnsBadRequestWithStandardErrorCode() throws Exception {
+        String json = """
+                {
+                  "email": "size-limit-test@example.com",
+                  "password": "password1234",
+                  "passwordConfirm": "password1234",
+                  "name": "%s"
+                }
+                """.formatted("가".repeat(101));
+
+        HttpResponse<String> response = httpClient.send(
+                HttpRequest.newBuilder(uri("/auth/signup"))
+                        .header("Content-Type", "application/json")
+                        .POST(HttpRequest.BodyPublishers.ofString(json))
+                        .build(),
+                HttpResponse.BodyHandlers.ofString()
+        );
+
+        assertThat(response.statusCode()).isEqualTo(400);
+        assertThat(response.body()).contains("\"code\":\"INVALID_INPUT\"");
+    }
+
+    @Test
+    void fileLargerThanTwentyFiveMegabytesReturnsPayloadTooLarge() throws Exception {
+        HttpResponse<String> response = sendMultipart(25L * MEBIBYTE + 1, 0);
+
+        assertPayloadTooLarge(response);
+    }
+
+    @Test
+    void multipartRequestLargerThanThirtyMegabytesReturnsPayloadTooLarge() throws Exception {
+        HttpResponse<String> response = sendMultipart(25L * MEBIBYTE, 5L * MEBIBYTE + 1);
+
+        assertPayloadTooLarge(response);
+    }
+
+    private HttpResponse<String> sendMultipart(long fileBytes, long paddingBytes) throws Exception {
+        String boundary = "ieoduda-size-boundary";
+        byte[] fileHeader = ("--" + boundary + "\r\n"
+                + "Content-Disposition: form-data; name=\"file\"; filename=\"proof.pdf\"\r\n"
+                + "Content-Type: application/pdf\r\n\r\n").getBytes(StandardCharsets.UTF_8);
+        byte[] paddingHeader = ("\r\n--" + boundary + "\r\n"
+                + "Content-Disposition: form-data; name=\"padding\"\r\n\r\n").getBytes(StandardCharsets.UTF_8);
+        byte[] closing = ("\r\n--" + boundary + "--\r\n").getBytes(StandardCharsets.UTF_8);
+
+        HttpRequest.BodyPublisher body;
+        long contentLength;
+        if (paddingBytes > 0) {
+            body = HttpRequest.BodyPublishers.concat(
+                    HttpRequest.BodyPublishers.ofByteArray(fileHeader),
+                    zeroBody(fileBytes),
+                    HttpRequest.BodyPublishers.ofByteArray(paddingHeader),
+                    zeroBody(paddingBytes),
+                    HttpRequest.BodyPublishers.ofByteArray(closing)
+            );
+            contentLength = fileHeader.length + fileBytes + paddingHeader.length + paddingBytes + closing.length;
+        } else {
+            body = HttpRequest.BodyPublishers.concat(
+                    HttpRequest.BodyPublishers.ofByteArray(fileHeader),
+                    zeroBody(fileBytes),
+                    HttpRequest.BodyPublishers.ofByteArray(closing)
+            );
+            contentLength = fileHeader.length + fileBytes + closing.length;
+        }
+
+        Flow.Publisher<? extends ByteBuffer> fixedLengthBody = body;
+        HttpRequest request = HttpRequest.newBuilder(uri("/api/confirmer-acceptances/test-token/evidences"))
+                .timeout(Duration.ofSeconds(60))
+                .header("Content-Type", "multipart/form-data; boundary=" + boundary)
+                .POST(HttpRequest.BodyPublishers.fromPublisher(fixedLengthBody, contentLength))
+                .build();
+
+        return httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+    }
+
+    private static HttpRequest.BodyPublisher zeroBody(long length) {
+        return HttpRequest.BodyPublishers.ofInputStream(() -> new ZeroInputStream(length));
+    }
+
+    private void assertPayloadTooLarge(HttpResponse<String> response) {
+        assertThat(response.statusCode()).isEqualTo(413);
+        assertThat(response.body()).contains("\"code\":\"PAYLOAD_TOO_LARGE\"");
+    }
+
+    private URI uri(String path) {
+        return URI.create("http://127.0.0.1:" + port + path);
+    }
+
+    private static final class ZeroInputStream extends InputStream {
+        private long remaining;
+
+        private ZeroInputStream(long remaining) {
+            this.remaining = remaining;
+        }
+
+        @Override
+        public int read() {
+            if (remaining == 0) {
+                return -1;
+            }
+            remaining--;
+            return 0;
+        }
+
+        @Override
+        public int read(byte[] bytes, int offset, int length) throws IOException {
+            if (remaining == 0) {
+                return -1;
+            }
+            int count = (int) Math.min(length, remaining);
+            java.util.Arrays.fill(bytes, offset, offset + count, (byte) 0);
+            remaining -= count;
+            return count;
+        }
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/global/validation/InputSizeConstraintTest.java
+++ b/src/test/java/com/mamoki/ieojuda/global/validation/InputSizeConstraintTest.java
@@ -1,0 +1,164 @@
+package com.mamoki.ieojuda.global.validation;
+
+import com.mamoki.ieojuda.domain.account.dto.LoginRequest;
+import com.mamoki.ieojuda.domain.account.dto.RefreshRequest;
+import com.mamoki.ieojuda.domain.account.dto.SignupRequest;
+import com.mamoki.ieojuda.domain.account.dto.UserUpdateRequest;
+import com.mamoki.ieojuda.domain.confirmer.dto.ConfirmerDecisionRequest;
+import com.mamoki.ieojuda.domain.confirmer.dto.ConfirmerRegisterRequest;
+import com.mamoki.ieojuda.domain.confirmer.dto.ConfirmerUpdateRequest;
+import com.mamoki.ieojuda.domain.confirmer.dto.DisputeContactRegisterRequest;
+import com.mamoki.ieojuda.domain.confirmer.entity.Confirmer;
+import com.mamoki.ieojuda.domain.evidence.entity.Evidence;
+import com.mamoki.ieojuda.domain.evidence.service.EvidenceSubmitService;
+import com.mamoki.ieojuda.domain.partner.dto.PartnerReviewDecisionRequest;
+import com.mamoki.ieojuda.domain.plan.dto.ItemUpdateRequest;
+import com.mamoki.ieojuda.domain.plan.dto.SelfWarningEmailRequest;
+import com.mamoki.ieojuda.domain.plan.entity.Item;
+import com.mamoki.ieojuda.domain.recipient.dto.BackupRegisterRequest;
+import com.mamoki.ieojuda.domain.recipient.dto.RecipientInviteDecisionRequest;
+import com.mamoki.ieojuda.domain.recipient.dto.RecipientRegisterRequest;
+import com.mamoki.ieojuda.domain.recipient.dto.RecipientUpdateRequest;
+import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
+import com.mamoki.ieojuda.domain.releasecase.dto.ObjectionRequest;
+import com.mamoki.ieojuda.domain.releasecase.entity.Objection;
+import com.mamoki.ieojuda.global.exception.GlobalExceptionHandler;
+import jakarta.persistence.Column;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.constraints.Size;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import java.util.Map;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InputSizeConstraintTest {
+
+    private static final Map<Class<?>, Map<String, Integer>> EXPECTED_MAX_LENGTHS = Map.ofEntries(
+            Map.entry(LoginRequest.class, Map.of("email", 255, "password", 128)),
+            Map.entry(RefreshRequest.class, Map.of("refreshToken", 255)),
+            Map.entry(SignupRequest.class, Map.of("email", 255, "password", 128, "passwordConfirm", 128, "name", 100)),
+            Map.entry(UserUpdateRequest.class, Map.of("email", 255, "name", 100)),
+            Map.entry(ConfirmerRegisterRequest.class, Map.of("name", 100, "email", 255)),
+            Map.entry(ConfirmerUpdateRequest.class, Map.of("name", 100, "email", 255)),
+            Map.entry(DisputeContactRegisterRequest.class, Map.of("name", 100, "email", 255)),
+            Map.entry(ConfirmerDecisionRequest.class, Map.of("inquiry", 1000)),
+            Map.entry(PartnerReviewDecisionRequest.class, Map.of("failureReason", 1000)),
+            Map.entry(ItemUpdateRequest.class, Map.of(
+                    "targetName", 100,
+                    "locationType", 100,
+                    "action", 2000,
+                    "title", 200,
+                    "content", 2000,
+                    "precondition", 2000,
+                    "disclosureScope", 30,
+                    "actionType", 30
+            )),
+            Map.entry(SelfWarningEmailRequest.class, Map.of("email", 255)),
+            Map.entry(BackupRegisterRequest.class, Map.of("name", 100, "email", 255)),
+            Map.entry(RecipientRegisterRequest.class, Map.of("name", 100, "email", 255)),
+            Map.entry(RecipientUpdateRequest.class, Map.of("name", 100, "email", 255)),
+            Map.entry(RecipientInviteDecisionRequest.class, Map.of("inquiry", 1000)),
+            Map.entry(ObjectionRequest.class, Map.of("reason", 1000))
+    );
+
+    private static final Map<Class<?>, Map<String, Integer>> EXPECTED_COLUMN_LENGTHS = Map.of(
+            Item.class, Map.of(
+                    "targetName", 100, "locationType", 100, "action", 2000, "title", 200,
+                    "content", 2000, "precondition", 2000, "sourceExcerpt", 2000
+            ),
+            Confirmer.class, Map.of("inquiry", 1000),
+            Recipient.class, Map.of("inquiry", 1000),
+            Objection.class, Map.of("reason", 1000),
+            Evidence.class, Map.of("failureReason", 1000),
+            com.mamoki.ieojuda.domain.account.entity.User.class, Map.of("name", 100)
+    );
+
+    @Test
+    void requestDtoStringLimitsMatchTheInputContract() {
+        EXPECTED_MAX_LENGTHS.forEach((type, fields) -> fields.forEach((field, expectedMax) -> {
+            Size size;
+            try {
+                size = type.getDeclaredField(field).getAnnotation(Size.class);
+            } catch (NoSuchFieldException exception) {
+                throw new AssertionError(type.getSimpleName() + "." + field + " not found", exception);
+            }
+
+            assertThat(size)
+                    .as("%s.%s must declare @Size", type.getSimpleName(), field)
+                    .isNotNull();
+            assertThat(size.max())
+                    .as("%s.%s max length", type.getSimpleName(), field)
+                    .isEqualTo(expectedMax);
+        }));
+    }
+
+    @Test
+    void databaseColumnsMatchTheDtoLimits() {
+        EXPECTED_COLUMN_LENGTHS.forEach((type, fields) -> fields.forEach((field, expectedLength) -> {
+            Column column;
+            try {
+                column = type.getDeclaredField(field).getAnnotation(Column.class);
+            } catch (NoSuchFieldException exception) {
+                throw new AssertionError(type.getSimpleName() + "." + field + " not found", exception);
+            }
+            assertThat(column.length())
+                    .as("%s.%s database length", type.getSimpleName(), field)
+                    .isEqualTo(expectedLength);
+        }));
+    }
+
+    @Test
+    void itemAndObjectionBoundaryValuesAreAcceptedAndOverflowValuesAreRejected() {
+        Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+        ItemUpdateRequest validItem = new ItemUpdateRequest(
+                "x".repeat(100), "x".repeat(100), "x".repeat(2000),
+                "x".repeat(200), "x".repeat(2000), "x".repeat(2000), "PRIVATE", "OTHER"
+        );
+        ItemUpdateRequest oversizedItem = new ItemUpdateRequest(
+                "x".repeat(101), "x".repeat(101), "x".repeat(2001),
+                "x".repeat(201), "x".repeat(2001), "x".repeat(2001), "PRIVATE", "OTHER"
+        );
+
+        assertThat(validator.validate(validItem)).isEmpty();
+        assertThat(validator.validate(oversizedItem)).hasSize(6);
+        assertThat(validator.validate(new ObjectionRequest("x".repeat(1000)))).isEmpty();
+        assertThat(validator.validate(new ObjectionRequest("x".repeat(1001)))).hasSize(1);
+    }
+
+    @Test
+    void multipartLimitsAreTwentyFiveAndThirtyMegabytes() throws IOException {
+        Properties properties = new Properties();
+        try (InputStream input = getClass().getResourceAsStream("/application.properties")) {
+            assertThat(input).isNotNull();
+            properties.load(input);
+        }
+
+        assertThat(properties.getProperty("spring.servlet.multipart.max-file-size")).isEqualTo("25MB");
+        assertThat(properties.getProperty("spring.servlet.multipart.max-request-size")).isEqualTo("30MB");
+    }
+
+    @Test
+    void evidenceServiceFileLimitMatchesTheTwentyFiveMegabyteServletLimit() throws Exception {
+        var maxFileSize = EvidenceSubmitService.class.getDeclaredField("MAX_FILE_SIZE");
+        maxFileSize.setAccessible(true);
+
+        assertThat(maxFileSize.getLong(null)).isEqualTo(25L * 1024 * 1024);
+    }
+
+    @Test
+    void maxUploadSizeExceptionHasDedicatedHandler() {
+        var response = new GlobalExceptionHandler()
+                .handle(new MaxUploadSizeExceededException(25L * 1024 * 1024));
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.PAYLOAD_TOO_LARGE);
+    }
+
+}

--- a/src/test/java/com/mamoki/ieojuda/global/validation/InputSizeConstraintTest.java
+++ b/src/test/java/com/mamoki/ieojuda/global/validation/InputSizeConstraintTest.java
@@ -22,6 +22,8 @@ import com.mamoki.ieojuda.domain.recipient.dto.RecipientUpdateRequest;
 import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
 import com.mamoki.ieojuda.domain.releasecase.dto.ObjectionRequest;
 import com.mamoki.ieojuda.domain.releasecase.entity.Objection;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
 import com.mamoki.ieojuda.global.exception.GlobalExceptionHandler;
 import jakarta.persistence.Column;
 import jakarta.validation.Validation;
@@ -29,6 +31,8 @@ import jakarta.validation.Validator;
 import jakarta.validation.constraints.Size;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 import java.io.IOException;
@@ -38,6 +42,8 @@ import java.util.Map;
 import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class InputSizeConstraintTest {
 
@@ -143,6 +149,7 @@ class InputSizeConstraintTest {
 
         assertThat(properties.getProperty("spring.servlet.multipart.max-file-size")).isEqualTo("25MB");
         assertThat(properties.getProperty("spring.servlet.multipart.max-request-size")).isEqualTo("30MB");
+        assertThat(properties.getProperty("server.tomcat.max-swallow-size")).isEqualTo("35MB");
     }
 
     @Test
@@ -151,6 +158,22 @@ class InputSizeConstraintTest {
         maxFileSize.setAccessible(true);
 
         assertThat(maxFileSize.getLong(null)).isEqualTo(25L * 1024 * 1024);
+    }
+
+    @Test
+    void evidenceFilenameMatchesTheDatabaseColumnLimit() {
+        EvidenceSubmitService service = new EvidenceSubmitService(null, null, null, null);
+        MockMultipartFile valid = new MockMultipartFile(
+                "file", "x".repeat(255), "application/pdf", new byte[]{1});
+        MockMultipartFile oversized = new MockMultipartFile(
+                "file", "x".repeat(256), "application/pdf", new byte[]{1});
+
+        assertThatCode(() -> ReflectionTestUtils.invokeMethod(service, "validateFile", valid))
+                .doesNotThrowAnyException();
+        assertThatThrownBy(() -> ReflectionTestUtils.invokeMethod(service, "validateFile", oversized))
+                .isInstanceOfSatisfying(CustomException.class,
+                        exception -> assertThat(exception.getErrorCode())
+                                .isEqualTo(ErrorCode.EVIDENCE_SUBMISSION_INVALID));
     }
 
     @Test


### PR DESCRIPTION
## 연관 Issue

Closes #58

## 요약

사용자 입력 문자열과 DB 컬럼의 최대 길이를 맞추고, multipart 업로드 제한 및 400/413 표준 오류 응답을 적용했습니다.

## 작업 내용
- 사용자 입력 DTO에 이름·이메일·비밀번호·제목·본문·문의/이의/반려 사유 등의 최대 길이 검증 추가
- User, Item, Confirmer, Recipient, Objection, Evidence 엔티티 컬럼 길이를 입력 계약과 일치시킴
- 파일당 25MB, 요청 전체 30MB 및 Tomcat 35MB bounded swallow 설정 적용
- 증빙 파일명 255자 제한과 서비스 내부 25MB 제한 적용
- `MaxUploadSizeExceededException`을 `PAYLOAD_TOO_LARGE` HTTP 413으로 표준화
- 실제 embedded server HTTP 요청으로 JSON 400, 파일 25MB 초과 413, multipart 요청 30MB 초과 413 검증
- PostgreSQL 16과 Java 21 Docker 환경에서 전체 `clean test` 검증

## 범위
### 포함:
- 일반 입력 문자열·문의·이의·반려 사유·항목 필드 길이 제한
- DTO와 DB 컬럼 길이 정합성
- multipart 파일당 25MB·요청 전체 30MB 제한
- 초과 입력의 HTTP 400/413 응답

### 제외:
- AI 대화 1회·전체 이력 제한, 응답 토큰, 외부 API 타임아웃 및 응답 스키마 검증: #52에서 처리
- 악성 파일 내용 검사
- 명시적 운영 DB 마이그레이션 체계

## 스크린샷 / 미리 보기

해당 없음