### PR TITLE
[Refactor/#42]: 스냅샷 봉인 및 회귀 테스트 추가

### DIFF
--- a/src/main/java/com/mamoki/ieojuda/domain/confirmer/service/DeathReportService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/confirmer/service/DeathReportService.java
@@ -5,9 +5,11 @@ import com.mamoki.ieojuda.domain.confirmer.dto.DeathReportResponse;
 import com.mamoki.ieojuda.domain.confirmer.entity.Confirmer;
 import com.mamoki.ieojuda.domain.confirmer.entity.ReportStatus;
 import com.mamoki.ieojuda.domain.confirmer.repository.ConfirmerRepository;
+import com.mamoki.ieojuda.domain.plan.dto.PlanSnapshotDto;
 import com.mamoki.ieojuda.domain.plan.entity.Plan;
 import com.mamoki.ieojuda.domain.plan.entity.PlanVersion;
 import com.mamoki.ieojuda.domain.plan.repository.PlanVersionRepository;
+import com.mamoki.ieojuda.domain.plan.service.PlanSnapshotService;
 import com.mamoki.ieojuda.domain.recipient.entity.AcceptanceStatus;
 import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCase;
 import com.mamoki.ieojuda.domain.releasecase.repository.ReleaseCaseRepository;
@@ -33,6 +35,7 @@ public class DeathReportService {
     private final ConfirmerRepository confirmerRepository;
     private final ReleaseCaseRepository releaseCaseRepository;
     private final PlanVersionRepository planVersionRepository;
+    private final PlanSnapshotService planSnapshotService;
 
     @Transactional
     public DeathReportResponse report(String plainToken, DeathReportRequest request) {
@@ -80,8 +83,14 @@ public class DeathReportService {
             throw new CustomException(ErrorCode.ACTIVE_RELEASE_CASE_EXISTS);
         }
 
+        int nextVersionNum = (int) planVersionRepository.countByPlan_PlanId(plan.getPlanId()) + 1;
+        PlanSnapshotDto snapshot = planSnapshotService.buildSnapshot(plan);
+        String snapshotJson = planSnapshotService.serialize(snapshot);
+        String snapshotHash = planSnapshotService.hash(snapshotJson);
+
         PlanVersion planVersion = planVersionRepository.save(
-                PlanVersion.builder().plan(plan).versionNum(1).snapshotData(null).build());
+                PlanVersion.builder().plan(plan).versionNum(nextVersionNum).snapshotData(snapshotJson).build());
+        planVersion.seal(snapshotHash);
 
         ReleaseCase releaseCase = releaseCaseRepository.save(
                 ReleaseCase.builder().plan(plan).planVersion(planVersion).build());

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/dto/PlanSnapshotDto.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/dto/PlanSnapshotDto.java
@@ -1,0 +1,100 @@
+package com.mamoki.ieojuda.domain.plan.dto;
+
+import com.mamoki.ieojuda.domain.plan.entity.DisclosureScope;
+import com.mamoki.ieojuda.domain.plan.entity.Item;
+import com.mamoki.ieojuda.domain.plan.entity.ItemActionType;
+import com.mamoki.ieojuda.domain.plan.entity.ItemStatus;
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
+import com.mamoki.ieojuda.domain.recipient.entity.RoleType;
+import com.mamoki.ieojuda.domain.stage.entity.Dependency;
+
+import java.util.List;
+
+// 사망 신고가 확정되어 사건(ReleaseCase)이 열리는 순간의 계획 상태를 그대로 얼려 둔 스냅샷.
+// 이 시점 이후 사용자가 계획을 수정하더라도, 이미 열린 사건의 검토·발송 로직은 이 스냅샷만 읽는다(issue #42).
+public record PlanSnapshotDto(
+        Long planId,
+        Integer waitingDays,
+        List<ItemSnapshot> items,
+        List<RecipientSnapshot> recipients,
+        List<DependencySnapshot> dependencies
+) {
+
+    public record ItemSnapshot(
+            Long itemId,
+            Long recipientId,
+            String targetName,
+            String locationType,
+            String action,
+            String title,
+            String content,
+            String precondition,
+            DisclosureScope disclosureScope,
+            String sourceExcerpt,
+            ItemStatus status,
+            Integer sortOrder,
+            ItemActionType actionType
+    ) {
+        public static ItemSnapshot from(Item item) {
+            return new ItemSnapshot(
+                    item.getItemId(),
+                    item.getRecipient() != null ? item.getRecipient().getAssigneeId() : null,
+                    item.getTargetName(),
+                    item.getLocationType(),
+                    item.getAction(),
+                    item.getTitle(),
+                    item.getContent(),
+                    item.getPrecondition(),
+                    item.getDisclosureScope(),
+                    item.getSourceExcerpt(),
+                    item.getStatus(),
+                    item.getSortOrder(),
+                    item.getActionType()
+            );
+        }
+    }
+
+    public record RecipientSnapshot(
+            Long assigneeId,
+            String name,
+            String email,
+            RoleType roleType,
+            Boolean isBackup,
+            DisclosureScope disclosureScope,
+            Integer maxWaitHours,
+            Long backupForId
+    ) {
+        public static RecipientSnapshot from(Recipient recipient) {
+            return new RecipientSnapshot(
+                    recipient.getAssigneeId(),
+                    recipient.getName(),
+                    recipient.getEmail(),
+                    recipient.getRoleType(),
+                    recipient.getIsBackup(),
+                    recipient.getDisclosureScope(),
+                    recipient.getMaxWaitHours(),
+                    recipient.getBackupFor() != null ? recipient.getBackupFor().getAssigneeId() : null
+            );
+        }
+    }
+
+    public record DependencySnapshot(
+            Long itemId,
+            Long dependsOnItemId
+    ) {
+        public static DependencySnapshot from(Dependency dependency) {
+            return new DependencySnapshot(dependency.getItem().getItemId(), dependency.getDependsOnItem().getItemId());
+        }
+    }
+
+    public static PlanSnapshotDto of(Plan plan, List<Item> items, List<Recipient> recipients, List<Dependency> dependencies) {
+        return new PlanSnapshotDto(
+                plan.getPlanId(),
+                plan.getWaitingDays(),
+                items.stream().map(ItemSnapshot::from).toList(),
+                recipients.stream().map(RecipientSnapshot::from).toList(),
+                dependencies.stream().map(DependencySnapshot::from).toList()
+        );
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/entity/PlanVersion.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/entity/PlanVersion.java
@@ -7,6 +7,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Table(name = "plan_versions")
 @Getter
@@ -31,6 +33,13 @@ public class PlanVersion extends BaseCreatedAtEntity {
     @Column(name = "is_sealed")
     private Boolean isSealed;
 
+    // 스냅샷 원문(snapshotData)의 SHA-256 해시 - 이후 스냅샷이 변조 없이 그대로인지 검증하는 용도
+    @Column(name = "snapshot_hash", length = 64)
+    private String snapshotHash;
+
+    @Column(name = "sealed_at")
+    private LocalDateTime sealedAt;
+
     @Builder
     public PlanVersion(Plan plan, Integer versionNum, String snapshotData) {
         this.plan = plan;
@@ -39,7 +48,10 @@ public class PlanVersion extends BaseCreatedAtEntity {
         this.isSealed = false;
     }
 
-    public void seal() {
+    // 스냅샷 데이터를 확정하고, 이후 review·dispatch 파이프라인이 이 값을 신뢰할 수 있도록 봉인한다
+    public void seal(String snapshotHash) {
+        this.snapshotHash = snapshotHash;
+        this.sealedAt = LocalDateTime.now();
         this.isSealed = true;
     }
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/repository/PlanVersionRepository.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/repository/PlanVersionRepository.java
@@ -4,4 +4,7 @@ import com.mamoki.ieojuda.domain.plan.entity.PlanVersion;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PlanVersionRepository extends JpaRepository<PlanVersion, Long> {
+
+    // 사망 신고 접수 시 다음 버전 번호를 매기기 위한 카운트
+    long countByPlan_PlanId(Long planId);
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/service/PlanSnapshotService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/service/PlanSnapshotService.java
@@ -1,0 +1,60 @@
+package com.mamoki.ieojuda.domain.plan.service;
+
+import tools.jackson.databind.ObjectMapper;
+import com.mamoki.ieojuda.domain.plan.dto.PlanSnapshotDto;
+import com.mamoki.ieojuda.domain.plan.entity.Item;
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.plan.repository.ItemRepository;
+import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
+import com.mamoki.ieojuda.domain.recipient.repository.RecipientRepository;
+import com.mamoki.ieojuda.domain.stage.entity.Dependency;
+import com.mamoki.ieojuda.domain.stage.repository.DependencyRepository;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import com.mamoki.ieojuda.global.storage.IntegrityHasher;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+// 사건(ReleaseCase)이 열리는 시점의 계획 상태를 얼려 두는 스냅샷 생성/직렬화/역직렬화 담당(issue #42).
+// 스냅샷이 봉인된 이후에는 어떤 서비스도 이 스냅샷을 다시 만들지 않고 그대로 읽기만 해야 한다.
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PlanSnapshotService {
+
+    private final ItemRepository itemRepository;
+    private final RecipientRepository recipientRepository;
+    private final DependencyRepository dependencyRepository;
+    private final ObjectMapper objectMapper;
+
+    public PlanSnapshotDto buildSnapshot(Plan plan) {
+        List<Item> items = itemRepository.findByLifeArea_Plan_PlanIdOrderByItemIdAsc(plan.getPlanId());
+        List<Recipient> recipients = recipientRepository.findByPlan_PlanId(plan.getPlanId());
+        List<Dependency> dependencies = dependencyRepository.findByPlan_PlanId(plan.getPlanId());
+        return PlanSnapshotDto.of(plan, items, recipients, dependencies);
+    }
+
+    public String serialize(PlanSnapshotDto snapshot) {
+        try {
+            return objectMapper.writeValueAsString(snapshot);
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    public PlanSnapshotDto deserialize(String snapshotJson) {
+        try {
+            return objectMapper.readValue(snapshotJson, PlanSnapshotDto.class);
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    public String hash(String snapshotJson) {
+        return IntegrityHasher.sha256Hex(snapshotJson.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/releasecase/scheduler/ReleaseCaseScheduler.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/releasecase/scheduler/ReleaseCaseScheduler.java
@@ -1,8 +1,9 @@
 package com.mamoki.ieojuda.domain.releasecase.scheduler;
 
-import com.mamoki.ieojuda.domain.plan.entity.Item;
-import com.mamoki.ieojuda.domain.plan.repository.ItemRepository;
+import com.mamoki.ieojuda.domain.plan.dto.PlanSnapshotDto;
+import com.mamoki.ieojuda.domain.plan.service.PlanSnapshotService;
 import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
+import com.mamoki.ieojuda.domain.recipient.repository.RecipientRepository;
 import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCase;
 import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCaseStatus;
 import com.mamoki.ieojuda.domain.releasecase.repository.ReleaseCaseRepository;
@@ -14,18 +15,21 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.LinkedHashSet;
+import java.util.Comparator;
 import java.util.List;
-import java.util.Set;
+import java.util.Objects;
 
-// 명세서 "사후 인계" 화면 - 대기 기간이 지나면 이의 제기 없이 자동으로 발송 단계에 진입시킨다
+// 명세서 "사후 인계" 화면 - 대기 기간이 지나면 이의 제기 없이 자동으로 발송 단계에 진입시킨다.
+// 발송 대상·순서는 사건 생성 시점에 봉인된 계획 스냅샷(PlanVersion.snapshotData)만 읽는다 - 사건이 열린 뒤
+// 사용자가 계획을 수정하더라도 이미 진행 중인 발송에는 영향을 주지 않기 위함(issue #42).
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class ReleaseCaseScheduler {
 
     private final ReleaseCaseRepository releaseCaseRepository;
-    private final ItemRepository itemRepository;
+    private final RecipientRepository recipientRepository;
+    private final PlanSnapshotService planSnapshotService;
     private final HandoverStageService handoverStageService;
 
     // 10분마다 - 대기기간이 긴(일 단위) 도메인 특성상 촘촘한 주기가 필요하지 않음
@@ -41,21 +45,27 @@ public class ReleaseCaseScheduler {
     }
 
     private void progressCase(ReleaseCase releaseCase) {
-        Long planId = releaseCase.getPlan().getPlanId();
-
         // 실행 순서가 확정 안 된 계획은 발송 순서를 정할 수 없으므로, 확정될 때까지 매 주기 재시도한다
         if (releaseCase.getPlan().getOrderConfirmedAt() == null) {
             log.warn("[ReleaseCase Dispatch Skipped] caseId={} - 실행 순서가 아직 확정되지 않았습니다.", releaseCase.getCaseId());
             return;
         }
 
-        List<Item> items = itemRepository.findByLifeArea_Plan_PlanIdAndRecipientIsNotNullOrderBySortOrderAscItemIdAsc(planId);
-        Set<Recipient> orderedRecipients = new LinkedHashSet<>();
-        for (Item item : items) {
-            orderedRecipients.add(item.getRecipient());
-        }
+        PlanSnapshotDto snapshot = planSnapshotService.deserialize(releaseCase.getPlanVersion().getSnapshotData());
+
+        List<Long> orderedRecipientIds = snapshot.items().stream()
+                .filter(item -> item.recipientId() != null)
+                .sorted(Comparator.comparing(PlanSnapshotDto.ItemSnapshot::sortOrder))
+                .map(PlanSnapshotDto.ItemSnapshot::recipientId)
+                .distinct()
+                .toList();
+
+        List<Recipient> orderedRecipients = orderedRecipientIds.stream()
+                .map(id -> recipientRepository.findById(id).orElse(null))
+                .filter(Objects::nonNull)
+                .toList();
 
         releaseCase.startReleasing();
-        handoverStageService.createStagesAndDispatchFirst(releaseCase, List.copyOf(orderedRecipients));
+        handoverStageService.createStagesAndDispatchFirst(releaseCase, orderedRecipients);
     }
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/stage/repository/DependencyRepository.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/stage/repository/DependencyRepository.java
@@ -1,0 +1,12 @@
+package com.mamoki.ieojuda.domain.stage.repository;
+
+import com.mamoki.ieojuda.domain.stage.entity.Dependency;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface DependencyRepository extends JpaRepository<Dependency, Long> {
+
+    // 계획 스냅샷 생성 시 항목 간 선후행 관계를 함께 봉인하기 위한 조회
+    List<Dependency> findByPlan_PlanId(Long planId);
+}

--- a/src/test/java/com/mamoki/ieojuda/domain/confirmer/service/DeathReportServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/confirmer/service/DeathReportServiceTest.java
@@ -1,0 +1,91 @@
+package com.mamoki.ieojuda.domain.confirmer.service;
+
+import com.mamoki.ieojuda.domain.confirmer.dto.DeathReportRequest;
+import com.mamoki.ieojuda.domain.confirmer.entity.Confirmer;
+import com.mamoki.ieojuda.domain.confirmer.entity.Relationship;
+import com.mamoki.ieojuda.domain.confirmer.entity.ReportStatus;
+import com.mamoki.ieojuda.domain.confirmer.repository.ConfirmerRepository;
+import com.mamoki.ieojuda.domain.plan.dto.PlanSnapshotDto;
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.plan.entity.PlanVersion;
+import com.mamoki.ieojuda.domain.plan.repository.PlanVersionRepository;
+import com.mamoki.ieojuda.domain.plan.service.PlanSnapshotService;
+import com.mamoki.ieojuda.domain.releasecase.repository.ReleaseCaseRepository;
+import com.mamoki.ieojuda.global.email.token.TokenProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+// issue #42 회귀 테스트 - 두 확인자의 신고가 매치되어 사건이 생성될 때, 그 시점의 계획 스냅샷이
+// 실제로 직렬화·해시·봉인되고 버전 번호가 정확히 증가하는지 검증한다.
+class DeathReportServiceTest {
+
+    private ConfirmerRepository confirmerRepository;
+    private ReleaseCaseRepository releaseCaseRepository;
+    private PlanVersionRepository planVersionRepository;
+    private PlanSnapshotService planSnapshotService;
+    private DeathReportService deathReportService;
+
+    @BeforeEach
+    void setUp() {
+        confirmerRepository = mock(ConfirmerRepository.class);
+        releaseCaseRepository = mock(ReleaseCaseRepository.class);
+        planVersionRepository = mock(PlanVersionRepository.class);
+        planSnapshotService = mock(PlanSnapshotService.class);
+        deathReportService = new DeathReportService(
+                confirmerRepository, releaseCaseRepository, planVersionRepository, planSnapshotService);
+    }
+
+    @Test
+    void report_whenSecondConfirmerMatchesFirst_sealsFreshSnapshotWithIncrementedVersion() {
+        Plan plan = mock(Plan.class);
+        when(plan.getPlanId()).thenReturn(1L);
+
+        Confirmer reporting = Confirmer.builder().plan(plan).name("A").relationship(Relationship.FRIEND).email("a@test.com").build();
+        reporting.accept(null);
+        when(confirmerRepository.findByInviteToken(TokenProvider.hashToken("token-a"))).thenReturn(Optional.of(reporting));
+
+        Confirmer sibling = Confirmer.builder().plan(plan).name("B").relationship(Relationship.FRIEND).email("b@test.com").build();
+        sibling.accept(null);
+        sibling.report(LocalDate.of(2026, 8, 15)); // 이미 먼저 신고해서 REPORTED 상태
+        when(confirmerRepository.findByPlan_PlanIdAndConfirmIdNotAndReportStatus(1L, null, ReportStatus.REPORTED))
+                .thenReturn(List.of(sibling));
+
+        // 이 계획에 이미 봉인된 버전이 2개 있었다고 가정 - 새 버전은 3번이어야 한다
+        when(releaseCaseRepository.findFirstByPlan_PlanIdOrderByCaseIdDesc(1L)).thenReturn(Optional.empty());
+        when(planVersionRepository.countByPlan_PlanId(1L)).thenReturn(2L);
+
+        PlanSnapshotDto snapshot = new PlanSnapshotDto(1L, 7, List.of(), List.of(), List.of());
+        when(planSnapshotService.buildSnapshot(plan)).thenReturn(snapshot);
+        when(planSnapshotService.serialize(snapshot)).thenReturn("{\"planId\":1}");
+        when(planSnapshotService.hash("{\"planId\":1}")).thenReturn("deadbeef");
+
+        when(planVersionRepository.save(any(PlanVersion.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(releaseCaseRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        deathReportService.report("token-a", new DeathReportRequest(LocalDate.of(2026, 8, 15)));
+
+        ArgumentCaptor<PlanVersion> versionCaptor = ArgumentCaptor.forClass(PlanVersion.class);
+        verify(planVersionRepository).save(versionCaptor.capture());
+        PlanVersion savedVersion = versionCaptor.getValue();
+
+        assertThat(savedVersion.getVersionNum()).isEqualTo(3);
+        assertThat(savedVersion.getSnapshotData()).isEqualTo("{\"planId\":1}");
+        assertThat(savedVersion.getIsSealed()).isTrue();
+        assertThat(savedVersion.getSnapshotHash()).isEqualTo("deadbeef");
+        assertThat(savedVersion.getSealedAt()).isNotNull();
+
+        assertThat(reporting.getReportStatus()).isEqualTo(ReportStatus.MATCHED);
+        assertThat(sibling.getReportStatus()).isEqualTo(ReportStatus.MATCHED);
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/domain/releasecase/scheduler/ReleaseCaseSchedulerTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/releasecase/scheduler/ReleaseCaseSchedulerTest.java
@@ -1,0 +1,101 @@
+package com.mamoki.ieojuda.domain.releasecase.scheduler;
+
+import com.mamoki.ieojuda.domain.plan.dto.PlanSnapshotDto;
+import com.mamoki.ieojuda.domain.plan.entity.DisclosureScope;
+import com.mamoki.ieojuda.domain.plan.entity.ItemActionType;
+import com.mamoki.ieojuda.domain.plan.entity.ItemStatus;
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.plan.entity.PlanVersion;
+import com.mamoki.ieojuda.domain.plan.service.PlanSnapshotService;
+import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
+import com.mamoki.ieojuda.domain.recipient.repository.RecipientRepository;
+import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCase;
+import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCaseStatus;
+import com.mamoki.ieojuda.domain.releasecase.repository.ReleaseCaseRepository;
+import com.mamoki.ieojuda.domain.stage.service.HandoverStageService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+// issue #42 회귀 테스트 - 사건 생성 후 라이브 계획(항목/담당자)이 바뀌더라도, 스케줄러가 실제로
+// 발송하는 담당자는 사건 생성 시점에 봉인된 스냅샷 안의 값이어야 한다(라이브 테이블은 아예 조회하지 않는다).
+class ReleaseCaseSchedulerTest {
+
+    private ReleaseCaseRepository releaseCaseRepository;
+    private RecipientRepository recipientRepository;
+    private PlanSnapshotService planSnapshotService;
+    private HandoverStageService handoverStageService;
+    private ReleaseCaseScheduler scheduler;
+
+    @BeforeEach
+    void setUp() {
+        releaseCaseRepository = mock(ReleaseCaseRepository.class);
+        recipientRepository = mock(RecipientRepository.class);
+        planSnapshotService = mock(PlanSnapshotService.class);
+        handoverStageService = mock(HandoverStageService.class);
+        scheduler = new ReleaseCaseScheduler(releaseCaseRepository, recipientRepository, planSnapshotService, handoverStageService);
+    }
+
+    @Test
+    void progressExpiredWaitingCases_dispatchesRecipientFromSealedSnapshot_notFromLiveTables() {
+        // 사건 생성 시점에 봉인된 스냅샷: 항목이 recipientId=100번 담당자에게 배정되어 있었다
+        PlanSnapshotDto.ItemSnapshot itemSnapshot = new PlanSnapshotDto.ItemSnapshot(
+                1L, 100L, "target", "loc", "action", "title", "content", "precond",
+                DisclosureScope.FAMILY, "excerpt", ItemStatus.APPROVED, 0, ItemActionType.TRANSFER);
+        PlanSnapshotDto snapshot = new PlanSnapshotDto(1L, 7, List.of(itemSnapshot), List.of(), List.of());
+
+        Plan plan = mock(Plan.class);
+        when(plan.getOrderConfirmedAt()).thenReturn(LocalDateTime.now());
+
+        PlanVersion planVersion = mock(PlanVersion.class);
+        when(planVersion.getSnapshotData()).thenReturn("{\"frozen\":true}");
+
+        ReleaseCase releaseCase = mock(ReleaseCase.class);
+        when(releaseCase.getPlan()).thenReturn(plan);
+        when(releaseCase.getPlanVersion()).thenReturn(planVersion);
+
+        when(releaseCaseRepository.findByStatusAndFrozenFalseAndWaitingEndsAtLessThanEqual(
+                any(ReleaseCaseStatus.class), any(LocalDateTime.class)))
+                .thenReturn(List.of(releaseCase));
+        when(planSnapshotService.deserialize("{\"frozen\":true}")).thenReturn(snapshot);
+
+        Recipient recipientFromSnapshot = mock(Recipient.class);
+        when(recipientRepository.findById(100L)).thenReturn(Optional.of(recipientFromSnapshot));
+
+        scheduler.progressExpiredWaitingCases();
+
+        // 스냅샷에 적힌 담당자(100번)만 조회해서 그대로 인계 대상으로 넘긴다 -
+        // 사건이 열린 뒤 라이브 담당자가 다른 사람으로 재배정됐어도 그 값은 절대 읽지 않는다.
+        verify(recipientRepository).findById(100L);
+        verify(handoverStageService).createStagesAndDispatchFirst(releaseCase, List.of(recipientFromSnapshot));
+        verify(releaseCase).startReleasing();
+    }
+
+    @Test
+    void progressExpiredWaitingCases_skipsCase_whenOrderNotYetConfirmed() {
+        Plan plan = mock(Plan.class);
+        when(plan.getOrderConfirmedAt()).thenReturn(null);
+
+        ReleaseCase releaseCase = mock(ReleaseCase.class);
+        when(releaseCase.getPlan()).thenReturn(plan);
+
+        when(releaseCaseRepository.findByStatusAndFrozenFalseAndWaitingEndsAtLessThanEqual(
+                any(ReleaseCaseStatus.class), any(LocalDateTime.class)))
+                .thenReturn(List.of(releaseCase));
+
+        scheduler.progressExpiredWaitingCases();
+
+        verify(releaseCase, never()).startReleasing();
+        verifyNoInteractions(handoverStageService, planSnapshotService);
+    }
+}


### PR DESCRIPTION
## 연관 Issue
Closes #42

## 요약
사건(ReleaseCase)이 열리는 시점(사망 신고 확정)의 계획 상태를 스냅샷으로 얼려서 봉인하고, 이후 증빙 검토·발송 파이프라인이 라이브 계획 데이터가 아닌 이 봉인된 스냅샷만 읽도록 변경했습니다.

## 작업 내용
- `PlanVersion` 엔티티에 `snapshotHash`, `sealedAt` 필드 추가, `seal()`이 해시를 받아 봉인 시각을 함께 기록하도록 변경
- `PlanSnapshotDto` 신규 작성 - 계획의 항목/담당자/의존성을 담는 canonical 스냅샷 구조
- `PlanSnapshotService` 신규 작성 - 스냅샷 생성(`buildSnapshot`)·직렬화·역직렬화·SHA-256 해싱 담당
- `DeathReportService.createReleaseCase()` - 하드코딩되어 있던 `versionNum(1).snapshotData(null)`을 실제 계획 상태 스냅샷 생성 + 해시 봉인으로 교체, 버전 번호도 `PlanVersionRepository.countByPlan_PlanId + 1`로 정확히 증가하도록 수정
- `ReleaseCaseScheduler.progressCase()` - 발송 대상/순서를 정할 때 더 이상 `Item`/`Recipient` 라이브 테이블을 재조회하지 않고, 사건 생성 시점에 봉인된 스냅샷만 읽도록 변경
- `DependencyRepository` 신규 추가, `PlanVersionRepository.countByPlan_PlanId` 쿼리 메서드 추가
- `DeathReportServiceTest` 신규 작성 - 두 확인자 신고 매치 시 스냅샷이 실제로 직렬화·해시·봉인되고 버전 번호가 정확히 증가하는지 검증
- `ReleaseCaseSchedulerTest` 신규 작성 - 사건 생성 후 라이브 담당자가 바뀌어도 스케줄러가 봉인된 스냅샷 안의 담당자만 조회해서 인계하는지 검증

## 범위
### 포함:
- 사망 신고 확정 시점의 스냅샷 생성·해시·봉인
- 스케줄러의 발송 대상 조회를 스냅샷 기반으로 전환
- 사건 생성 후 원본 변경이 스냅샷/발송 데이터에 영향 없음을 증명하는 회귀 테스트
### 제외:
- 스냅샷 조회용 API(작성자/운영자가 봉인된 스냅샷 내용을 직접 볼 수 있는 엔드포인트)
- "패키지 생성 경로"(담당자별 사후 패키지 화면) - 아직 서비스/컨트롤러가 존재하지 않는 미구현 기능이라 이번 범위에서 다룰 대상이 없었음
- 계획 편집 UI 변경, 장기 보관 정책 수립

## 스크린샷 / 미리 보기
백엔드 API 변경으로 스크린샷은 없습니다. 검증 내역:
- 사망 신고 확정 직후 `plan_versions.is_sealed=true`, `snapshot_hash` 채워짐 확인
- 이후 항목 제목을 라이브로 수정해도 `snapshot_data` 안의 제목은 그대로 유지됨을 DB에서 직접 확인
- `DeathReportServiceTest`, `ReleaseCaseSchedulerTest` 신규 회귀 테스트 통과, 전체 테스트 스위트(`./gradlew test`) 정상 통과