### PR TITLE
[Fix/#40]: 타 사용자 planId 접근 시 404 반환하도록 소유권 검사 추가

### DIFF
--- a/src/main/java/com/mamoki/ieojuda/domain/confirmer/controller/DisputeContactController.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/confirmer/controller/DisputeContactController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -29,20 +30,22 @@ public class DisputeContactController {
     @Operation(summary = "이의 제기 연락처 등록", description = "이의 제기 연락처를 등록하고 그 주소로 검증 메일을 발송합니다.")
     @PostMapping("/plans/{planId}/dispute-contacts")
     public ResponseEntity<RsData<DisputeContactResponse>> register(
+            @AuthenticationPrincipal Long userId,
             @Parameter(description = "계획 ID") @PathVariable Long planId,
             @Valid @RequestBody DisputeContactRegisterRequest request
     ) {
-        return ResponseEntity.ok(RsData.success(disputeContactService.register(planId, request)));
+        return ResponseEntity.ok(RsData.success(disputeContactService.register(userId, planId, request)));
     }
 
     @Operation(summary = "이의 제기 연락처 수정", description = "이름/이메일을 수정합니다. 이메일이 바뀌면 검증 상태가 초기화되고 새 검증 메일이 발송됩니다.")
     @PutMapping("/plans/{planId}/dispute-contacts/{contactId}")
     public ResponseEntity<RsData<DisputeContactResponse>> update(
+            @AuthenticationPrincipal Long userId,
             @Parameter(description = "계획 ID") @PathVariable Long planId,
             @Parameter(description = "이의 제기 연락처 ID") @PathVariable Long contactId,
             @Valid @RequestBody DisputeContactRegisterRequest request
     ) {
-        return ResponseEntity.ok(RsData.success(disputeContactService.update(planId, contactId, request)));
+        return ResponseEntity.ok(RsData.success(disputeContactService.update(userId, planId, contactId, request)));
     }
 
     // 검증 메일의 링크를 클릭해서 접근하는 엔드포인트라 로그인이 필요 없다(토큰 자체가 증명)

--- a/src/main/java/com/mamoki/ieojuda/domain/confirmer/service/ConfirmerService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/confirmer/service/ConfirmerService.java
@@ -11,7 +11,7 @@ import com.mamoki.ieojuda.domain.confirmer.dto.ConfirmerUpdateResponse;
 import com.mamoki.ieojuda.domain.confirmer.entity.Confirmer;
 import com.mamoki.ieojuda.domain.confirmer.repository.ConfirmerRepository;
 import com.mamoki.ieojuda.domain.plan.entity.Plan;
-import com.mamoki.ieojuda.domain.plan.repository.PlanRepository;
+import com.mamoki.ieojuda.domain.plan.service.PlanOwnershipReader;
 import com.mamoki.ieojuda.domain.recipient.entity.AcceptanceStatus;
 import com.mamoki.ieojuda.global.config.AppProperties;
 import com.mamoki.ieojuda.global.email.contract.EmailContent;
@@ -38,7 +38,7 @@ import java.util.Set;
 @Transactional(readOnly = true)
 public class ConfirmerService {
 
-    private final PlanRepository planRepository;
+    private final PlanOwnershipReader planOwnershipReader;
     private final ConfirmerRepository confirmerRepository;
     private final EmailSender emailSender;
     private final AppProperties appProperties;
@@ -46,7 +46,7 @@ public class ConfirmerService {
     @Transactional
     // 특정 계획에 여러 명의 확인자를 한번에 등록하는 함수
     public ConfirmerBulkRegisterResponse registerAll(Long userId, Long planId, ConfirmerBulkRegisterRequest request) {
-        Plan plan = findOwnedPlan(userId, planId);
+        Plan plan = planOwnershipReader.findOwnedPlan(userId, planId);
         validateAll(planId, request.confirmers());
 
         List<ConfirmerRegisterResponse> responses = new ArrayList<>();
@@ -109,7 +109,7 @@ public class ConfirmerService {
 
     // "역할 점검" 화면 상세 - 이름 클릭 시 해당 확인자 정보
     public ConfirmerDetailResponse getConfirmer(Long userId, Long planId, Long confirmId) {
-        findOwnedPlan(userId, planId);
+        planOwnershipReader.findOwnedPlan(userId, planId);
         Confirmer confirmer = findOwnedConfirmer(planId, confirmId);
         return ConfirmerDetailResponse.from(confirmer);
     }
@@ -140,7 +140,7 @@ public class ConfirmerService {
     // "확인자 수정하기" - 이름/이메일 수정. 이메일이 바뀌면 재검증이 필요하므로 수락 이메일을 다시 보낸다
     @Transactional
     public ConfirmerUpdateResponse updateConfirmer(Long userId, Long planId, Long confirmId, ConfirmerUpdateRequest request) {
-        findOwnedPlan(userId, planId);
+        planOwnershipReader.findOwnedPlan(userId, planId);
         Confirmer confirmer = findOwnedConfirmer(planId, confirmId);
 
         boolean emailChanged = confirmer.updateContact(request.name(), request.email());
@@ -154,16 +154,6 @@ public class ConfirmerService {
                 sendResult != null && sendResult.success(),
                 sendResult == null || sendResult.bounceType() == null ? null : sendResult.bounceType().name()
         );
-    }
-
-    // 로그인한 사용자가 자신의 계획에만 확인자를 등록할 수 있도록 검증 (불일치 시 존재 노출 방지를 위해 NOT_FOUND로 응답)
-    private Plan findOwnedPlan(Long userId, Long planId) {
-        Plan plan = planRepository.findById(planId)
-                .orElseThrow(() -> new CustomException(ErrorCode.PLAN_NOT_FOUND));
-        if (!plan.getUser().getUserId().equals(userId)) {
-            throw new CustomException(ErrorCode.PLAN_NOT_FOUND);
-        }
-        return plan;
     }
 
     private Confirmer findOwnedConfirmer(Long planId, Long confirmId) {

--- a/src/main/java/com/mamoki/ieojuda/domain/confirmer/service/DisputeContactService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/confirmer/service/DisputeContactService.java
@@ -5,7 +5,7 @@ import com.mamoki.ieojuda.domain.confirmer.dto.DisputeContactResponse;
 import com.mamoki.ieojuda.domain.confirmer.entity.DisputeContact;
 import com.mamoki.ieojuda.domain.confirmer.repository.DisputeContactRepository;
 import com.mamoki.ieojuda.domain.plan.entity.Plan;
-import com.mamoki.ieojuda.domain.plan.repository.PlanRepository;
+import com.mamoki.ieojuda.domain.plan.service.PlanOwnershipReader;
 import com.mamoki.ieojuda.global.config.AppProperties;
 import com.mamoki.ieojuda.global.email.contract.EmailContent;
 import com.mamoki.ieojuda.global.email.contract.EmailSendResult;
@@ -29,15 +29,14 @@ import java.time.ZoneId;
 @Transactional(readOnly = true)
 public class DisputeContactService {
 
-    private final PlanRepository planRepository;
+    private final PlanOwnershipReader planOwnershipReader;
     private final DisputeContactRepository disputeContactRepository;
     private final EmailSender emailSender;
     private final AppProperties appProperties;
 
     @Transactional
-    public DisputeContactResponse register(Long planId, DisputeContactRegisterRequest request) {
-        Plan plan = planRepository.findById(planId)
-                .orElseThrow(() -> new CustomException(ErrorCode.PLAN_NOT_FOUND));
+    public DisputeContactResponse register(Long userId, Long planId, DisputeContactRegisterRequest request) {
+        Plan plan = planOwnershipReader.findOwnedPlan(userId, planId);
 
         DisputeContact contact = disputeContactRepository.save(DisputeContact.builder()
                 .plan(plan)
@@ -51,7 +50,8 @@ public class DisputeContactService {
 
     // "대기 이의제기 수정" 화면 - 이미 등록된 연락처의 이름/이메일 수정. 이메일이 바뀌면 검증을 다시 받아야 하므로 재발송한다.
     @Transactional
-    public DisputeContactResponse update(Long planId, Long contactId, DisputeContactRegisterRequest request) {
+    public DisputeContactResponse update(Long userId, Long planId, Long contactId, DisputeContactRegisterRequest request) {
+        planOwnershipReader.findOwnedPlan(userId, planId);
         DisputeContact contact = findContact(planId, contactId);
         boolean emailChanged = !contact.getEmail().equals(request.email());
 

--- a/src/main/java/com/mamoki/ieojuda/domain/handoffcheck/service/HandoffCheckService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/handoffcheck/service/HandoffCheckService.java
@@ -5,12 +5,9 @@ import com.mamoki.ieojuda.domain.confirmer.repository.ConfirmerRepository;
 import com.mamoki.ieojuda.domain.handoffcheck.dto.HandoffCheckAssigneeResponse;
 import com.mamoki.ieojuda.domain.handoffcheck.dto.HandoffCheckConfirmerResponse;
 import com.mamoki.ieojuda.domain.handoffcheck.dto.HandoffCheckStatusResponse;
-import com.mamoki.ieojuda.domain.plan.entity.Plan;
-import com.mamoki.ieojuda.domain.plan.repository.PlanRepository;
+import com.mamoki.ieojuda.domain.plan.service.PlanOwnershipReader;
 import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
 import com.mamoki.ieojuda.domain.recipient.repository.RecipientRepository;
-import com.mamoki.ieojuda.global.exception.CustomException;
-import com.mamoki.ieojuda.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,12 +23,12 @@ import java.util.Map;
 @Transactional(readOnly = true)
 public class HandoffCheckService {
 
-    private final PlanRepository planRepository;
+    private final PlanOwnershipReader planOwnershipReader;
     private final RecipientRepository recipientRepository;
     private final ConfirmerRepository confirmerRepository;
 
     public HandoffCheckStatusResponse getHandoffCheck(Long userId, Long planId) {
-        findOwnedPlan(userId, planId);
+        planOwnershipReader.findOwnedPlan(userId, planId);
 
         List<HandoffCheckAssigneeResponse> assignees = buildAssignees(planId);
         List<HandoffCheckConfirmerResponse> confirmers = confirmerRepository.findByPlan_PlanIdOrderByConfirmIdAsc(planId).stream()
@@ -57,15 +54,5 @@ public class HandoffCheckService {
                 .sorted(Comparator.comparing(Recipient::getAssigneeId))
                 .map(recipient -> HandoffCheckAssigneeResponse.of(recipient, backupByPrimaryId.get(recipient.getAssigneeId())))
                 .toList();
-    }
-
-    // 로그인한 사용자가 자신의 계획만 조회할 수 있도록 검증 (불일치 시 존재 노출 방지를 위해 NOT_FOUND로 응답)
-    private Plan findOwnedPlan(Long userId, Long planId) {
-        Plan plan = planRepository.findById(planId)
-                .orElseThrow(() -> new CustomException(ErrorCode.PLAN_NOT_FOUND));
-        if (!plan.getUser().getUserId().equals(userId)) {
-            throw new CustomException(ErrorCode.PLAN_NOT_FOUND);
-        }
-        return plan;
     }
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/controller/ConversationController.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/controller/ConversationController.java
@@ -13,6 +13,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -34,33 +35,36 @@ public class ConversationController {
     @Operation(summary = "대화 세션 시작", description = "새 대화 세션을 시작합니다. 처음 채팅을 시작할 때, 또는 나중에 수정하러 다시 들어올 때마다 호출합니다.")
     @PostMapping
     public ResponseEntity<RsData<ConversationResponse>> start(
+            @AuthenticationPrincipal Long userId,
             @Parameter(description = "계획 ID") @PathVariable Long planId
     ) {
-        return ResponseEntity.ok(RsData.success(conversationService.startConversation(planId)));
+        return ResponseEntity.ok(RsData.success(conversationService.startConversation(userId, planId)));
     }
 
     // page=0이 최신 턴, size만큼 과거로 내려가며 조회 (무한 스크롤)
     @Operation(summary = "대화 이력 조회", description = "page=0이 최신 턴이며, size만큼 과거로 내려가며 조회합니다(무한 스크롤). 응답의 messages는 항상 오래된 순으로 정렬됩니다.")
     @GetMapping("/{conversationId}/messages")
     public ResponseEntity<RsData<LifeAreaMessageHistoryResponse>> getHistory(
+            @AuthenticationPrincipal Long userId,
             @Parameter(description = "계획 ID") @PathVariable Long planId,
             @Parameter(description = "대화 세션 ID") @PathVariable Long conversationId,
             @Parameter(description = "페이지 번호 (0부터 시작, 최신 턴)") @RequestParam(defaultValue = "0") int page,
             @Parameter(description = "페이지 크기") @RequestParam(defaultValue = "20") int size
     ) {
         LifeAreaMessageHistoryResponse history = conversationService
-                .getHistory(planId, conversationId, PageRequest.of(page, size));
+                .getHistory(userId, planId, conversationId, PageRequest.of(page, size));
         return ResponseEntity.ok(RsData.success(history));
     }
 
     @Operation(summary = "사용자 발화 전송", description = "사용자 발화를 OpenAI에 전달해 다음 턴을 받습니다. AI가 되묻는 중이면 QUESTION, 구조화를 끝냈으면 RESULT(항목 목록)를 반환합니다. 한 발화에 여러 사람·주제가 섞여 있으면 항목이 여러 카테고리로 나뉘어 반환될 수 있습니다.")
     @PostMapping("/{conversationId}/messages")
     public ResponseEntity<RsData<LifeAreaTurnResponse>> sendMessage(
+            @AuthenticationPrincipal Long userId,
             @Parameter(description = "계획 ID") @PathVariable Long planId,
             @Parameter(description = "대화 세션 ID") @PathVariable Long conversationId,
             @Valid @RequestBody LifeAreaMessageRequest request
     ) {
-        LifeAreaTurnResponse result = conversationService.sendMessage(planId, conversationId, request.content());
+        LifeAreaTurnResponse result = conversationService.sendMessage(userId, planId, conversationId, request.content());
         return ResponseEntity.ok(RsData.success(result));
     }
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/controller/ItemReviewController.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/controller/ItemReviewController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -32,40 +33,44 @@ public class ItemReviewController {
     @Operation(summary = "항목 단건 조회")
     @GetMapping("/{itemId}")
     public ResponseEntity<RsData<ItemResponse>> getItem(
+            @AuthenticationPrincipal Long userId,
             @Parameter(description = "계획 ID") @PathVariable Long planId,
             @Parameter(description = "항목 ID") @PathVariable Long itemId
     ) {
-        return ResponseEntity.ok(RsData.success(itemReviewService.getItem(planId, itemId)));
+        return ResponseEntity.ok(RsData.success(itemReviewService.getItem(userId, planId, itemId)));
     }
 
     @Operation(summary = "항목 승인", description = "AI가 만든 항목을 승인합니다. 원문 근거가 없는 항목은 승인할 수 없습니다.")
     @PostMapping("/review")
     public ResponseEntity<RsData<ItemResponse>> approve(
+            @AuthenticationPrincipal Long userId,
             @Parameter(description = "계획 ID") @PathVariable Long planId,
             @Valid @RequestBody ItemReviewRequest request
     ) {
-        ItemResponse result = itemReviewService.approve(planId, request);
+        ItemResponse result = itemReviewService.approve(userId, planId, request);
         return ResponseEntity.ok(RsData.success(result));
     }
 
     @Operation(summary = "항목 인라인 수정", description = "대화창에서 AI가 만든 항목을 화면 전환 없이 사용자가 직접 고쳐서 저장합니다.")
     @PutMapping("/{itemId}")
     public ResponseEntity<RsData<ItemResponse>> update(
+            @AuthenticationPrincipal Long userId,
             @Parameter(description = "계획 ID") @PathVariable Long planId,
             @Parameter(description = "항목 ID") @PathVariable Long itemId,
             @Valid @RequestBody ItemUpdateRequest request
     ) {
-        ItemResponse result = itemReviewService.update(planId, itemId, request);
+        ItemResponse result = itemReviewService.update(userId, planId, itemId, request);
         return ResponseEntity.ok(RsData.success(result));
     }
 
     @Operation(summary = "항목 삭제", description = "AI가 만든 항목을 완전히 삭제합니다(상태 변경이 아닌 실제 삭제).")
     @DeleteMapping("/{itemId}")
     public ResponseEntity<RsData<Void>> delete(
+            @AuthenticationPrincipal Long userId,
             @Parameter(description = "계획 ID") @PathVariable Long planId,
             @Parameter(description = "항목 ID") @PathVariable Long itemId
     ) {
-        itemReviewService.delete(planId, itemId);
+        itemReviewService.delete(userId, planId, itemId);
         return ResponseEntity.ok(RsData.success(null));
     }
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/controller/LifeAreaController.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/controller/LifeAreaController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,8 +30,9 @@ public class LifeAreaController {
     @Operation(summary = "삶의 구역별 항목 조회", description = "가족/관계 정리/업무 연속성 3개 구역 각각에 지금까지 쌓인 항목 전체를 조회합니다.")
     @GetMapping
     public ResponseEntity<RsData<List<LifeAreaResponse>>> getLifeAreas(
+            @AuthenticationPrincipal Long userId,
             @Parameter(description = "계획 ID") @PathVariable Long planId
     ) {
-        return ResponseEntity.ok(RsData.success(lifeAreaService.getLifeAreas(planId)));
+        return ResponseEntity.ok(RsData.success(lifeAreaService.getLifeAreas(userId, planId)));
     }
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/controller/PlanController.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/controller/PlanController.java
@@ -42,43 +42,48 @@ public class PlanController {
     @Operation(summary = "계획 조회")
     @GetMapping("/{planId}")
     public ResponseEntity<RsData<PlanResponse>> getPlan(
+            @AuthenticationPrincipal Long userId,
             @Parameter(description = "계획 ID") @PathVariable Long planId
     ) {
-        return ResponseEntity.ok(RsData.success(planService.getPlan(planId)));
+        return ResponseEntity.ok(RsData.success(planService.getPlan(userId, planId)));
     }
 
     @Operation(summary = "대기·이의제기 설정 조회", description = "저장된 대기 기간, 본인 경고 이메일, 이의 제기 연락처를 한 번에 조회합니다. 아직 등록 안 한 항목은 null로 옵니다.")
     @GetMapping("/{planId}/release-policy")
     public ResponseEntity<RsData<ReleaseSettingsResponse>> getReleaseSettings(
+            @AuthenticationPrincipal Long userId,
             @Parameter(description = "계획 ID") @PathVariable Long planId
     ) {
-        return ResponseEntity.ok(RsData.success(planService.getReleaseSettings(planId)));
+        return ResponseEntity.ok(RsData.success(planService.getReleaseSettings(userId, planId)));
     }
 
     @Operation(summary = "대기 기간 설정", description = "증빙 승인 후 실제 발송까지 기다리는 대기 기간(7~30일)을 저장합니다.")
     @PutMapping("/{planId}/release-policy")
     public ResponseEntity<RsData<ReleasePolicyResponse>> updateReleasePolicy(
+            @AuthenticationPrincipal Long userId,
             @Parameter(description = "계획 ID") @PathVariable Long planId,
             @Valid @RequestBody ReleasePolicyRequest request
     ) {
-        return ResponseEntity.ok(RsData.success(planService.updateReleasePolicy(planId, request)));
+        return ResponseEntity.ok(RsData.success(planService.updateReleasePolicy(userId, planId, request)));
     }
 
     @Operation(summary = "본인 경고 이메일 등록", description = "실행 신고가 오면 가장 먼저 경고 메일을 받을 본인 주소를 등록하고, 그 주소로 검증 메일을 발송합니다.")
     @PostMapping("/{planId}/self-warning-email")
     public ResponseEntity<RsData<SelfWarningEmailResponse>> requestSelfWarningEmailVerification(
+            @AuthenticationPrincipal Long userId,
             @Parameter(description = "계획 ID") @PathVariable Long planId,
             @Valid @RequestBody SelfWarningEmailRequest request
     ) {
-        return ResponseEntity.ok(RsData.success(planService.requestSelfWarningEmailVerification(planId, request)));
+        return ResponseEntity.ok(RsData.success(planService.requestSelfWarningEmailVerification(userId, planId, request)));
     }
 
     // 명세서 "마이페이지" API 호출: 계획 비활성화 POST /api/plans/{planId}/deactivate
     @Operation(summary = "계획 비활성화", description = "마이페이지에서 계획을 비활성화 상태로 전환합니다.")
     @PostMapping("/{planId}/deactivate")
     public ResponseEntity<RsData<PlanResponse>> deactivate(
+            @AuthenticationPrincipal Long userId,
             @Parameter(description = "계획 ID") @PathVariable Long planId
     ) {
-        return ResponseEntity.ok(RsData.success(planService.deactivate(planId)));
+        return ResponseEntity.ok(RsData.success(planService.deactivate(userId, planId)));
     }
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/repository/PlanRepository.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/repository/PlanRepository.java
@@ -9,6 +9,9 @@ public interface PlanRepository extends JpaRepository<Plan, Long> {
     // 1인 1계획 고정 - 로그인한 사용자가 자기 planId를 모를 때(예: 로그인 직후) 조회용
     Optional<Plan> findByUser_UserId(Long userId);
 
+    // 소유권 검증 겸 조회 - 타인의 planId면 결과가 없다(PlanOwnershipReader에서 사용)
+    Optional<Plan> findByPlanIdAndUser_UserId(Long planId, Long userId);
+
     // 본인 경고 이메일 검증 링크 클릭 시 토큰으로 계획을 찾기 위한 조회
     Optional<Plan> findBySelfWarningVerifyToken(String selfWarningVerifyToken);
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/service/ConversationService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/service/ConversationService.java
@@ -22,7 +22,6 @@ import com.mamoki.ieojuda.domain.plan.repository.ConversationRepository;
 import com.mamoki.ieojuda.domain.plan.repository.ItemRepository;
 import com.mamoki.ieojuda.domain.plan.repository.LifeAreaMessageRepository;
 import com.mamoki.ieojuda.domain.plan.repository.LifeAreaRepository;
-import com.mamoki.ieojuda.domain.plan.repository.PlanRepository;
 import com.mamoki.ieojuda.global.exception.CustomException;
 import com.mamoki.ieojuda.global.exception.ErrorCode;
 import com.mamoki.ieojuda.global.openai.component.OpenAIClient;
@@ -49,7 +48,7 @@ import java.util.Map;
 @Transactional(readOnly = true)
 public class ConversationService {
 
-    private final PlanRepository planRepository;
+    private final PlanOwnershipReader planOwnershipReader;
     private final ConversationRepository conversationRepository;
     private final LifeAreaMessageRepository lifeAreaMessageRepository;
     private final LifeAreaRepository lifeAreaRepository;
@@ -59,15 +58,15 @@ public class ConversationService {
 
     // 새 대화 세션 시작 - 처음 채팅을 시작할 때, 또는 나중에 수정하러 다시 들어올 때마다 호출
     @Transactional
-    public ConversationResponse startConversation(Long planId) {
-        Plan plan = findPlan(planId);
+    public ConversationResponse startConversation(Long userId, Long planId) {
+        Plan plan = planOwnershipReader.findOwnedPlan(userId, planId);
         Conversation conversation = conversationRepository.save(Conversation.builder().plan(plan).build());
         return ConversationResponse.from(conversation);
     }
 
     // 대화 작성 화면 - 최신 턴부터 페이지 단위로 조회(무한 스크롤), 화면엔 오래된 순으로 뒤집어서 반환
-    public LifeAreaMessageHistoryResponse getHistory(Long planId, Long conversationId, Pageable pageable) {
-        Conversation conversation = findConversation(planId, conversationId);
+    public LifeAreaMessageHistoryResponse getHistory(Long userId, Long planId, Long conversationId, Pageable pageable) {
+        Conversation conversation = findConversation(userId, planId, conversationId);
 
         Slice<LifeAreaMessage> slice = lifeAreaMessageRepository
                 .findByConversation_ConversationIdOrderByMessageIdDesc(conversation.getConversationId(), pageable);
@@ -82,8 +81,8 @@ public class ConversationService {
 
     // 대화 작성 화면 - 사용자 발화 전송 -> AI의 다음 턴(질문 또는 구조화 결과) 반환
     @Transactional
-    public LifeAreaTurnResponse sendMessage(Long planId, Long conversationId, String userContent) {
-        Conversation conversation = findConversation(planId, conversationId);
+    public LifeAreaTurnResponse sendMessage(Long userId, Long planId, Long conversationId, String userContent) {
+        Conversation conversation = findConversation(userId, planId, conversationId);
         Plan plan = conversation.getPlan();
 
         // step 1. 이 세션 안에서 지금까지의 대화 이력 로드
@@ -210,12 +209,8 @@ public class ConversationService {
         return role == MessageRole.ASSISTANT ? "assistant" : "user";
     }
 
-    private Plan findPlan(Long planId) {
-        return planRepository.findById(planId)
-                .orElseThrow(() -> new CustomException(ErrorCode.PLAN_NOT_FOUND));
-    }
-
-    private Conversation findConversation(Long planId, Long conversationId) {
+    private Conversation findConversation(Long userId, Long planId, Long conversationId) {
+        planOwnershipReader.findOwnedPlan(userId, planId);
         Conversation conversation = conversationRepository.findById(conversationId)
                 .orElseThrow(() -> new CustomException(ErrorCode.CONVERSATION_NOT_FOUND));
         if (!conversation.getPlan().getPlanId().equals(planId)) {

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/service/ItemOrderService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/service/ItemOrderService.java
@@ -8,7 +8,6 @@ import com.mamoki.ieojuda.domain.plan.entity.Item;
 import com.mamoki.ieojuda.domain.plan.entity.ItemActionType;
 import com.mamoki.ieojuda.domain.plan.entity.Plan;
 import com.mamoki.ieojuda.domain.plan.repository.ItemRepository;
-import com.mamoki.ieojuda.domain.plan.repository.PlanRepository;
 import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
 import com.mamoki.ieojuda.global.exception.CustomException;
 import com.mamoki.ieojuda.global.exception.ErrorCode;
@@ -30,11 +29,11 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class ItemOrderService {
 
-    private final PlanRepository planRepository;
+    private final PlanOwnershipReader planOwnershipReader;
     private final ItemRepository itemRepository;
 
     public OrderCheckResponse getOrderCheck(Long userId, Long planId) {
-        findOwnedPlan(userId, planId);
+        planOwnershipReader.findOwnedPlan(userId, planId);
         List<Item> items = itemRepository.findByLifeArea_Plan_PlanIdAndRecipientIsNotNullOrderBySortOrderAscItemIdAsc(planId);
         return OrderCheckResponse.of(buildItemResponses(items));
     }
@@ -42,7 +41,7 @@ public class ItemOrderService {
     // 드래그로 바뀐 순서를 저장 - 순서가 바뀌었으므로 기존 확정 상태는 초기화한다
     @Transactional
     public OrderCheckResponse reorder(Long userId, Long planId, ItemReorderRequest request) {
-        Plan plan = findOwnedPlan(userId, planId);
+        Plan plan = planOwnershipReader.findOwnedPlan(userId, planId);
         List<Item> items = itemRepository.findByLifeArea_Plan_PlanIdAndRecipientIsNotNullOrderBySortOrderAscItemIdAsc(planId);
 
         Map<Long, Item> itemsById = items.stream().collect(Collectors.toMap(Item::getItemId, item -> item));
@@ -64,7 +63,7 @@ public class ItemOrderService {
     // "순서 확정하기" - 충돌이 하나라도 남아있으면 확정할 수 없다
     @Transactional
     public OrderConfirmResponse confirm(Long userId, Long planId) {
-        Plan plan = findOwnedPlan(userId, planId);
+        Plan plan = planOwnershipReader.findOwnedPlan(userId, planId);
         List<Item> items = itemRepository.findByLifeArea_Plan_PlanIdAndRecipientIsNotNullOrderBySortOrderAscItemIdAsc(planId);
 
         boolean hasConflict = buildItemResponses(items).stream().anyMatch(OrderCheckItemResponse::conflict);
@@ -123,15 +122,5 @@ public class ItemOrderService {
 
     private int sortOrderOf(Item item) {
         return item.getSortOrder() == null ? 0 : item.getSortOrder();
-    }
-
-    // 로그인한 사용자가 자신의 계획만 조회할 수 있도록 검증 (불일치 시 존재 노출 방지를 위해 NOT_FOUND로 응답)
-    private Plan findOwnedPlan(Long userId, Long planId) {
-        Plan plan = planRepository.findById(planId)
-                .orElseThrow(() -> new CustomException(ErrorCode.PLAN_NOT_FOUND));
-        if (!plan.getUser().getUserId().equals(userId)) {
-            throw new CustomException(ErrorCode.PLAN_NOT_FOUND);
-        }
-        return plan;
     }
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/service/ItemReviewService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/service/ItemReviewService.java
@@ -20,15 +20,16 @@ import org.springframework.transaction.annotation.Transactional;
 public class ItemReviewService {
 
     private final ItemRepository itemRepository;
+    private final PlanOwnershipReader planOwnershipReader;
 
     // 항목 단건 조회
-    public ItemResponse getItem(Long planId, Long itemId) {
-        return ItemResponse.from(findItem(planId, itemId));
+    public ItemResponse getItem(Long userId, Long planId, Long itemId) {
+        return ItemResponse.from(findItem(userId, planId, itemId));
     }
 
     @Transactional
-    public ItemResponse approve(Long planId, ItemReviewRequest request) {
-        Item item = findItem(planId, request.itemId());
+    public ItemResponse approve(Long userId, Long planId, ItemReviewRequest request) {
+        Item item = findItem(userId, planId, request.itemId());
 
         // 명세서 예외 처리: 원문 근거 없는 항목은 승인할 수 없음
         if (item.getSourceExcerpt() == null || item.getSourceExcerpt().isBlank()) {
@@ -41,15 +42,15 @@ public class ItemReviewService {
 
     // "삭제" 버튼 - 기각(상태만 변경) 대신 항목을 DB에서 완전히 제거
     @Transactional
-    public void delete(Long planId, Long itemId) {
-        Item item = findItem(planId, itemId);
+    public void delete(Long userId, Long planId, Long itemId) {
+        Item item = findItem(userId, planId, itemId);
         itemRepository.delete(item);
     }
 
     // 대화창 인라인 "수정" 버튼 - AI가 만든 초안을 사용자가 직접 고쳐서 저장 (대화 화면 전환 없이 처리)
     @Transactional
-    public ItemResponse update(Long planId, Long itemId, ItemUpdateRequest request) {
-        Item item = findItem(planId, itemId);
+    public ItemResponse update(Long userId, Long planId, Long itemId, ItemUpdateRequest request) {
+        Item item = findItem(userId, planId, itemId);
 
         DisclosureScope disclosureScope;
         try {
@@ -71,7 +72,8 @@ public class ItemReviewService {
         return ItemResponse.from(item);
     }
 
-    private Item findItem(Long planId, Long itemId) {
+    private Item findItem(Long userId, Long planId, Long itemId) {
+        planOwnershipReader.findOwnedPlan(userId, planId);
         Item item = itemRepository.findById(itemId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ITEM_NOT_FOUND));
         if (!item.getLifeArea().getPlan().getPlanId().equals(planId)) {

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/service/LifeAreaService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/service/LifeAreaService.java
@@ -25,8 +25,10 @@ import java.util.stream.Collectors;
 public class LifeAreaService {
 
     private final ItemRepository itemRepository;
+    private final PlanOwnershipReader planOwnershipReader;
 
-    public List<LifeAreaResponse> getLifeAreas(Long planId) {
+    public List<LifeAreaResponse> getLifeAreas(Long userId, Long planId) {
+        planOwnershipReader.findOwnedPlan(userId, planId);
         List<Item> items = itemRepository.findByLifeArea_Plan_PlanIdOrderByItemIdAsc(planId);
 
         Map<LifeAreaCategory, List<Item>> itemsByCategory = items.stream()

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/service/PlanOwnershipReader.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/service/PlanOwnershipReader.java
@@ -1,0 +1,21 @@
+package com.mamoki.ieojuda.domain.plan.service;
+
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.plan.repository.PlanRepository;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+// 로그인한 사용자가 자신의 계획만 조회할 수 있도록 검증 (불일치 시 존재 노출 방지를 위해 NOT_FOUND로 응답)
+@Component
+@RequiredArgsConstructor
+public class PlanOwnershipReader {
+
+    private final PlanRepository planRepository;
+
+    public Plan findOwnedPlan(Long userId, Long planId) {
+        return planRepository.findByPlanIdAndUser_UserId(planId, userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.PLAN_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/service/PlanService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/service/PlanService.java
@@ -38,12 +38,13 @@ public class PlanService {
     private static final int MAX_WAITING_DAYS = 30;
 
     private final PlanRepository planRepository;
+    private final PlanOwnershipReader planOwnershipReader;
     private final DisputeContactRepository disputeContactRepository;
     private final EmailSender emailSender;
     private final AppProperties appProperties;
 
-    public PlanResponse getPlan(Long planId) {
-        return PlanResponse.from(findPlan(planId));
+    public PlanResponse getPlan(Long userId, Long planId) {
+        return PlanResponse.from(planOwnershipReader.findOwnedPlan(userId, planId));
     }
 
     // 로그인한 사용자가 자기 planId를 모를 때(로그인 직후 등) 조회
@@ -54,36 +55,37 @@ public class PlanService {
     }
 
     @Transactional
-    public PlanResponse deactivate(Long planId) {
-        Plan plan = findPlan(planId);
+    public PlanResponse deactivate(Long userId, Long planId) {
+        Plan plan = planOwnershipReader.findOwnedPlan(userId, planId);
         plan.deactivate();
         return PlanResponse.from(plan);
     }
 
     // "대기 이의제기 수정" 화면 - 저장된 대기기간/본인경고이메일/이의제기연락처를 한 번에 조회
-    public ReleaseSettingsResponse getReleaseSettings(Long planId) {
-        Plan plan = findPlan(planId);
+    public ReleaseSettingsResponse getReleaseSettings(Long userId, Long planId) {
+        Plan plan = planOwnershipReader.findOwnedPlan(userId, planId);
         var disputeContact = disputeContactRepository.findFirstByPlan_PlanIdOrderByContactIdDesc(planId).orElse(null);
         return ReleaseSettingsResponse.of(plan, disputeContact);
     }
 
     // "대기 이의제기 설정" 화면 - 대기 기간 저장
+    // 소유권 검증을 범위 검증보다 먼저 수행한다 - 순서가 반대면 "타인 planId + 잘못된 값" 조합이 400을 돌려줘 존재를 흘린다
     @Transactional
-    public ReleasePolicyResponse updateReleasePolicy(Long planId, ReleasePolicyRequest request) {
+    public ReleasePolicyResponse updateReleasePolicy(Long userId, Long planId, ReleasePolicyRequest request) {
+        Plan plan = planOwnershipReader.findOwnedPlan(userId, planId);
         if (request.waitingDays() == null
                 || request.waitingDays() < MIN_WAITING_DAYS
                 || request.waitingDays() > MAX_WAITING_DAYS) {
             throw new CustomException(ErrorCode.INVALID_WAITING_PERIOD);
         }
-        Plan plan = findPlan(planId);
         plan.updateWaitingDays(request.waitingDays());
         return ReleasePolicyResponse.from(plan);
     }
 
     // "대기 이의제기 설정" 화면 - 본인 경고 이메일 등록 + 검증 메일 발송
     @Transactional
-    public SelfWarningEmailResponse requestSelfWarningEmailVerification(Long planId, SelfWarningEmailRequest request) {
-        Plan plan = findPlan(planId);
+    public SelfWarningEmailResponse requestSelfWarningEmailVerification(Long userId, Long planId, SelfWarningEmailRequest request) {
+        Plan plan = planOwnershipReader.findOwnedPlan(userId, planId);
 
         String plainToken = TokenProvider.generatePlainToken();
         LocalDateTime expiresAt = LocalDateTime.now().plusHours(appProperties.getInviteTokenTtlHours());
@@ -118,10 +120,5 @@ public class PlanService {
         }
 
         plan.verifySelfWarningEmail();
-    }
-
-    private Plan findPlan(Long planId) {
-        return planRepository.findById(planId)
-                .orElseThrow(() -> new CustomException(ErrorCode.PLAN_NOT_FOUND));
     }
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/recipient/service/RecipientService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/recipient/service/RecipientService.java
@@ -7,7 +7,7 @@ import com.mamoki.ieojuda.domain.plan.entity.ItemStatus;
 import com.mamoki.ieojuda.domain.plan.entity.LifeArea;
 import com.mamoki.ieojuda.domain.plan.entity.Plan;
 import com.mamoki.ieojuda.domain.plan.repository.ItemRepository;
-import com.mamoki.ieojuda.domain.plan.repository.PlanRepository;
+import com.mamoki.ieojuda.domain.plan.service.PlanOwnershipReader;
 import com.mamoki.ieojuda.domain.recipient.dto.BackupRegisterRequest;
 import com.mamoki.ieojuda.domain.recipient.dto.BackupRegisterResponse;
 import com.mamoki.ieojuda.domain.recipient.dto.RecipientAcceptanceEmailResponse;
@@ -52,13 +52,13 @@ public class RecipientService {
 
     private final ItemRepository itemRepository;
     private final RecipientRepository recipientRepository;
-    private final PlanRepository planRepository;
+    private final PlanOwnershipReader planOwnershipReader;
     private final EmailSender emailSender;
     private final AppProperties appProperties;
 
     @Transactional
     public RecipientBulkRegisterResponse registerAll(Long userId, Long planId, RecipientBulkRegisterRequest request) {
-        findOwnedPlan(userId, planId);
+        planOwnershipReader.findOwnedPlan(userId, planId);
         List<Item> items = validateAll(planId, request.recipients());
 
         List<RecipientRegisterResponse> responses = new ArrayList<>();
@@ -210,7 +210,7 @@ public class RecipientService {
 
     // "역할 점검" 화면 상세 - 이름 클릭 시 해당 담당자에게 배정된 항목 전체
     public RecipientDetailResponse getRecipient(Long userId, Long planId, Long assigneeId) {
-        findOwnedPlan(userId, planId);
+        planOwnershipReader.findOwnedPlan(userId, planId);
         Recipient recipient = findOwnedRecipient(planId, assigneeId);
 
         List<ItemResponse> items = itemRepository.findByRecipient_AssigneeIdOrderByItemIdAsc(assigneeId).stream()
@@ -246,7 +246,7 @@ public class RecipientService {
     // "담당자 수정하기" - 이름/이메일 수정. 이메일이 바뀌면 재검증이 필요하므로 수락 이메일을 다시 보낸다
     @Transactional
     public RecipientUpdateResponse updateRecipient(Long userId, Long planId, Long assigneeId, RecipientUpdateRequest request) {
-        findOwnedPlan(userId, planId);
+        planOwnershipReader.findOwnedPlan(userId, planId);
         Recipient recipient = findOwnedRecipient(planId, assigneeId);
 
         boolean emailChanged = recipient.updateContact(request.name(), request.email());
@@ -260,16 +260,6 @@ public class RecipientService {
                 sendResult != null && sendResult.success(),
                 sendResult == null || sendResult.bounceType() == null ? null : sendResult.bounceType().name()
         );
-    }
-
-    // 로그인한 사용자가 자신의 계획만 조회할 수 있도록 검증 (불일치 시 존재 노출 방지를 위해 NOT_FOUND로 응답)
-    private Plan findOwnedPlan(Long userId, Long planId) {
-        Plan plan = planRepository.findById(planId)
-                .orElseThrow(() -> new CustomException(ErrorCode.PLAN_NOT_FOUND));
-        if (!plan.getUser().getUserId().equals(userId)) {
-            throw new CustomException(ErrorCode.PLAN_NOT_FOUND);
-        }
-        return plan;
     }
 
     private Recipient findOwnedRecipient(Long planId, Long assigneeId) {

--- a/src/main/java/com/mamoki/ieojuda/domain/releasecase/service/ReleaseStatusService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/releasecase/service/ReleaseStatusService.java
@@ -1,7 +1,7 @@
 package com.mamoki.ieojuda.domain.releasecase.service;
 
 import com.mamoki.ieojuda.domain.plan.entity.Plan;
-import com.mamoki.ieojuda.domain.plan.repository.PlanRepository;
+import com.mamoki.ieojuda.domain.plan.service.PlanOwnershipReader;
 import com.mamoki.ieojuda.domain.releasecase.dto.ReleaseStatusResponse;
 import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCase;
 import com.mamoki.ieojuda.domain.releasecase.repository.ReleaseCaseRepository;
@@ -17,11 +17,11 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class ReleaseStatusService {
 
-    private final PlanRepository planRepository;
+    private final PlanOwnershipReader planOwnershipReader;
     private final ReleaseCaseRepository releaseCaseRepository;
 
     public ReleaseStatusResponse getStatus(Long userId, Long planId) {
-        Plan plan = findOwnedPlan(userId, planId);
+        Plan plan = planOwnershipReader.findOwnedPlan(userId, planId);
         ReleaseCase releaseCase = releaseCaseRepository.findFirstByPlan_PlanIdOrderByCaseIdDesc(plan.getPlanId()).orElse(null);
         return ReleaseStatusResponse.of(releaseCase);
     }
@@ -29,21 +29,11 @@ public class ReleaseStatusService {
     // "살아계신가요? 지금 멈출 수 있어요" - 본인 확인 후 절차 전체를 즉시 취소
     @Transactional
     public ReleaseStatusResponse cancel(Long userId, Long planId) {
-        Plan plan = findOwnedPlan(userId, planId);
+        Plan plan = planOwnershipReader.findOwnedPlan(userId, planId);
         ReleaseCase releaseCase = releaseCaseRepository.findFirstByPlan_PlanIdOrderByCaseIdDesc(plan.getPlanId())
                 .orElseThrow(() -> new CustomException(ErrorCode.RELEASE_CASE_NOT_FOUND));
 
         releaseCase.cancel();
         return ReleaseStatusResponse.of(releaseCase);
-    }
-
-    // 로그인한 사용자가 자신의 계획만 조회할 수 있도록 검증 (불일치 시 존재 노출 방지를 위해 NOT_FOUND로 응답)
-    private Plan findOwnedPlan(Long userId, Long planId) {
-        Plan plan = planRepository.findById(planId)
-                .orElseThrow(() -> new CustomException(ErrorCode.PLAN_NOT_FOUND));
-        if (!plan.getUser().getUserId().equals(userId)) {
-            throw new CustomException(ErrorCode.PLAN_NOT_FOUND);
-        }
-        return plan;
     }
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/rolecheck/service/RoleCheckService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/rolecheck/service/RoleCheckService.java
@@ -2,13 +2,10 @@ package com.mamoki.ieojuda.domain.rolecheck.service;
 
 import com.mamoki.ieojuda.domain.confirmer.entity.Confirmer;
 import com.mamoki.ieojuda.domain.confirmer.repository.ConfirmerRepository;
-import com.mamoki.ieojuda.domain.plan.entity.Plan;
-import com.mamoki.ieojuda.domain.plan.repository.PlanRepository;
+import com.mamoki.ieojuda.domain.plan.service.PlanOwnershipReader;
 import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
 import com.mamoki.ieojuda.domain.recipient.repository.RecipientRepository;
 import com.mamoki.ieojuda.domain.rolecheck.dto.RoleCheckSummaryResponse;
-import com.mamoki.ieojuda.global.exception.CustomException;
-import com.mamoki.ieojuda.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,12 +19,12 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class RoleCheckService {
 
-    private final PlanRepository planRepository;
+    private final PlanOwnershipReader planOwnershipReader;
     private final RecipientRepository recipientRepository;
     private final ConfirmerRepository confirmerRepository;
 
     public List<RoleCheckSummaryResponse> getRoleChecks(Long userId, Long planId) {
-        findOwnedPlan(userId, planId);
+        planOwnershipReader.findOwnedPlan(userId, planId);
 
         List<RoleCheckSummaryResponse> results = new ArrayList<>();
         for (Recipient recipient : recipientRepository.findByPlan_PlanIdAndIsBackupFalseOrderByAssigneeIdAsc(planId)) {
@@ -37,15 +34,5 @@ public class RoleCheckService {
             results.add(RoleCheckSummaryResponse.from(confirmer));
         }
         return results;
-    }
-
-    // 로그인한 사용자가 자신의 계획만 조회할 수 있도록 검증 (불일치 시 존재 노출 방지를 위해 NOT_FOUND로 응답)
-    private Plan findOwnedPlan(Long userId, Long planId) {
-        Plan plan = planRepository.findById(planId)
-                .orElseThrow(() -> new CustomException(ErrorCode.PLAN_NOT_FOUND));
-        if (!plan.getUser().getUserId().equals(userId)) {
-            throw new CustomException(ErrorCode.PLAN_NOT_FOUND);
-        }
-        return plan;
     }
 }

--- a/src/test/java/com/mamoki/ieojuda/domain/confirmer/service/DisputeContactServiceBolaTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/confirmer/service/DisputeContactServiceBolaTest.java
@@ -1,0 +1,71 @@
+package com.mamoki.ieojuda.domain.confirmer.service;
+
+import com.mamoki.ieojuda.domain.confirmer.dto.DisputeContactRegisterRequest;
+import com.mamoki.ieojuda.domain.confirmer.repository.DisputeContactRepository;
+import com.mamoki.ieojuda.domain.plan.repository.PlanRepository;
+import com.mamoki.ieojuda.domain.plan.service.PlanOwnershipReader;
+import com.mamoki.ieojuda.global.config.AppProperties;
+import com.mamoki.ieojuda.global.email.sender.EmailSender;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+// 사용자 B가 사용자 A의 planId에 이의 제기 연락처를 등록/수정하려 하면 PLAN_NOT_FOUND로 막혀야 한다.
+// 통과시키면 공격자가 스스로를 피해자 계획의 이의 제기 연락처로 등록해 발송 거부권을 얻으므로, disputeContactRepository/emailSender에
+// 전혀 손대지 않는지가 특히 중요하다.
+class DisputeContactServiceBolaTest {
+
+    private static final Long ATTACKER_ID = 2L;
+    private static final Long PLAN_ID = 10L;
+    private static final Long CONTACT_ID = 100L;
+
+    private PlanRepository planRepository;
+    private DisputeContactRepository disputeContactRepository;
+    private EmailSender emailSender;
+    private DisputeContactService disputeContactService;
+
+    @BeforeEach
+    void setUp() {
+        planRepository = mock(PlanRepository.class);
+        disputeContactRepository = mock(DisputeContactRepository.class);
+        emailSender = mock(EmailSender.class);
+        disputeContactService = new DisputeContactService(
+                new PlanOwnershipReader(planRepository),
+                disputeContactRepository,
+                emailSender,
+                mock(AppProperties.class)
+        );
+        when(planRepository.findByPlanIdAndUser_UserId(PLAN_ID, ATTACKER_ID)).thenReturn(Optional.empty());
+    }
+
+    @Test
+    void registerRejectsNonOwnerAndDoesNotRegisterAContact() {
+        DisputeContactRegisterRequest request = new DisputeContactRegisterRequest("공격자", "attacker@example.com");
+
+        assertThatThrownBy(() -> disputeContactService.register(ATTACKER_ID, PLAN_ID, request))
+                .isInstanceOfSatisfying(CustomException.class,
+                        exception -> assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.PLAN_NOT_FOUND));
+        verifyNoInteractions(disputeContactRepository);
+        verifyNoInteractions(emailSender);
+    }
+
+    @Test
+    void updateRejectsNonOwnerAndDoesNotTouchTheContact() {
+        DisputeContactRegisterRequest request = new DisputeContactRegisterRequest("공격자", "attacker@example.com");
+
+        assertThatThrownBy(() -> disputeContactService.update(ATTACKER_ID, PLAN_ID, CONTACT_ID, request))
+                .isInstanceOfSatisfying(CustomException.class,
+                        exception -> assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.PLAN_NOT_FOUND));
+        verifyNoInteractions(disputeContactRepository);
+        verifyNoInteractions(emailSender);
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/domain/plan/service/ConversationServiceBolaTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/plan/service/ConversationServiceBolaTest.java
@@ -1,0 +1,83 @@
+package com.mamoki.ieojuda.domain.plan.service;
+
+import com.mamoki.ieojuda.domain.plan.repository.ConversationRepository;
+import com.mamoki.ieojuda.domain.plan.repository.ItemRepository;
+import com.mamoki.ieojuda.domain.plan.repository.LifeAreaMessageRepository;
+import com.mamoki.ieojuda.domain.plan.repository.LifeAreaRepository;
+import com.mamoki.ieojuda.domain.plan.repository.PlanRepository;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import com.mamoki.ieojuda.global.openai.component.OpenAIClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+// 사용자 B가 사용자 A의 planId로 대화 세션 시작/이력조회/발화전송을 시도하면 PLAN_NOT_FOUND로 막혀야 한다.
+// 특히 sendMessage는 성공 시 OpenAI 호출 + 항목 삭제/생성이라는 부수효과가 크므로, 거부됐을 때 그 부수효과가 전혀 없어야 한다.
+class ConversationServiceBolaTest {
+
+    private static final Long OWNER_ID = 1L;
+    private static final Long ATTACKER_ID = 2L;
+    private static final Long PLAN_ID = 10L;
+    private static final Long CONVERSATION_ID = 100L;
+
+    private PlanRepository planRepository;
+    private ConversationRepository conversationRepository;
+    private ItemRepository itemRepository;
+    private OpenAIClient openAIClient;
+    private ConversationService conversationService;
+
+    @BeforeEach
+    void setUp() {
+        planRepository = mock(PlanRepository.class);
+        conversationRepository = mock(ConversationRepository.class);
+        itemRepository = mock(ItemRepository.class);
+        openAIClient = mock(OpenAIClient.class);
+        conversationService = new ConversationService(
+                new PlanOwnershipReader(planRepository),
+                conversationRepository,
+                mock(LifeAreaMessageRepository.class),
+                mock(LifeAreaRepository.class),
+                itemRepository,
+                openAIClient,
+                mock(ObjectMapper.class)
+        );
+        when(planRepository.findByPlanIdAndUser_UserId(PLAN_ID, ATTACKER_ID)).thenReturn(Optional.empty());
+    }
+
+    @Test
+    void startConversationRejectsNonOwnerAndDoesNotCreateASession() {
+        assertThatThrownBy(() -> conversationService.startConversation(ATTACKER_ID, PLAN_ID))
+                .isInstanceOfSatisfying(CustomException.class,
+                        exception -> assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.PLAN_NOT_FOUND));
+        verifyNoInteractions(conversationRepository);
+    }
+
+    @Test
+    void getHistoryRejectsNonOwnerBeforeLookingUpTheConversation() {
+        assertThatThrownBy(() -> conversationService.getHistory(
+                ATTACKER_ID, PLAN_ID, CONVERSATION_ID, PageRequest.of(0, 20)))
+                .isInstanceOfSatisfying(CustomException.class,
+                        exception -> assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.PLAN_NOT_FOUND));
+        verifyNoInteractions(conversationRepository);
+    }
+
+    @Test
+    void sendMessageRejectsNonOwnerAndNeverCallsOpenAiOrDeletesItems() {
+        assertThatThrownBy(() -> conversationService.sendMessage(ATTACKER_ID, PLAN_ID, CONVERSATION_ID, "안녕하세요"))
+                .isInstanceOfSatisfying(CustomException.class,
+                        exception -> assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.PLAN_NOT_FOUND));
+        verifyNoInteractions(conversationRepository);
+        verifyNoInteractions(openAIClient);
+        verifyNoInteractions(itemRepository);
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/domain/plan/service/ItemReviewServiceBolaTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/plan/service/ItemReviewServiceBolaTest.java
@@ -1,0 +1,75 @@
+package com.mamoki.ieojuda.domain.plan.service;
+
+import com.mamoki.ieojuda.domain.plan.dto.ItemReviewRequest;
+import com.mamoki.ieojuda.domain.plan.dto.ItemUpdateRequest;
+import com.mamoki.ieojuda.domain.plan.repository.ItemRepository;
+import com.mamoki.ieojuda.domain.plan.repository.PlanRepository;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+// 사용자 B가 사용자 A의 planId로 항목 조회/승인/수정/삭제를 시도하면 PLAN_NOT_FOUND로 막혀야 한다.
+// delete는 실제 삭제(파괴적)이므로, 거부됐을 때 itemRepository에 전혀 손대지 않는지가 특히 중요하다.
+class ItemReviewServiceBolaTest {
+
+    private static final Long OWNER_ID = 1L;
+    private static final Long ATTACKER_ID = 2L;
+    private static final Long PLAN_ID = 10L;
+    private static final Long ITEM_ID = 100L;
+
+    private PlanRepository planRepository;
+    private ItemRepository itemRepository;
+    private ItemReviewService itemReviewService;
+
+    @BeforeEach
+    void setUp() {
+        planRepository = mock(PlanRepository.class);
+        itemRepository = mock(ItemRepository.class);
+        itemReviewService = new ItemReviewService(itemRepository, new PlanOwnershipReader(planRepository));
+        when(planRepository.findByPlanIdAndUser_UserId(PLAN_ID, ATTACKER_ID)).thenReturn(Optional.empty());
+    }
+
+    @Test
+    void getItemRejectsNonOwnerAndDoesNotTouchItemRepository() {
+        assertThatThrownBy(() -> itemReviewService.getItem(ATTACKER_ID, PLAN_ID, ITEM_ID))
+                .isInstanceOfSatisfying(CustomException.class,
+                        exception -> assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.PLAN_NOT_FOUND));
+        verifyNoInteractions(itemRepository);
+    }
+
+    @Test
+    void approveRejectsNonOwnerAndDoesNotTouchItemRepository() {
+        assertThatThrownBy(() -> itemReviewService.approve(ATTACKER_ID, PLAN_ID, new ItemReviewRequest(ITEM_ID)))
+                .isInstanceOfSatisfying(CustomException.class,
+                        exception -> assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.PLAN_NOT_FOUND));
+        verifyNoInteractions(itemRepository);
+    }
+
+    @Test
+    void updateRejectsNonOwnerAndDoesNotTouchItemRepository() {
+        ItemUpdateRequest request = new ItemUpdateRequest(
+                "대상", "위치", "행동", "제목", "내용", null, "FAMILY", "OTHER");
+
+        assertThatThrownBy(() -> itemReviewService.update(ATTACKER_ID, PLAN_ID, ITEM_ID, request))
+                .isInstanceOfSatisfying(CustomException.class,
+                        exception -> assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.PLAN_NOT_FOUND));
+        verifyNoInteractions(itemRepository);
+    }
+
+    @Test
+    void deleteRejectsNonOwnerAndNeverDeletesTheItem() {
+        assertThatThrownBy(() -> itemReviewService.delete(ATTACKER_ID, PLAN_ID, ITEM_ID))
+                .isInstanceOfSatisfying(CustomException.class,
+                        exception -> assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.PLAN_NOT_FOUND));
+        verifyNoInteractions(itemRepository);
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/domain/plan/service/LifeAreaServiceBolaTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/plan/service/LifeAreaServiceBolaTest.java
@@ -1,0 +1,54 @@
+package com.mamoki.ieojuda.domain.plan.service;
+
+import com.mamoki.ieojuda.domain.plan.repository.ItemRepository;
+import com.mamoki.ieojuda.domain.plan.repository.PlanRepository;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+// 사용자 B가 사용자 A의 planId로 삶의 구역별 항목 조회를 시도하면 PLAN_NOT_FOUND로 막혀야 한다
+class LifeAreaServiceBolaTest {
+
+    private static final Long OWNER_ID = 1L;
+    private static final Long ATTACKER_ID = 2L;
+    private static final Long PLAN_ID = 10L;
+
+    private PlanRepository planRepository;
+    private ItemRepository itemRepository;
+    private LifeAreaService lifeAreaService;
+
+    @BeforeEach
+    void setUp() {
+        planRepository = mock(PlanRepository.class);
+        itemRepository = mock(ItemRepository.class);
+        lifeAreaService = new LifeAreaService(itemRepository, new PlanOwnershipReader(planRepository));
+        when(planRepository.findByPlanIdAndUser_UserId(PLAN_ID, ATTACKER_ID)).thenReturn(Optional.empty());
+    }
+
+    @Test
+    void getLifeAreasRejectsNonOwnerAndDoesNotDumpItems() {
+        assertThatThrownBy(() -> lifeAreaService.getLifeAreas(ATTACKER_ID, PLAN_ID))
+                .isInstanceOfSatisfying(CustomException.class,
+                        exception -> assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.PLAN_NOT_FOUND));
+        verifyNoInteractions(itemRepository);
+    }
+
+    @Test
+    void getLifeAreasReturnsItemsForTheOwner() {
+        when(planRepository.findByPlanIdAndUser_UserId(PLAN_ID, OWNER_ID))
+                .thenReturn(Optional.of(mock(com.mamoki.ieojuda.domain.plan.entity.Plan.class)));
+        when(itemRepository.findByLifeArea_Plan_PlanIdOrderByItemIdAsc(PLAN_ID)).thenReturn(List.of());
+
+        assertThat(lifeAreaService.getLifeAreas(OWNER_ID, PLAN_ID)).isNotEmpty();
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/domain/plan/service/PlanOwnershipReaderTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/plan/service/PlanOwnershipReaderTest.java
@@ -1,0 +1,60 @@
+package com.mamoki.ieojuda.domain.plan.service;
+
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.plan.repository.PlanRepository;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class PlanOwnershipReaderTest {
+
+    private static final Long OWNER_ID = 1L;
+    private static final Long OTHER_USER_ID = 2L;
+    private static final Long PLAN_ID = 10L;
+
+    private PlanRepository planRepository;
+    private PlanOwnershipReader planOwnershipReader;
+
+    @BeforeEach
+    void setUp() {
+        planRepository = mock(PlanRepository.class);
+        planOwnershipReader = new PlanOwnershipReader(planRepository);
+    }
+
+    @Test
+    void returnsThePlanWhenTheCallerIsTheOwner() {
+        Plan plan = mock(Plan.class);
+        when(planRepository.findByPlanIdAndUser_UserId(PLAN_ID, OWNER_ID)).thenReturn(Optional.of(plan));
+
+        Plan result = planOwnershipReader.findOwnedPlan(OWNER_ID, PLAN_ID);
+
+        assertThat(result).isSameAs(plan);
+    }
+
+    @Test
+    void throwsPlanNotFoundWhenTheCallerIsNotTheOwner() {
+        when(planRepository.findByPlanIdAndUser_UserId(PLAN_ID, OTHER_USER_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> planOwnershipReader.findOwnedPlan(OTHER_USER_ID, PLAN_ID))
+                .isInstanceOfSatisfying(CustomException.class,
+                        exception -> assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.PLAN_NOT_FOUND));
+    }
+
+    @Test
+    void throwsTheSamePlanNotFoundWhenThePlanDoesNotExistAtAll() {
+        when(planRepository.findByPlanIdAndUser_UserId(999L, OWNER_ID)).thenReturn(Optional.empty());
+
+        // 존재하지 않는 planId와 타인 소유 planId가 같은 예외를 던져야 존재 여부가 노출되지 않는다
+        assertThatThrownBy(() -> planOwnershipReader.findOwnedPlan(OWNER_ID, 999L))
+                .isInstanceOfSatisfying(CustomException.class,
+                        exception -> assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.PLAN_NOT_FOUND));
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/domain/plan/service/PlanServiceBolaTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/plan/service/PlanServiceBolaTest.java
@@ -1,0 +1,100 @@
+package com.mamoki.ieojuda.domain.plan.service;
+
+import com.mamoki.ieojuda.domain.confirmer.repository.DisputeContactRepository;
+import com.mamoki.ieojuda.domain.plan.dto.ReleasePolicyRequest;
+import com.mamoki.ieojuda.domain.plan.dto.SelfWarningEmailRequest;
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.plan.entity.PlanStatus;
+import com.mamoki.ieojuda.domain.plan.repository.PlanRepository;
+import com.mamoki.ieojuda.global.config.AppProperties;
+import com.mamoki.ieojuda.global.email.sender.EmailSender;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+// 사용자 B가 사용자 A의 planId로 PlanController/PlanService 엔드포인트를 호출하면
+// 전부 PLAN_NOT_FOUND(404)로 막혀야 한다는 수평 권한 상승(BOLA) 회귀 테스트
+class PlanServiceBolaTest {
+
+    private static final Long OWNER_ID = 1L;
+    private static final Long ATTACKER_ID = 2L;
+    private static final Long PLAN_ID = 10L;
+
+    private PlanRepository planRepository;
+    private DisputeContactRepository disputeContactRepository;
+    private EmailSender emailSender;
+    private PlanService planService;
+
+    @BeforeEach
+    void setUp() {
+        planRepository = mock(PlanRepository.class);
+        disputeContactRepository = mock(DisputeContactRepository.class);
+        emailSender = mock(EmailSender.class);
+        planService = new PlanService(
+                planRepository,
+                new PlanOwnershipReader(planRepository),
+                disputeContactRepository,
+                emailSender,
+                mock(AppProperties.class)
+        );
+        // 사용자 A의 계획만 존재한다 - 사용자 B(공격자)로 조회하면 항상 빈 Optional
+        when(planRepository.findByPlanIdAndUser_UserId(PLAN_ID, ATTACKER_ID)).thenReturn(Optional.empty());
+    }
+
+    @Test
+    void getPlanRejectsNonOwner() {
+        assertThatThrownBy(() -> planService.getPlan(ATTACKER_ID, PLAN_ID))
+                .isInstanceOfSatisfying(CustomException.class,
+                        exception -> assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.PLAN_NOT_FOUND));
+    }
+
+    @Test
+    void deactivateRejectsNonOwner() {
+        assertThatThrownBy(() -> planService.deactivate(ATTACKER_ID, PLAN_ID))
+                .isInstanceOfSatisfying(CustomException.class,
+                        exception -> assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.PLAN_NOT_FOUND));
+    }
+
+    @Test
+    void getReleaseSettingsRejectsNonOwnerAndDoesNotLeakDisputeContact() {
+        assertThatThrownBy(() -> planService.getReleaseSettings(ATTACKER_ID, PLAN_ID))
+                .isInstanceOfSatisfying(CustomException.class,
+                        exception -> assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.PLAN_NOT_FOUND));
+        verifyNoInteractions(disputeContactRepository);
+    }
+
+    @Test
+    void updateReleasePolicyRejectsNonOwnerEvenWithAValidWaitingDaysValue() {
+        // 소유자였다면 통과했을 유효한 값(14일)이어도, 소유자 검증이 범위 검증보다 먼저 막아야 한다
+        assertThatThrownBy(() -> planService.updateReleasePolicy(ATTACKER_ID, PLAN_ID, new ReleasePolicyRequest(14)))
+                .isInstanceOfSatisfying(CustomException.class,
+                        exception -> assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.PLAN_NOT_FOUND));
+    }
+
+    @Test
+    void requestSelfWarningEmailVerificationRejectsNonOwnerAndDoesNotSendEmail() {
+        assertThatThrownBy(() -> planService.requestSelfWarningEmailVerification(
+                ATTACKER_ID, PLAN_ID, new SelfWarningEmailRequest("attacker@example.com")))
+                .isInstanceOfSatisfying(CustomException.class,
+                        exception -> assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.PLAN_NOT_FOUND));
+        verifyNoInteractions(emailSender);
+    }
+
+    @Test
+    void getPlanReturnsThePlanForItsOwner() {
+        Plan plan = mock(Plan.class);
+        when(plan.getStatus()).thenReturn(PlanStatus.DRAFT);
+        when(planRepository.findByPlanIdAndUser_UserId(PLAN_ID, OWNER_ID)).thenReturn(Optional.of(plan));
+
+        assertThat(planService.getPlan(OWNER_ID, PLAN_ID)).isNotNull();
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/domain/plan/service/PlanServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/plan/service/PlanServiceTest.java
@@ -29,6 +29,9 @@ import static org.mockito.Mockito.when;
 
 class PlanServiceTest {
 
+    private static final Long USER_ID = 1L;
+    private static final Long PLAN_ID = 1L;
+
     private PlanRepository planRepository;
     private Plan plan;
     private PlanService planService;
@@ -40,6 +43,7 @@ class PlanServiceTest {
         plan = mock(Plan.class);
         planService = new PlanService(
                 planRepository,
+                new PlanOwnershipReader(planRepository),
                 mock(DisputeContactRepository.class),
                 mock(EmailSender.class),
                 mock(AppProperties.class)
@@ -50,9 +54,9 @@ class PlanServiceTest {
     @ParameterizedTest
     @MethodSource("validWaitingDays")
     void updateReleasePolicyAcceptsEveryDayWithinRange(int waitingDays) {
-        when(planRepository.findById(1L)).thenReturn(Optional.of(plan));
+        when(planRepository.findByPlanIdAndUser_UserId(PLAN_ID, USER_ID)).thenReturn(Optional.of(plan));
 
-        planService.updateReleasePolicy(1L, new ReleasePolicyRequest(waitingDays));
+        planService.updateReleasePolicy(USER_ID, PLAN_ID, new ReleasePolicyRequest(waitingDays));
 
         verify(plan).updateWaitingDays(waitingDays);
     }
@@ -73,10 +77,12 @@ class PlanServiceTest {
     }
 
     private void assertInvalidWaitingDays(Integer waitingDays) {
-        assertThatThrownBy(() -> planService.updateReleasePolicy(1L, new ReleasePolicyRequest(waitingDays)))
+        when(planRepository.findByPlanIdAndUser_UserId(PLAN_ID, USER_ID)).thenReturn(Optional.of(plan));
+
+        assertThatThrownBy(() -> planService.updateReleasePolicy(USER_ID, PLAN_ID, new ReleasePolicyRequest(waitingDays)))
                 .isInstanceOfSatisfying(CustomException.class,
                         exception -> assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INVALID_WAITING_PERIOD));
-        verifyNoInteractions(planRepository);
+        verify(plan, org.mockito.Mockito.never()).updateWaitingDays(org.mockito.ArgumentMatchers.any());
     }
 
     @Test


### PR DESCRIPTION
## 연관 Issue

- Closes #40 

## 요약
인증된 사용자가 타인의 `planId`를 추측/입력해 계획과 하위 자원(삶의 구역, 대화, 항목 검토, 대기·이의제기 설정)에 접근·변경할 수 있던 BOLA/IDOR 취약점을  제거했습니다.

## 변경 사항

- `PlanRepository`에 소유자 조건이 포함된 조회(`findByPlanIdAndUser_UserId`) 추가, 소유권 검증을 담당하는 공용 컴포넌트 `PlanOwnershipReader` 도입            
- 이미 소유권 검사가 있던 6개 서비스(`ItemOrderService`, `RecipientService`, `ConfirmerService`, `HandoffCheckService`, `ReleaseStatusService`,               
  `RoleCheckService`)의 중복 코드를 `PlanOwnershipReader`로 통합                                                                                                
- 소유권 검사가 없던 5개 서비스(`PlanService`, `LifeAreaService`, `ConversationService`, `ItemReviewService`, `DisputeContactService`)와 해당 컨트롤러 5개에  
  인증 사용자 ID 전달 및 소유자 검증 추가                                                                                                                       
- `PlanService.updateReleasePolicy`는 소유권 검증을 입력값 범위 검증보다 먼저 수행하도록 순서 조정(타인 planId + 잘못된 값 조합으로 계획 존재 여부가 노출되는 
  것 방지)                                                                                                                                                      
- 타인의 객체에 접근 시 일관되게 `404 PLAN_NOT_FOUND` 반환하도록 통일                                                                                         
- 수평 권한 상승(BOLA) 회귀 테스트 20건 추가

## 범위

### 포함

- 계획·삶의 구역·항목 검토·대화·순서·이의 제기 연락처 API의 객체 소유권 검사
- 인증 사용자 ID를 서비스 계층까지 전달하고 소유자 조건을 포함한 조회 적용
- 타인 객체 접근 시 일관된 `404 Not F

### 제외
- 화면 UI 변경

## 스크린샷 / 미리 보기
<img width="1420" height="654" alt="image" src="https://github.com/user-attachments/assets/a31bf5ed-24f4-4739-a5b5-01ab65b13281" />
-B 토큰으로 A 소유 `GET /api/plans/2/items/3` 요청 시 `404 PLAN_NOT_FOUND` 반환 확인