### PR TITLE
[Fix/#48]: 계정 이메일 변경 및 삭제 안전 정책 적용

### DIFF
--- a/src/main/java/com/mamoki/ieojuda/domain/account/service/UserService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/account/service/UserService.java
@@ -5,16 +5,33 @@ import com.mamoki.ieojuda.domain.account.dto.UserResponse;
 import com.mamoki.ieojuda.domain.account.dto.UserUpdateRequest;
 import com.mamoki.ieojuda.domain.account.entity.User;
 import com.mamoki.ieojuda.domain.account.repository.UserRepository;
+import com.mamoki.ieojuda.domain.confirmer.entity.Confirmer;
+import com.mamoki.ieojuda.domain.confirmer.entity.DisputeContact;
+import com.mamoki.ieojuda.domain.confirmer.repository.ConfirmerRepository;
 import com.mamoki.ieojuda.domain.confirmer.repository.DisputeContactRepository;
+import com.mamoki.ieojuda.domain.evidence.entity.Evidence;
+import com.mamoki.ieojuda.domain.evidence.repository.EvidenceRepository;
+import com.mamoki.ieojuda.domain.audit.repository.EmailLogRepository;
+import com.mamoki.ieojuda.domain.handoffcheck.repository.HandoffCheckRepository;
+import com.mamoki.ieojuda.domain.handoffcheck.repository.HandoffCheckResponseRepository;
 import com.mamoki.ieojuda.domain.plan.entity.Plan;
 import com.mamoki.ieojuda.domain.plan.repository.ConversationRepository;
 import com.mamoki.ieojuda.domain.plan.repository.ItemRepository;
 import com.mamoki.ieojuda.domain.plan.repository.LifeAreaMessageRepository;
 import com.mamoki.ieojuda.domain.plan.repository.LifeAreaRepository;
 import com.mamoki.ieojuda.domain.plan.repository.PlanRepository;
+import com.mamoki.ieojuda.domain.plan.repository.PlanVersionRepository;
+import com.mamoki.ieojuda.domain.postaccess.repository.PackageIssueRepository;
+import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
 import com.mamoki.ieojuda.domain.recipient.repository.RecipientRepository;
+import com.mamoki.ieojuda.domain.releasecase.repository.ObjectionRepository;
+import com.mamoki.ieojuda.domain.releasecase.repository.ReleaseCaseRepository;
+import com.mamoki.ieojuda.domain.releasecase.service.ReleaseCaseGuardService;
+import com.mamoki.ieojuda.domain.stage.repository.DependencyRepository;
+import com.mamoki.ieojuda.domain.stage.repository.HandoverStageRepository;
 import com.mamoki.ieojuda.global.exception.CustomException;
 import com.mamoki.ieojuda.global.exception.ErrorCode;
+import com.mamoki.ieojuda.global.storage.EvidenceStorageClient;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,18 +50,44 @@ public class UserService {
     private final ItemRepository itemRepository;
     private final RecipientRepository recipientRepository;
     private final DisputeContactRepository disputeContactRepository;
+    private final ConfirmerRepository confirmerRepository;
+    private final ReleaseCaseRepository releaseCaseRepository;
+    private final PlanVersionRepository planVersionRepository;
+    private final EvidenceRepository evidenceRepository;
+    private final EmailLogRepository emailLogRepository;
+    private final HandoverStageRepository handoverStageRepository;
+    private final ObjectionRepository objectionRepository;
+    private final HandoffCheckRepository handoffCheckRepository;
+    private final HandoffCheckResponseRepository handoffCheckResponseRepository;
+    private final PackageIssueRepository packageIssueRepository;
+    private final DependencyRepository dependencyRepository;
+    private final EvidenceStorageClient evidenceStorageClient;
+    private final ReleaseCaseGuardService releaseCaseGuardService;
 
     @Transactional
     public UserResponse updateProfile(Long userId, UserUpdateRequest request) {
         User user = findUser(userId);
+        boolean emailChanged = !user.getEmail().equals(request.email());
 
-        if (!user.getEmail().equals(request.email())
-                && userRepository.existsByEmailAndUserIdNot(request.email(), userId)) {
+        if (emailChanged && userRepository.existsByEmailAndUserIdNot(request.email(), userId)) {
             throw new CustomException(ErrorCode.DUPLICATE_EMAIL);
         }
 
         user.updateProfile(request.email(), request.name());
+
+        // 로그인 이메일이 실제로 바뀌면(계정 탈취 대응) 이 계획에 걸린 담당자/확인자/이의연락처의
+        // 기존 초대 토큰을 전부 무효화한다 - 새 이메일로 재초대해야 다시 접근할 수 있다.
+        if (emailChanged) {
+            planRepository.findByUser_UserId(userId).ifPresent(plan -> invalidatePlanInviteTokens(plan.getPlanId()));
+        }
+
         return UserResponse.from(user);
+    }
+
+    private void invalidatePlanInviteTokens(Long planId) {
+        recipientRepository.findByPlan_PlanId(planId).forEach(Recipient::invalidateInviteToken);
+        confirmerRepository.findByPlan_PlanIdOrderByConfirmIdAsc(planId).forEach(Confirmer::invalidateInviteToken);
+        disputeContactRepository.findByPlan_PlanId(planId).forEach(DisputeContact::invalidateInviteToken);
     }
 
     // "사후 인계 안내" 화면 - 필수 동의 조회/기록. ConsentCheckFilter가 이 값으로 전체 API 접근을 막는다.
@@ -60,13 +103,17 @@ public class UserService {
     }
 
     // 계정·계획 데이터를 영구 삭제한다(되돌릴 수 없음).
-    // confirmer(Confirmer)/evidence/releasecase 등은 아직 어떤 서비스도 행을 만들지 않아 삭제 대상이 없다 -
-    // 나중에 그 도메인들이 실제로 wiring되면 여기에 삭제 순서를 추가해야 한다.
+    // 진행 중인 사후 인계 사건이 있으면 삭제하지 않고, 그 사건을 동결한 뒤 막는다(운영자 검토 대상).
     @Transactional
     public void deleteAccount(Long userId) {
         User user = findUser(userId);
 
-        planRepository.findByUser_UserId(userId).ifPresent(this::deletePlanData);
+        planRepository.findByUser_UserId(userId).ifPresent(plan -> {
+            if (releaseCaseGuardService.freezeIfActiveCaseExists(plan.getPlanId())) {
+                throw new CustomException(ErrorCode.ACTIVE_RELEASE_CASE_EXISTS);
+            }
+            deletePlanData(plan);
+        });
 
         userRepository.delete(user);
     }
@@ -75,13 +122,36 @@ public class UserService {
     private void deletePlanData(Plan plan) {
         Long planId = plan.getPlanId();
 
+        emailLogRepository.deleteAll(emailLogRepository.findByPlan_PlanIdOrderBySentAtDesc(planId));
+        deleteEvidenceWithStorage(planId);
+        objectionRepository.deleteAll(objectionRepository.findByPlan_PlanId(planId));
+        handoffCheckResponseRepository.deleteAll(handoffCheckResponseRepository.findByHandoffCheck_Plan_PlanId(planId));
+        handoffCheckRepository.deleteAll(handoffCheckRepository.findByPlan_PlanId(planId));
+        packageIssueRepository.deleteAll(packageIssueRepository.findByRecipient_Plan_PlanId(planId));
+        dependencyRepository.deleteAll(dependencyRepository.findByPlan_PlanId(planId));
         lifeAreaMessageRepository.deleteAll(lifeAreaMessageRepository.findByConversation_Plan_PlanId(planId));
         itemRepository.deleteAll(itemRepository.findByLifeArea_Plan_PlanIdOrderByItemIdAsc(planId));
+        handoverStageRepository.deleteAll(handoverStageRepository.findByPlan_PlanId(planId));
         recipientRepository.deleteAll(recipientRepository.findByPlan_PlanId(planId));
         disputeContactRepository.deleteAll(disputeContactRepository.findByPlan_PlanId(planId));
+        releaseCaseRepository.deleteAll(releaseCaseRepository.findByPlan_PlanId(planId));
+        planVersionRepository.deleteAll(planVersionRepository.findByPlan_PlanId(planId));
+        confirmerRepository.deleteAll(confirmerRepository.findByPlan_PlanIdOrderByConfirmIdAsc(planId));
         lifeAreaRepository.deleteAll(lifeAreaRepository.findByPlan_PlanId(planId));
         conversationRepository.deleteAll(conversationRepository.findByPlan_PlanId(planId));
         planRepository.delete(plan);
+    }
+
+    // S3 원본까지 함께 정리한다. 이미 자동/수동 삭제 절차로 원본이 지워진 증빙(deletedAt != null)은
+    // 다시 지우려고 시도하지 않는다 - 존재하지 않는 스토리지 키를 지우는 시도를 막기 위함.
+    private void deleteEvidenceWithStorage(Long planId) {
+        var evidences = evidenceRepository.findByPlan_PlanId(planId);
+        for (Evidence evidence : evidences) {
+            if (evidence.getDeletedAt() == null) {
+                evidenceStorageClient.delete(evidence.getStorageKey());
+            }
+        }
+        evidenceRepository.deleteAll(evidences);
     }
 
     private User findUser(Long userId) {

--- a/src/main/java/com/mamoki/ieojuda/domain/confirmer/entity/Confirmer.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/confirmer/entity/Confirmer.java
@@ -81,6 +81,13 @@ public class Confirmer {
         this.inviteTokenExpiresAt = expiresAt;
     }
 
+    // 계정 이메일 변경 등 계정 탈취 대응 - 기존 초대 토큰으로는 더 이상 아무것도 할 수 없게 만든다
+    // (수락 완료 후에는 만료 검사를 건너뛰는 개인 접근키로 쓰이므로, 만료가 아니라 값 자체를 지워야 진짜로 막힌다)
+    public void invalidateInviteToken() {
+        this.inviteToken = null;
+        this.inviteTokenExpiresAt = null;
+    }
+
     // 수락 요청 재전송 - 새 토큰이 발급되므로 만료 상태를 수락 대기로 되돌린다
     public void resetAcceptance() {
         this.acceptanceStatus = AcceptanceStatus.PENDING;

--- a/src/main/java/com/mamoki/ieojuda/domain/confirmer/entity/DisputeContact.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/confirmer/entity/DisputeContact.java
@@ -56,6 +56,12 @@ public class DisputeContact {
         this.inviteTokenExpiresAt = expiresAt;
     }
 
+    // 계정 이메일 변경 등 계정 탈취 대응 - 기존 초대 토큰으로는 더 이상 아무것도 할 수 없게 만든다
+    public void invalidateInviteToken() {
+        this.inviteToken = null;
+        this.inviteTokenExpiresAt = null;
+    }
+
     // 이메일 검증 완료
     public void verify() {
         this.isVerified = true;

--- a/src/main/java/com/mamoki/ieojuda/domain/evidence/repository/EvidenceRepository.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/evidence/repository/EvidenceRepository.java
@@ -3,8 +3,13 @@ package com.mamoki.ieojuda.domain.evidence.repository;
 import com.mamoki.ieojuda.domain.evidence.entity.Evidence;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface EvidenceRepository extends JpaRepository<Evidence, Long> {
 
     // "공식 증빙 자료 제출" 화면 - 사건당 최대 3개 제한 검증용
     long countByReleaseCase_CaseId(Long caseId);
+
+    // 계정 삭제 시 이 계획에 제출된 증빙을 전부 지우기 위한 조회 (S3 원본도 같이 정리해야 함)
+    List<Evidence> findByPlan_PlanId(Long planId);
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/handoffcheck/repository/HandoffCheckRepository.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/handoffcheck/repository/HandoffCheckRepository.java
@@ -1,0 +1,12 @@
+package com.mamoki.ieojuda.domain.handoffcheck.repository;
+
+import com.mamoki.ieojuda.domain.handoffcheck.entity.HandoffCheck;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface HandoffCheckRepository extends JpaRepository<HandoffCheck, Long> {
+
+    // 계정 삭제 시 이 계획에 쌓인 역할 점검 발송 이력을 전부 지우기 위한 조회
+    List<HandoffCheck> findByPlan_PlanId(Long planId);
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/handoffcheck/repository/HandoffCheckResponseRepository.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/handoffcheck/repository/HandoffCheckResponseRepository.java
@@ -1,0 +1,12 @@
+package com.mamoki.ieojuda.domain.handoffcheck.repository;
+
+import com.mamoki.ieojuda.domain.handoffcheck.entity.HandoffCheckResponse;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface HandoffCheckResponseRepository extends JpaRepository<HandoffCheckResponse, Long> {
+
+    // 계정 삭제 시 이 계획의 역할 점검 응답을 전부 지우기 위한 조회 (handoff_checks보다 먼저 지워야 함)
+    List<HandoffCheckResponse> findByHandoffCheck_Plan_PlanId(Long planId);
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/repository/PlanVersionRepository.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/repository/PlanVersionRepository.java
@@ -3,5 +3,10 @@ package com.mamoki.ieojuda.domain.plan.repository;
 import com.mamoki.ieojuda.domain.plan.entity.PlanVersion;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PlanVersionRepository extends JpaRepository<PlanVersion, Long> {
+
+    // 계정 삭제 시 이 계획의 스냅샷 버전을 전부 지우기 위한 조회 (release_cases보다 나중에 지워야 함)
+    List<PlanVersion> findByPlan_PlanId(Long planId);
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/postaccess/repository/PackageIssueRepository.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/postaccess/repository/PackageIssueRepository.java
@@ -1,0 +1,12 @@
+package com.mamoki.ieojuda.domain.postaccess.repository;
+
+import com.mamoki.ieojuda.domain.postaccess.entity.PackageIssue;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PackageIssueRepository extends JpaRepository<PackageIssue, Long> {
+
+    // 계정 삭제 시 이 계획의 패키지 문제 신고를 전부 지우기 위한 조회 (items/role_assigness보다 먼저 지워야 함)
+    List<PackageIssue> findByRecipient_Plan_PlanId(Long planId);
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/recipient/entity/Recipient.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/recipient/entity/Recipient.java
@@ -101,6 +101,12 @@ public class Recipient {
         this.inviteTokenExpiresAt = expiresAt;
     }
 
+    // 계정 이메일 변경 등 계정 탈취 대응 - 기존 초대 토큰으로는 더 이상 아무것도 할 수 없게 만든다
+    public void invalidateInviteToken() {
+        this.inviteToken = null;
+        this.inviteTokenExpiresAt = null;
+    }
+
     // 담당자 수락
     public void accept(String inquiry) {
         this.acceptanceStatus = AcceptanceStatus.ACCEPTED;

--- a/src/main/java/com/mamoki/ieojuda/domain/releasecase/repository/ObjectionRepository.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/releasecase/repository/ObjectionRepository.java
@@ -3,5 +3,10 @@ package com.mamoki.ieojuda.domain.releasecase.repository;
 import com.mamoki.ieojuda.domain.releasecase.entity.Objection;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ObjectionRepository extends JpaRepository<Objection, Long> {
+
+    // 계정 삭제 시 이 계획에 접수된 이의 제기를 전부 지우기 위한 조회
+    List<Objection> findByPlan_PlanId(Long planId);
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/releasecase/repository/ReleaseCaseRepository.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/releasecase/repository/ReleaseCaseRepository.java
@@ -15,4 +15,7 @@ public interface ReleaseCaseRepository extends JpaRepository<ReleaseCase, Long> 
 
     // 스케줄러 - 대기 기간이 끝났고 동결되지 않은 사건을 찾기 위한 조회
     List<ReleaseCase> findByStatusAndFrozenFalseAndWaitingEndsAtLessThanEqual(ReleaseCaseStatus status, LocalDateTime now);
+
+    // 계정 삭제 시 이 계획에 쌓인 사건(취소/완료된 과거 이력 포함)을 전부 지우기 위한 조회
+    List<ReleaseCase> findByPlan_PlanId(Long planId);
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/releasecase/service/ReleaseCaseGuardService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/releasecase/service/ReleaseCaseGuardService.java
@@ -1,0 +1,35 @@
+package com.mamoki.ieojuda.domain.releasecase.service;
+
+import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCase;
+import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCaseStatus;
+import com.mamoki.ieojuda.domain.releasecase.repository.ReleaseCaseRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+// 계정 삭제 시도가 진행 중인 사후 인계 사건 때문에 막힐 때, 그 사건을 동결(freeze)해서 운영 검토로 넘긴다.
+// UserService.deleteAccount()는 이 동결 직후 예외를 던져 트랜잭션을 롤백하므로, 동결 자체는 그 롤백과
+// 무관하게 남아야 한다 - 그래서 별도 빈으로 분리하고 REQUIRES_NEW로 독립 트랜잭션에 커밋한다.
+@Service
+@RequiredArgsConstructor
+public class ReleaseCaseGuardService {
+
+    private final ReleaseCaseRepository releaseCaseRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public boolean freezeIfActiveCaseExists(Long planId) {
+        return releaseCaseRepository.findFirstByPlan_PlanIdOrderByCaseIdDesc(planId)
+                .filter(this::isActive)
+                .map(releaseCase -> {
+                    releaseCase.freeze();
+                    return true;
+                })
+                .orElse(false);
+    }
+
+    private boolean isActive(ReleaseCase releaseCase) {
+        return releaseCase.getStatus() != ReleaseCaseStatus.CANCELED
+                && releaseCase.getStatus() != ReleaseCaseStatus.COMPLETED;
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/stage/repository/DependencyRepository.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/stage/repository/DependencyRepository.java
@@ -1,0 +1,12 @@
+package com.mamoki.ieojuda.domain.stage.repository;
+
+import com.mamoki.ieojuda.domain.stage.entity.Dependency;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface DependencyRepository extends JpaRepository<Dependency, Long> {
+
+    // 계정 삭제 시 이 계획의 항목 선후행 관계를 전부 지우기 위한 조회 (items보다 먼저 지워야 함)
+    List<Dependency> findByPlan_PlanId(Long planId);
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/stage/repository/HandoverStageRepository.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/stage/repository/HandoverStageRepository.java
@@ -3,5 +3,10 @@ package com.mamoki.ieojuda.domain.stage.repository;
 import com.mamoki.ieojuda.domain.stage.entity.HandoverStage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface HandoverStageRepository extends JpaRepository<HandoverStage, Long> {
+
+    // 계정 삭제 시 이 계획의 인계 단계를 전부 지우기 위한 조회 (email_logs보다 나중, role_assigness/release_cases보다 먼저 지워야 함)
+    List<HandoverStage> findByPlan_PlanId(Long planId);
 }

--- a/src/test/java/com/mamoki/ieojuda/domain/account/service/UserServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/account/service/UserServiceTest.java
@@ -1,0 +1,190 @@
+package com.mamoki.ieojuda.domain.account.service;
+
+import com.mamoki.ieojuda.domain.account.dto.UserUpdateRequest;
+import com.mamoki.ieojuda.domain.account.entity.User;
+import com.mamoki.ieojuda.domain.account.repository.UserRepository;
+import com.mamoki.ieojuda.domain.audit.repository.EmailLogRepository;
+import com.mamoki.ieojuda.domain.confirmer.entity.Confirmer;
+import com.mamoki.ieojuda.domain.confirmer.entity.DisputeContact;
+import com.mamoki.ieojuda.domain.confirmer.entity.Relationship;
+import com.mamoki.ieojuda.domain.confirmer.repository.ConfirmerRepository;
+import com.mamoki.ieojuda.domain.confirmer.repository.DisputeContactRepository;
+import com.mamoki.ieojuda.domain.evidence.entity.Evidence;
+import com.mamoki.ieojuda.domain.evidence.repository.EvidenceRepository;
+import com.mamoki.ieojuda.domain.handoffcheck.repository.HandoffCheckRepository;
+import com.mamoki.ieojuda.domain.handoffcheck.repository.HandoffCheckResponseRepository;
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.plan.repository.ConversationRepository;
+import com.mamoki.ieojuda.domain.plan.repository.ItemRepository;
+import com.mamoki.ieojuda.domain.plan.repository.LifeAreaMessageRepository;
+import com.mamoki.ieojuda.domain.plan.repository.LifeAreaRepository;
+import com.mamoki.ieojuda.domain.plan.repository.PlanRepository;
+import com.mamoki.ieojuda.domain.plan.repository.PlanVersionRepository;
+import com.mamoki.ieojuda.domain.postaccess.repository.PackageIssueRepository;
+import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
+import com.mamoki.ieojuda.domain.recipient.repository.RecipientRepository;
+import com.mamoki.ieojuda.domain.releasecase.repository.ObjectionRepository;
+import com.mamoki.ieojuda.domain.releasecase.repository.ReleaseCaseRepository;
+import com.mamoki.ieojuda.domain.releasecase.service.ReleaseCaseGuardService;
+import com.mamoki.ieojuda.domain.stage.repository.DependencyRepository;
+import com.mamoki.ieojuda.domain.stage.repository.HandoverStageRepository;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import com.mamoki.ieojuda.global.storage.EvidenceStorageClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+// issue #48 회귀 테스트 - 계정 이메일 변경 시 토큰 무효화, 계정 삭제 시 진행 중 사건 차단/고아 데이터 방지를 검증한다.
+class UserServiceTest {
+
+    private UserRepository userRepository;
+    private PlanRepository planRepository;
+    private ConversationRepository conversationRepository;
+    private LifeAreaRepository lifeAreaRepository;
+    private LifeAreaMessageRepository lifeAreaMessageRepository;
+    private ItemRepository itemRepository;
+    private RecipientRepository recipientRepository;
+    private DisputeContactRepository disputeContactRepository;
+    private ConfirmerRepository confirmerRepository;
+    private ReleaseCaseRepository releaseCaseRepository;
+    private PlanVersionRepository planVersionRepository;
+    private EvidenceRepository evidenceRepository;
+    private EmailLogRepository emailLogRepository;
+    private HandoverStageRepository handoverStageRepository;
+    private ObjectionRepository objectionRepository;
+    private HandoffCheckRepository handoffCheckRepository;
+    private HandoffCheckResponseRepository handoffCheckResponseRepository;
+    private PackageIssueRepository packageIssueRepository;
+    private DependencyRepository dependencyRepository;
+    private EvidenceStorageClient evidenceStorageClient;
+    private ReleaseCaseGuardService releaseCaseGuardService;
+    private UserService userService;
+
+    @BeforeEach
+    void setUp() {
+        userRepository = mock(UserRepository.class);
+        planRepository = mock(PlanRepository.class);
+        conversationRepository = mock(ConversationRepository.class);
+        lifeAreaRepository = mock(LifeAreaRepository.class);
+        lifeAreaMessageRepository = mock(LifeAreaMessageRepository.class);
+        itemRepository = mock(ItemRepository.class);
+        recipientRepository = mock(RecipientRepository.class);
+        disputeContactRepository = mock(DisputeContactRepository.class);
+        confirmerRepository = mock(ConfirmerRepository.class);
+        releaseCaseRepository = mock(ReleaseCaseRepository.class);
+        planVersionRepository = mock(PlanVersionRepository.class);
+        evidenceRepository = mock(EvidenceRepository.class);
+        emailLogRepository = mock(EmailLogRepository.class);
+        handoverStageRepository = mock(HandoverStageRepository.class);
+        objectionRepository = mock(ObjectionRepository.class);
+        handoffCheckRepository = mock(HandoffCheckRepository.class);
+        handoffCheckResponseRepository = mock(HandoffCheckResponseRepository.class);
+        packageIssueRepository = mock(PackageIssueRepository.class);
+        dependencyRepository = mock(DependencyRepository.class);
+        evidenceStorageClient = mock(EvidenceStorageClient.class);
+        releaseCaseGuardService = mock(ReleaseCaseGuardService.class);
+
+        userService = new UserService(
+                userRepository, planRepository, conversationRepository, lifeAreaRepository, lifeAreaMessageRepository,
+                itemRepository, recipientRepository, disputeContactRepository, confirmerRepository,
+                releaseCaseRepository, planVersionRepository, evidenceRepository, emailLogRepository,
+                handoverStageRepository, objectionRepository, handoffCheckRepository, handoffCheckResponseRepository,
+                packageIssueRepository, dependencyRepository, evidenceStorageClient, releaseCaseGuardService);
+    }
+
+    @Test
+    void updateProfile_whenEmailChanges_invalidatesEveryPlanInviteToken() {
+        User user = User.builder().email("old@test.com").password("hash").name("A").build();
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(userRepository.existsByEmailAndUserIdNot("new@test.com", 1L)).thenReturn(false);
+
+        Plan plan = mock(Plan.class);
+        when(plan.getPlanId()).thenReturn(10L);
+        when(planRepository.findByUser_UserId(1L)).thenReturn(Optional.of(plan));
+
+        Recipient recipient = mock(Recipient.class);
+        when(recipientRepository.findByPlan_PlanId(10L)).thenReturn(List.of(recipient));
+
+        Confirmer confirmer = Confirmer.builder().plan(plan).name("B").relationship(Relationship.FRIEND).email("b@test.com").build();
+        confirmer.issueInviteToken("some-hash", null);
+        when(confirmerRepository.findByPlan_PlanIdOrderByConfirmIdAsc(10L)).thenReturn(List.of(confirmer));
+
+        DisputeContact disputeContact = mock(DisputeContact.class);
+        when(disputeContactRepository.findByPlan_PlanId(10L)).thenReturn(List.of(disputeContact));
+
+        userService.updateProfile(1L, new UserUpdateRequest("new@test.com", "A"));
+
+        assertThat(user.getEmail()).isEqualTo("new@test.com");
+        verify(recipient).invalidateInviteToken();
+        assertThat(confirmer.getInviteToken()).isNull();
+        verify(disputeContact).invalidateInviteToken();
+    }
+
+    @Test
+    void updateProfile_whenEmailUnchanged_doesNotTouchInviteTokens() {
+        User user = User.builder().email("same@test.com").password("hash").name("A").build();
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        userService.updateProfile(1L, new UserUpdateRequest("same@test.com", "New Name"));
+
+        assertThat(user.getName()).isEqualTo("New Name");
+        verifyNoInteractions(planRepository, recipientRepository, confirmerRepository, disputeContactRepository);
+    }
+
+    @Test
+    void deleteAccount_whenActiveCaseExists_isBlockedAndDeletesNothing() {
+        User user = User.builder().email("owner@test.com").password("hash").name("A").build();
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        Plan plan = mock(Plan.class);
+        when(plan.getPlanId()).thenReturn(10L);
+        when(planRepository.findByUser_UserId(1L)).thenReturn(Optional.of(plan));
+        when(releaseCaseGuardService.freezeIfActiveCaseExists(10L)).thenReturn(true);
+
+        assertThatThrownBy(() -> userService.deleteAccount(1L))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.ACTIVE_RELEASE_CASE_EXISTS));
+
+        verify(userRepository, never()).delete(user);
+        verifyNoInteractions(itemRepository, recipientRepository, releaseCaseRepository, evidenceStorageClient);
+    }
+
+    @Test
+    void deleteAccount_whenNoActiveCase_deletesPlanDataAndEvidenceStorageThenUser() {
+        User user = User.builder().email("owner@test.com").password("hash").name("A").build();
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        Plan plan = mock(Plan.class);
+        when(plan.getPlanId()).thenReturn(10L);
+        when(planRepository.findByUser_UserId(1L)).thenReturn(Optional.of(plan));
+        when(releaseCaseGuardService.freezeIfActiveCaseExists(10L)).thenReturn(false);
+
+        Evidence undeletedEvidence = mock(Evidence.class);
+        when(undeletedEvidence.getDeletedAt()).thenReturn(null);
+        when(undeletedEvidence.getStorageKey()).thenReturn("evidence/10/real-file.pdf");
+
+        Evidence alreadyDeletedEvidence = mock(Evidence.class);
+        when(alreadyDeletedEvidence.getDeletedAt()).thenReturn(java.time.LocalDateTime.now());
+
+        when(evidenceRepository.findByPlan_PlanId(10L)).thenReturn(List.of(undeletedEvidence, alreadyDeletedEvidence));
+
+        userService.deleteAccount(1L);
+
+        // S3 원본은 아직 안 지워진 증빙만 골라서 지운다
+        verify(evidenceStorageClient).delete("evidence/10/real-file.pdf");
+        verify(evidenceStorageClient, org.mockito.Mockito.times(1)).delete(org.mockito.ArgumentMatchers.anyString());
+
+        verify(userRepository).delete(user);
+    }
+}


### PR DESCRIPTION
## 연관 Issue
Closes #48

## 요약
계정 이메일 변경과 계정 삭제가 최근 추가된 사후 인계 도메인(사망신고/증빙/사건/발송)과 맞지 않아 실제로 깨져 있던 문제를 고쳤습니다. 이메일 변경 시 관련 초대 토큰을 무효화하고, 진행 중인 사건이 있으면 삭제를 막고 동결하며, 삭제 시 FK 위반 없이 모든 관련 데이터(S3 포함)를 정리하도록 만들었습니다.

## 작업 내용
- `UserService.updateProfile()` - 계정 이메일이 실제로 바뀔 때만 그 계획의 담당자/확인자/이의연락처 초대 토큰을 전부 무효화
- `Recipient`/`Confirmer`/`DisputeContact` 엔티티에 `invalidateInviteToken()` 추가
- `ReleaseCaseGuardService` 신규 - 계정 삭제 시도 시 진행 중 사건이 있으면 별도 트랜잭션(`REQUIRES_NEW`)으로 동결. 삭제 자체는 실패해서 롤백되더라도 동결 상태는 남도록 분리
- `UserService.deleteAccount()` - 진행 중 사건이 있으면 즉시 차단(`ACTIVE_RELEASE_CASE_EXISTS`), 없으면 삭제 진행
- `UserService.deletePlanData()` - 그동안 빠져있던 10개 테이블(`death_confirmers`, `release_cases`, `plan_versions`, `evidences`, `email_logs`, `handover_stages`, `item_dependencies`, `package_issues`, `handoff_checks`, `handoff_check_responses`, `objections`) 전부 FK 순서에 맞게 삭제 로직에 편입
- 증빙 삭제 시 DB 로우뿐 아니라 `EvidenceStorageClient`로 S3 원본 파일도 같이 삭제 (이미 삭제된 증빙은 재시도 안 함)
- `HandoffCheckRepository`/`HandoffCheckResponseRepository`/`PackageIssueRepository`/`DependencyRepository` 신규 생성, 기존 5개 레포지토리(`Evidence`/`Objection`/`HandoverStage`/`PlanVersion`/`ReleaseCase`)에 `findByPlan_PlanId` 계열 메서드 추가
- `UserServiceTest` 신규 작성 - 이메일 변경 시 토큰 무효화, 이메일 미변경 시 무영향, 진행 중 사건 있으면 삭제 차단, 사건 없으면 S3 포함 정상 삭제까지 4개 케이스 검증

## 범위
### 포함:
- 계정 이메일 변경 시 담당자/확인자/이의연락처 초대 토큰 무효화
- 진행 중 사건이 있는 계정의 삭제 차단 및 사건 동결
- 계정 삭제 시 FK 위반·고아 데이터(DB + S3) 없는 완전한 삭제 오케스트레이션
- 관련 통합 테스트
### 제외:
- 마이페이지 화면 디자인
- 법적 보존 기간 자체의 결정
- "운영 검토" 큐/알림 등 별도 워크플로 화면 (지금은 사건을 동결만 해두고, 기존 관리자 화면에서 확인·해제하는 구조)

## 스크린샷 / 미리 보기
백엔드 API 변경으로 스크린샷은 없습니다. 검증 내역:
- 무효화된 옛 토큰으로 사망신고 API 재호출 → `401 TOKEN_INVALID` 확인
- 담당자/이의연락처 토큰도 이메일 변경 시 함께 무효화됨을 확인
- 실제 S3에 파일 업로드 후 계정 삭제 → `boto3`로 S3 객체가 `EXISTS`→`NOT_FOUND`로 실제 삭제됨을 확인
- 진행 중 사건이 있는 계정 삭제 시도 → `409` 차단 + 계정은 그대로, 사건은 `frozen=true`로 동결됨을 확인 (삭제 트랜잭션 롤백과 무관하게 동결이 남는 것까지 확인)
- 증빙/사건/버전/발송이력/이의제기/역할점검 등 17개 테이블을 모두 채운 계정 삭제 → 전부 0건, FK 위반 없이 정상 삭제
- `UserServiceTest` 신규 4개 케이스 포함 전체 테스트 스위트(`./gradlew test`) 통과