### PR TITLE
[Fix/#55]: 인증 및 공개 링크 요청 제한 강화

### DIFF
--- a/src/main/java/com/mamoki/ieojuda/domain/account/dto/SignupRequest.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/account/dto/SignupRequest.java
@@ -3,13 +3,15 @@ package com.mamoki.ieojuda.domain.account.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public record SignupRequest(
         @Schema(description = "이메일", example = "user@example.com")
         @NotBlank(message = "이메일을 입력해 주세요.") @Email(message = "이메일 형식이 올바르지 않습니다.") String email,
 
         @Schema(description = "비밀번호", example = "password1234")
-        @NotBlank(message = "비밀번호를 입력해 주세요.") String password,
+        @NotBlank(message = "비밀번호를 입력해 주세요.")
+        @Size(min = 10, max = 100, message = "비밀번호는 10자 이상이어야 합니다.") String password,
 
         @Schema(description = "비밀번호 확인", example = "password1234")
         @NotBlank(message = "비밀번호 확인을 입력해 주세요.") String passwordConfirm,

--- a/src/main/java/com/mamoki/ieojuda/domain/account/service/AuthService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/account/service/AuthService.java
@@ -7,11 +7,15 @@ import com.mamoki.ieojuda.domain.account.dto.SignupResponse;
 import com.mamoki.ieojuda.domain.account.dto.TokenResponse;
 import com.mamoki.ieojuda.domain.account.entity.User;
 import com.mamoki.ieojuda.domain.account.repository.UserRepository;
+import com.mamoki.ieojuda.domain.audit.entity.AuthAuditEventType;
+import com.mamoki.ieojuda.domain.audit.service.AuthAuditService;
 import com.mamoki.ieojuda.domain.plan.entity.Plan;
 import com.mamoki.ieojuda.domain.plan.repository.PlanRepository;
 import com.mamoki.ieojuda.global.exception.CustomException;
 import com.mamoki.ieojuda.global.exception.ErrorCode;
 import com.mamoki.ieojuda.global.jwt.component.JwtTokenProvider;
+import com.mamoki.ieojuda.global.util.ClientIpResolver;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -27,6 +31,10 @@ public class AuthService {
     private final PlanRepository planRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
+    private final PasswordBreachChecker passwordBreachChecker;
+    private final LoginAttemptService loginAttemptService;
+    private final AuthAuditService authAuditService;
+    private final HttpServletRequest httpServletRequest;
 
     @Transactional
     public SignupResponse signup(SignupRequest request) {
@@ -35,6 +43,10 @@ public class AuthService {
         }
         if (userRepository.existsByEmail(request.email())) {
             throw new CustomException(ErrorCode.DUPLICATE_EMAIL);
+        }
+        // "유출 비밀번호 검사"(issue #55) - 평문은 절대 밖으로 나가지 않고 해시 앞 5자리로만 조회한다
+        if (passwordBreachChecker.isBreached(request.password())) {
+            throw new CustomException(ErrorCode.BREACHED_PASSWORD);
         }
 
         User user = userRepository.save(User.builder()
@@ -51,14 +63,24 @@ public class AuthService {
 
     @Transactional
     public TokenResponse login(LoginRequest request) {
-        // 계정 존재 여부가 드러나지 않도록 이메일 불일치/비밀번호 불일치 둘 다 같은 에러코드로 응답
-        User user = userRepository.findByEmail(request.email())
-                .orElseThrow(() -> new CustomException(ErrorCode.INVALID_CREDENTIALS));
+        String normalizedEmail = request.email().trim().toLowerCase();
+        String ip = ClientIpResolver.resolve(httpServletRequest);
 
-        if (!passwordEncoder.matches(request.password(), user.getPassword())) {
+        if (loginAttemptService.isLocked(normalizedEmail)) {
+            authAuditService.record(normalizedEmail, ip, AuthAuditEventType.LOGIN_LOCKED_ATTEMPT, null);
+            throw new CustomException(ErrorCode.ACCOUNT_TEMPORARILY_LOCKED);
+        }
+
+        // 계정 존재 여부가 드러나지 않도록 이메일 불일치/비밀번호 불일치 둘 다 같은 에러코드로 응답
+        User user = userRepository.findByEmail(request.email()).orElse(null);
+        if (user == null || !passwordEncoder.matches(request.password(), user.getPassword())) {
+            boolean nowLocked = loginAttemptService.recordFailure(normalizedEmail);
+            authAuditService.record(normalizedEmail, ip,
+                    nowLocked ? AuthAuditEventType.LOGIN_LOCKED : AuthAuditEventType.LOGIN_FAILURE, null);
             throw new CustomException(ErrorCode.INVALID_CREDENTIALS);
         }
 
+        loginAttemptService.recordSuccess(normalizedEmail);
         return issueTokens(user);
     }
 

--- a/src/main/java/com/mamoki/ieojuda/domain/account/service/LoginAttemptService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/account/service/LoginAttemptService.java
@@ -1,0 +1,57 @@
+package com.mamoki.ieojuda.domain.account.service;
+
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+// issue #55 - 계정(이메일) 단위 로그인 실패 추적 및 잠금. IP 단위 제한은 RateLimitFilter가 별도로 담당한다.
+// 단일 인스턴스 배포를 전제로 메모리에 상태를 둔다(Redis 등 세션 저장소 도입은 이슈 범위 밖).
+@Component
+public class LoginAttemptService {
+
+    private static final int MAX_FAILURES = 5;
+    private static final Duration FAILURE_WINDOW = Duration.ofMinutes(15);
+    private static final Duration LOCK_DURATION = Duration.ofMinutes(15);
+
+    private final Map<String, Attempt> attempts = new ConcurrentHashMap<>();
+
+    public boolean isLocked(String key) {
+        Attempt attempt = attempts.get(key);
+        if (attempt == null) {
+            return false;
+        }
+        synchronized (attempt) {
+            return attempt.lockedUntilMs > System.currentTimeMillis();
+        }
+    }
+
+    // 반환값 - 이번 실패로 새로 잠금 상태에 진입했는지 여부(감사 로그에 LOGIN_LOCKED로 구분 기록하기 위함)
+    public boolean recordFailure(String key) {
+        Attempt attempt = attempts.computeIfAbsent(key, k -> new Attempt());
+        synchronized (attempt) {
+            long now = System.currentTimeMillis();
+            if (now - attempt.windowStartMs >= FAILURE_WINDOW.toMillis()) {
+                attempt.windowStartMs = now;
+                attempt.failureCount = 0;
+            }
+            attempt.failureCount++;
+            if (attempt.failureCount >= MAX_FAILURES) {
+                attempt.lockedUntilMs = now + LOCK_DURATION.toMillis();
+                return true;
+            }
+            return false;
+        }
+    }
+
+    public void recordSuccess(String key) {
+        attempts.remove(key);
+    }
+
+    private static final class Attempt {
+        long windowStartMs = System.currentTimeMillis();
+        int failureCount = 0;
+        long lockedUntilMs = 0;
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/account/service/PasswordBreachChecker.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/account/service/PasswordBreachChecker.java
@@ -1,0 +1,67 @@
+package com.mamoki.ieojuda.domain.account.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.util.Locale;
+
+// issue #55 "유출 비밀번호 검사" - Have I Been Pwned의 k-anonymity range API를 사용해, 평문 비밀번호는
+// 절대 네트워크로 보내지 않고 SHA-1 해시 앞 5자리만으로 유출 여부를 조회한다.
+// 외부 서비스가 불가용하면 가입 자체를 막지 않는다(fail-open) - 이 검사는 부가적인 방어선이지,
+// 회원가입의 핵심 경로를 이 외부 API 가용성에 종속시킬 정도로 중요하진 않다.
+@Slf4j
+@Component
+public class PasswordBreachChecker {
+
+    private static final String RANGE_API_URL = "https://api.pwnedpasswords.com/range/";
+
+    private final HttpClient httpClient = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(3))
+            .build();
+
+    public boolean isBreached(String plainPassword) {
+        String sha1Hex = sha1Hex(plainPassword);
+        String prefix = sha1Hex.substring(0, 5);
+        String suffix = sha1Hex.substring(5);
+
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(RANGE_API_URL + prefix))
+                    .timeout(Duration.ofSeconds(3))
+                    .GET()
+                    .build();
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() != 200) {
+                log.warn("[Password Breach Check] 예상치 못한 응답 코드={}", response.statusCode());
+                return false;
+            }
+            return response.body().lines().anyMatch(line -> line.regionMatches(true, 0, suffix, 0, suffix.length()));
+        } catch (Exception e) {
+            log.warn("[Password Breach Check] 조회 실패, 가입은 계속 진행함. cause={}", e.getMessage());
+            return false;
+        }
+    }
+
+    private String sha1Hex(String plainPassword) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-1");
+            byte[] hashBytes = digest.digest(plainPassword.getBytes(StandardCharsets.UTF_8));
+            StringBuilder sb = new StringBuilder(hashBytes.length * 2);
+            for (byte b : hashBytes) {
+                sb.append(String.format("%02x", b));
+            }
+            return sb.toString().toUpperCase(Locale.ROOT);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-1 알고리즘을 사용할 수 없습니다.", e);
+        }
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/audit/controller/AuthAuditController.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/audit/controller/AuthAuditController.java
@@ -1,0 +1,33 @@
+package com.mamoki.ieojuda.domain.audit.controller;
+
+import com.mamoki.ieojuda.domain.audit.dto.AuthAuditLogResponse;
+import com.mamoki.ieojuda.domain.audit.service.AuthAuditService;
+import com.mamoki.ieojuda.global.rsdata.RsData;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+// issue #55 "인증 실패 감사" 화면 - 운영관리자 전용. 로그인 실패/잠금, rate limit 초과 이력을 최신순으로 조회
+@Tag(name = "Admin - Auth Audit", description = "운영관리자 - 로그인 실패 / 잠금 / rate limit 초과 감사")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/auth-audit-logs")
+public class AuthAuditController {
+
+    private final AuthAuditService authAuditService;
+
+    @Operation(summary = "인증 실패 감사 조회", description = "로그인 실패/잠금, rate limit 초과 이력을 최신순으로 페이지 단위 조회합니다.")
+    @GetMapping
+    public ResponseEntity<RsData<Page<AuthAuditLogResponse>>> getLogs(
+            @PageableDefault(size = 50) Pageable pageable
+    ) {
+        return ResponseEntity.ok(RsData.success(authAuditService.getLogs(pageable)));
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/audit/dto/AuthAuditLogResponse.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/audit/dto/AuthAuditLogResponse.java
@@ -1,0 +1,20 @@
+package com.mamoki.ieojuda.domain.audit.dto;
+
+import com.mamoki.ieojuda.domain.audit.entity.AuthAuditEventType;
+import com.mamoki.ieojuda.domain.audit.entity.AuthAuditLog;
+
+import java.time.LocalDateTime;
+
+public record AuthAuditLogResponse(
+        Long logId,
+        String email,
+        String ipAddress,
+        AuthAuditEventType eventType,
+        String detail,
+        LocalDateTime occurredAt
+) {
+    public static AuthAuditLogResponse from(AuthAuditLog log) {
+        return new AuthAuditLogResponse(
+                log.getLogId(), log.getEmail(), log.getIpAddress(), log.getEventType(), log.getDetail(), log.getOccurredAt());
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/audit/entity/AuthAuditEventType.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/audit/entity/AuthAuditEventType.java
@@ -1,0 +1,12 @@
+package com.mamoki.ieojuda.domain.audit.entity;
+
+public enum AuthAuditEventType {
+    LOGIN_FAILURE,               // 비밀번호 불일치 등 일반 로그인 실패
+    LOGIN_LOCKED,                // 이번 실패로 계정이 잠금 상태로 전환됨
+    LOGIN_LOCKED_ATTEMPT,        // 이미 잠긴 계정에 재시도
+    RATE_LIMIT_EXCEEDED,         // 경로별 rate limit 초과
+    PUBLIC_LINK_TOKEN_FAILURE,   // 사망신고/증빙/이의제기/역할수락 등 공개 링크에서 존재하지 않는 토큰 시도
+    PUBLIC_LINK_TOKEN_LOCKED,    // 이번 실패로 해당 토큰이 잠금 상태로 전환됨
+    PUBLIC_LINK_TOKEN_LOCKED_ATTEMPT, // 이미 잠긴 토큰에 재시도
+    PUBLIC_LINK_STATE_FAILURE   // 토큰 자체는 유효하지만 만료/재사용/미검증 등 상태가 안 맞아 실패 (detail에 구체 사유 기록)
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/audit/entity/AuthAuditLog.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/audit/entity/AuthAuditLog.java
@@ -1,0 +1,55 @@
+package com.mamoki.ieojuda.domain.audit.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+// issue #55 - 고위험 인증 실패(로그인 실패/잠금, rate limit 초과)를 운영자가 추적할 수 있게 남기는 감사 로그
+@Entity
+@Table(name = "auth_audit_logs")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AuthAuditLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "log_id")
+    private Long logId;
+
+    // 시도된 이메일 - 실제 존재하는 계정이 아닐 수도 있음(존재 여부를 노출하지 않기 위해 그대로 기록만 함)
+    @Column(name = "email", length = 255)
+    private String email;
+
+    @Column(name = "ip_address", length = 64)
+    private String ipAddress;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "event_type", length = 50)
+    private AuthAuditEventType eventType;
+
+    @Column(name = "detail", length = 255)
+    private String detail;
+
+    @Column(name = "occurred_at")
+    private LocalDateTime occurredAt;
+
+    @Builder
+    public AuthAuditLog(String email, String ipAddress, AuthAuditEventType eventType, String detail) {
+        this.email = email;
+        this.ipAddress = ipAddress;
+        this.eventType = eventType;
+        this.detail = detail;
+        this.occurredAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/audit/repository/AuthAuditLogRepository.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/audit/repository/AuthAuditLogRepository.java
@@ -1,0 +1,12 @@
+package com.mamoki.ieojuda.domain.audit.repository;
+
+import com.mamoki.ieojuda.domain.audit.entity.AuthAuditLog;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AuthAuditLogRepository extends JpaRepository<AuthAuditLog, Long> {
+
+    // "인증 실패 감사" 화면 - 운영관리자가 최신순으로 조회
+    Page<AuthAuditLog> findAllByOrderByOccurredAtDesc(Pageable pageable);
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/audit/service/AuthAuditService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/audit/service/AuthAuditService.java
@@ -1,0 +1,38 @@
+package com.mamoki.ieojuda.domain.audit.service;
+
+import com.mamoki.ieojuda.domain.audit.dto.AuthAuditLogResponse;
+import com.mamoki.ieojuda.domain.audit.entity.AuthAuditEventType;
+import com.mamoki.ieojuda.domain.audit.entity.AuthAuditLog;
+import com.mamoki.ieojuda.domain.audit.repository.AuthAuditLogRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+// issue #55 - 고위험 인증 실패 감사 기록/조회.
+// record()는 호출자(AuthService.login() 등)가 이어서 예외를 던지고 롤백되는 경우가 대부분이라,
+// 그 롤백에 감사 기록까지 같이 사라지지 않도록 독립 트랜잭션(REQUIRES_NEW)으로 커밋한다.
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuthAuditService {
+
+    private final AuthAuditLogRepository authAuditLogRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void record(String email, String ipAddress, AuthAuditEventType eventType, String detail) {
+        authAuditLogRepository.save(AuthAuditLog.builder()
+                .email(email)
+                .ipAddress(ipAddress)
+                .eventType(eventType)
+                .detail(detail)
+                .build());
+    }
+
+    // "인증 실패 감사" 화면 - 운영관리자 전용
+    public Page<AuthAuditLogResponse> getLogs(Pageable pageable) {
+        return authAuditLogRepository.findAllByOrderByOccurredAtDesc(pageable).map(AuthAuditLogResponse::from);
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/confirmer/service/ConfirmerInviteService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/confirmer/service/ConfirmerInviteService.java
@@ -11,6 +11,8 @@ import com.mamoki.ieojuda.global.email.token.TokenProvider;
 import com.mamoki.ieojuda.global.email.token.TokenValidator;
 import com.mamoki.ieojuda.global.exception.CustomException;
 import com.mamoki.ieojuda.global.exception.ErrorCode;
+import com.mamoki.ieojuda.global.ratelimit.PublicLinkAuditor;
+import com.mamoki.ieojuda.global.ratelimit.TokenLookupGuard;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,6 +28,8 @@ public class ConfirmerInviteService {
 
     private final ConfirmerRepository confirmerRepository;
     private final AppProperties appProperties;
+    private final TokenLookupGuard tokenLookupGuard;
+    private final PublicLinkAuditor publicLinkAuditor;
 
     // 초대 조회 - 만료된 링크는 상태를 EXPIRED로 반영하고 차단, 이미 수락/거절한 경우는 현재 상태를 그대로 보여준다
     @Transactional
@@ -65,8 +69,8 @@ public class ConfirmerInviteService {
     }
 
     private Confirmer findByToken(String plainToken) {
-        return confirmerRepository.findByInviteToken(TokenProvider.hashToken(plainToken))
-                .orElseThrow(() -> new CustomException(ErrorCode.TOKEN_INVALID));
+        return tokenLookupGuard.resolve(plainToken,
+                () -> confirmerRepository.findByInviteToken(TokenProvider.hashToken(plainToken)));
     }
 
     private void checkNotExpired(Confirmer confirmer) {
@@ -75,6 +79,7 @@ public class ConfirmerInviteService {
                 : confirmer.getInviteTokenExpiresAt().atZone(ZoneId.systemDefault()).toInstant();
         if (TokenValidator.isExpired(expiresAt, Instant.now())) {
             confirmer.expire();
+            publicLinkAuditor.recordStateFailure(ErrorCode.ACCESS_LINK_EXPIRED);
             throw new CustomException(ErrorCode.ACCESS_LINK_EXPIRED);
         }
     }
@@ -82,6 +87,7 @@ public class ConfirmerInviteService {
     // 수락/거절은 대기 중(PENDING) 상태에서만 가능 - 이미 처리된 링크의 재사용을 차단
     private void checkPending(Confirmer confirmer) {
         if (confirmer.getAcceptanceStatus() != AcceptanceStatus.PENDING) {
+            publicLinkAuditor.recordStateFailure(ErrorCode.ACCESS_LINK_ALREADY_USED);
             throw new CustomException(ErrorCode.ACCESS_LINK_ALREADY_USED);
         }
     }

--- a/src/main/java/com/mamoki/ieojuda/domain/confirmer/service/DeathReportService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/confirmer/service/DeathReportService.java
@@ -14,6 +14,8 @@ import com.mamoki.ieojuda.domain.releasecase.repository.ReleaseCaseRepository;
 import com.mamoki.ieojuda.global.email.token.TokenProvider;
 import com.mamoki.ieojuda.global.exception.CustomException;
 import com.mamoki.ieojuda.global.exception.ErrorCode;
+import com.mamoki.ieojuda.global.ratelimit.PublicLinkAuditor;
+import com.mamoki.ieojuda.global.ratelimit.TokenLookupGuard;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,15 +35,19 @@ public class DeathReportService {
     private final ConfirmerRepository confirmerRepository;
     private final ReleaseCaseRepository releaseCaseRepository;
     private final PlanVersionRepository planVersionRepository;
+    private final TokenLookupGuard tokenLookupGuard;
+    private final PublicLinkAuditor publicLinkAuditor;
 
     @Transactional
     public DeathReportResponse report(String plainToken, DeathReportRequest request) {
         Confirmer confirmer = findByToken(plainToken);
 
         if (confirmer.getAcceptanceStatus() != AcceptanceStatus.ACCEPTED) {
+            publicLinkAuditor.recordStateFailure(ErrorCode.FORBIDDEN);
             throw new CustomException(ErrorCode.FORBIDDEN);
         }
         if (confirmer.getReportStatus() != ReportStatus.NOT_REPORTED) {
+            publicLinkAuditor.recordStateFailure(ErrorCode.ACCESS_LINK_ALREADY_USED);
             throw new CustomException(ErrorCode.ACCESS_LINK_ALREADY_USED);
         }
 
@@ -90,7 +96,7 @@ public class DeathReportService {
     }
 
     private Confirmer findByToken(String plainToken) {
-        return confirmerRepository.findByInviteToken(TokenProvider.hashToken(plainToken))
-                .orElseThrow(() -> new CustomException(ErrorCode.TOKEN_INVALID));
+        return tokenLookupGuard.resolve(plainToken,
+                () -> confirmerRepository.findByInviteToken(TokenProvider.hashToken(plainToken)));
     }
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/confirmer/service/DisputeContactService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/confirmer/service/DisputeContactService.java
@@ -15,6 +15,8 @@ import com.mamoki.ieojuda.global.email.token.TokenProvider;
 import com.mamoki.ieojuda.global.email.token.TokenValidator;
 import com.mamoki.ieojuda.global.exception.CustomException;
 import com.mamoki.ieojuda.global.exception.ErrorCode;
+import com.mamoki.ieojuda.global.ratelimit.PublicLinkAuditor;
+import com.mamoki.ieojuda.global.ratelimit.TokenLookupGuard;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,6 +35,8 @@ public class DisputeContactService {
     private final DisputeContactRepository disputeContactRepository;
     private final EmailSender emailSender;
     private final AppProperties appProperties;
+    private final TokenLookupGuard tokenLookupGuard;
+    private final PublicLinkAuditor publicLinkAuditor;
 
     @Transactional
     public DisputeContactResponse register(Long planId, DisputeContactRegisterRequest request) {
@@ -94,8 +98,8 @@ public class DisputeContactService {
     // 검증 링크 클릭 - 로그인 불필요(토큰 자체가 증명)
     @Transactional
     public void verify(String plainToken) {
-        DisputeContact contact = disputeContactRepository.findByInviteToken(TokenProvider.hashToken(plainToken))
-                .orElseThrow(() -> new CustomException(ErrorCode.TOKEN_INVALID));
+        DisputeContact contact = tokenLookupGuard.resolve(plainToken,
+                () -> disputeContactRepository.findByInviteToken(TokenProvider.hashToken(plainToken)));
 
         if (Boolean.TRUE.equals(contact.getIsVerified())) {
             return; // 이미 검증됨 - 링크 재클릭은 그냥 성공 처리
@@ -103,6 +107,7 @@ public class DisputeContactService {
 
         Instant expiresAt = contact.getInviteTokenExpiresAt().atZone(ZoneId.systemDefault()).toInstant();
         if (TokenValidator.isExpired(expiresAt, Instant.now())) {
+            publicLinkAuditor.recordStateFailure(ErrorCode.ACCESS_LINK_EXPIRED);
             throw new CustomException(ErrorCode.ACCESS_LINK_EXPIRED);
         }
 

--- a/src/main/java/com/mamoki/ieojuda/domain/evidence/service/EvidenceSubmitService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/evidence/service/EvidenceSubmitService.java
@@ -13,6 +13,8 @@ import com.mamoki.ieojuda.domain.releasecase.repository.ReleaseCaseRepository;
 import com.mamoki.ieojuda.global.email.token.TokenProvider;
 import com.mamoki.ieojuda.global.exception.CustomException;
 import com.mamoki.ieojuda.global.exception.ErrorCode;
+import com.mamoki.ieojuda.global.ratelimit.PublicLinkAuditor;
+import com.mamoki.ieojuda.global.ratelimit.TokenLookupGuard;
 import com.mamoki.ieojuda.global.storage.EvidenceStorageClient;
 import com.mamoki.ieojuda.global.storage.contract.EvidenceUpload;
 import com.mamoki.ieojuda.global.storage.contract.StoredEvidence;
@@ -38,11 +40,14 @@ public class EvidenceSubmitService {
     private final ReleaseCaseRepository releaseCaseRepository;
     private final EvidenceRepository evidenceRepository;
     private final EvidenceStorageClient evidenceStorageClient;
+    private final TokenLookupGuard tokenLookupGuard;
+    private final PublicLinkAuditor publicLinkAuditor;
 
     @Transactional
     public EvidenceSubmitResponse submit(String plainToken, MultipartFile file) {
         Confirmer confirmer = findByToken(plainToken);
         if (confirmer.getAcceptanceStatus() != AcceptanceStatus.ACCEPTED) {
+            publicLinkAuditor.recordStateFailure(ErrorCode.FORBIDDEN);
             throw new CustomException(ErrorCode.FORBIDDEN);
         }
 
@@ -96,7 +101,7 @@ public class EvidenceSubmitService {
     }
 
     private Confirmer findByToken(String plainToken) {
-        return confirmerRepository.findByInviteToken(TokenProvider.hashToken(plainToken))
-                .orElseThrow(() -> new CustomException(ErrorCode.TOKEN_INVALID));
+        return tokenLookupGuard.resolve(plainToken,
+                () -> confirmerRepository.findByInviteToken(TokenProvider.hashToken(plainToken)));
     }
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/recipient/service/RecipientInviteService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/recipient/service/RecipientInviteService.java
@@ -13,6 +13,8 @@ import com.mamoki.ieojuda.global.email.token.TokenProvider;
 import com.mamoki.ieojuda.global.email.token.TokenValidator;
 import com.mamoki.ieojuda.global.exception.CustomException;
 import com.mamoki.ieojuda.global.exception.ErrorCode;
+import com.mamoki.ieojuda.global.ratelimit.PublicLinkAuditor;
+import com.mamoki.ieojuda.global.ratelimit.TokenLookupGuard;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,6 +32,8 @@ public class RecipientInviteService {
     private final RecipientRepository recipientRepository;
     private final ItemRepository itemRepository;
     private final AppProperties appProperties;
+    private final TokenLookupGuard tokenLookupGuard;
+    private final PublicLinkAuditor publicLinkAuditor;
 
     // 초대 조회 - 만료된 링크는 상태를 EXPIRED로 반영하고 차단, 이미 수락/거절한 경우는 현재 상태를 그대로 보여준다
     @Transactional
@@ -76,8 +80,8 @@ public class RecipientInviteService {
     }
 
     private Recipient findByToken(String plainToken) {
-        return recipientRepository.findByInviteToken(TokenProvider.hashToken(plainToken))
-                .orElseThrow(() -> new CustomException(ErrorCode.TOKEN_INVALID));
+        return tokenLookupGuard.resolve(plainToken,
+                () -> recipientRepository.findByInviteToken(TokenProvider.hashToken(plainToken)));
     }
 
     private void checkNotExpired(Recipient recipient) {
@@ -86,6 +90,7 @@ public class RecipientInviteService {
                 : recipient.getInviteTokenExpiresAt().atZone(ZoneId.systemDefault()).toInstant();
         if (TokenValidator.isExpired(expiresAt, Instant.now())) {
             recipient.expire();
+            publicLinkAuditor.recordStateFailure(ErrorCode.ACCESS_LINK_EXPIRED);
             throw new CustomException(ErrorCode.ACCESS_LINK_EXPIRED);
         }
     }
@@ -93,6 +98,7 @@ public class RecipientInviteService {
     // 수락/거절은 대기 중(PENDING) 상태에서만 가능 - 이미 처리된 링크의 재사용을 차단
     private void checkPending(Recipient recipient) {
         if (recipient.getAcceptanceStatus() != AcceptanceStatus.PENDING) {
+            publicLinkAuditor.recordStateFailure(ErrorCode.ACCESS_LINK_ALREADY_USED);
             throw new CustomException(ErrorCode.ACCESS_LINK_ALREADY_USED);
         }
     }

--- a/src/main/java/com/mamoki/ieojuda/domain/releasecase/service/ObjectionService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/releasecase/service/ObjectionService.java
@@ -12,6 +12,8 @@ import com.mamoki.ieojuda.domain.releasecase.repository.ReleaseCaseRepository;
 import com.mamoki.ieojuda.global.email.token.TokenProvider;
 import com.mamoki.ieojuda.global.exception.CustomException;
 import com.mamoki.ieojuda.global.exception.ErrorCode;
+import com.mamoki.ieojuda.global.ratelimit.PublicLinkAuditor;
+import com.mamoki.ieojuda.global.ratelimit.TokenLookupGuard;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,15 +27,18 @@ public class ObjectionService {
     private final DisputeContactRepository disputeContactRepository;
     private final ReleaseCaseRepository releaseCaseRepository;
     private final ObjectionRepository objectionRepository;
+    private final TokenLookupGuard tokenLookupGuard;
+    private final PublicLinkAuditor publicLinkAuditor;
 
     // 이메일 검증까지 마친 연락처는, 이후 언제든 이 토큰으로 다시 접근해 이의를 제기할 수 있는 개인 접근키를 겸한다
     // (검증 자체에 쓰인 만료시각은 "검증 대기" 창구용이라 여기서는 별도로 검사하지 않는다)
     @Transactional
     public ObjectionResponse raise(String plainToken, ObjectionRequest request) {
-        DisputeContact contact = disputeContactRepository.findByInviteToken(TokenProvider.hashToken(plainToken))
-                .orElseThrow(() -> new CustomException(ErrorCode.TOKEN_INVALID));
+        DisputeContact contact = tokenLookupGuard.resolve(plainToken,
+                () -> disputeContactRepository.findByInviteToken(TokenProvider.hashToken(plainToken)));
 
         if (!Boolean.TRUE.equals(contact.getIsVerified())) {
+            publicLinkAuditor.recordStateFailure(ErrorCode.DISPUTE_CONTACT_NOT_VERIFIED);
             throw new CustomException(ErrorCode.DISPUTE_CONTACT_NOT_VERIFIED);
         }
 

--- a/src/main/java/com/mamoki/ieojuda/global/config/SecurityConfig.java
+++ b/src/main/java/com/mamoki/ieojuda/global/config/SecurityConfig.java
@@ -1,11 +1,15 @@
 package com.mamoki.ieojuda.global.config;
 
 import com.mamoki.ieojuda.domain.account.repository.UserRepository;
+import com.mamoki.ieojuda.domain.audit.service.AuthAuditService;
 import com.mamoki.ieojuda.global.consent.filter.ConsentCheckFilter;
 import com.mamoki.ieojuda.global.exception.ErrorCode;
 import com.mamoki.ieojuda.global.jwt.component.JwtTokenProvider;
 import com.mamoki.ieojuda.global.jwt.filter.JwtAuthenticationFilter;
 import com.mamoki.ieojuda.global.jwt.filter.SecurityErrorResponseWriter;
+import com.mamoki.ieojuda.global.ratelimit.RateLimitFilter;
+import com.mamoki.ieojuda.global.ratelimit.RateLimitRule;
+import com.mamoki.ieojuda.global.ratelimit.RateLimiter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -21,6 +25,7 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import java.time.Duration;
 import java.util.List;
 
 @Configuration
@@ -54,10 +59,28 @@ public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final UserRepository userRepository;
+    private final RateLimiter rateLimiter;
+    private final AuthAuditService authAuditService;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    // issue #55 - 경로별 rate limit 정책. 더 구체적인(민감한) 규칙을 넓은 catch-all 규칙보다 앞에 둔다.
+    private List<RateLimitRule> rateLimitRules() {
+        return List.of(
+                new RateLimitRule("signup", "/auth/signup", "POST", 5, Duration.ofHours(1)),
+                new RateLimitRule("login", "/auth/login", "POST", 10, Duration.ofMinutes(15)),
+                new RateLimitRule("refresh", "/auth/refresh", "POST", 20, Duration.ofMinutes(15)),
+                new RateLimitRule("death-report", "/api/confirmer-acceptances/*/death-report", "POST", 10, Duration.ofHours(1)),
+                new RateLimitRule("evidence-submit", "/api/confirmer-acceptances/*/evidences", "POST", 10, Duration.ofHours(1)),
+                new RateLimitRule("objection", "/api/dispute-contacts/*/objections", "POST", 10, Duration.ofHours(1)),
+                new RateLimitRule("dispute-verify", "/api/dispute-contacts/*/verify", null, 20, Duration.ofHours(1)),
+                new RateLimitRule("self-warning-email", "/api/self-warning-email/**", null, 20, Duration.ofHours(1)),
+                new RateLimitRule("confirmer-link", "/api/confirmer-acceptances/**", null, 30, Duration.ofHours(1)),
+                new RateLimitRule("recipient-link", "/api/recipient-acceptances/**", null, 30, Duration.ofHours(1))
+        );
     }
 
     // 토큰이 아예 없거나(익명) SecurityContext에 인증이 안 채워진 채로 보호된 API에 접근한 경우.
@@ -109,6 +132,7 @@ public class SecurityConfig {
                         .authenticationEntryPoint(authenticationEntryPoint())
                         .accessDeniedHandler(accessDeniedHandler()))
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new RateLimitFilter(rateLimiter, rateLimitRules(), authAuditService), JwtAuthenticationFilter.class)
                 .addFilterAfter(new ConsentCheckFilter(userRepository), JwtAuthenticationFilter.class);
 
         return http.build();

--- a/src/main/java/com/mamoki/ieojuda/global/exception/ErrorCode.java
+++ b/src/main/java/com/mamoki/ieojuda/global/exception/ErrorCode.java
@@ -10,6 +10,7 @@ public enum ErrorCode {
 
     // 회원가입 / 로그인 관련 예외 (400)
     PASSWORD_CONFIRMATION_MISMATCH(HttpStatus.BAD_REQUEST, "PASSWORD_CONFIRMATION_MISMATCH", "비밀번호와 비밀번호 확인이 일치하지 않습니다."),
+    BREACHED_PASSWORD(HttpStatus.BAD_REQUEST, "BREACHED_PASSWORD", "이미 유출된 적이 있는 비밀번호입니다. 다른 비밀번호를 사용해 주세요."),
 
     // 계획 / 삶의 구역 / AI 구조화 관련 예외 (400)
     INVALID_WAITING_PERIOD(HttpStatus.BAD_REQUEST, "INVALID_WAITING_PERIOD", "대기 기간은 7일 이상 30일 이하여야 합니다."),
@@ -48,6 +49,9 @@ public enum ErrorCode {
     ACCESS_LINK_EXPIRED(HttpStatus.UNAUTHORIZED, "ACCESS_LINK_EXPIRED", "링크가 만료되었습니다."),
     ACCESS_LINK_ALREADY_USED(HttpStatus.UNAUTHORIZED, "ACCESS_LINK_ALREADY_USED", "이미 사용되었거나 재사용할 수 없는 링크입니다."),
     OTP_VERIFICATION_FAILED(HttpStatus.UNAUTHORIZED, "OTP_VERIFICATION_FAILED", "OTP 인증에 실패했습니다."),
+    ACCOUNT_TEMPORARILY_LOCKED(HttpStatus.TOO_MANY_REQUESTS, "ACCOUNT_TEMPORARILY_LOCKED", "로그인 실패 횟수가 많아 잠시 후 다시 시도해 주세요."),
+    TOKEN_TEMPORARILY_LOCKED(HttpStatus.TOO_MANY_REQUESTS, "TOKEN_TEMPORARILY_LOCKED", "이 링크로 실패 횟수가 많아 잠시 후 다시 시도해 주세요."),
+    TOO_MANY_REQUESTS(HttpStatus.TOO_MANY_REQUESTS, "TOO_MANY_REQUESTS", "요청이 너무 많습니다. 잠시 후 다시 시도해 주세요."),
 
     // 권한 에러 (403)
     FORBIDDEN(HttpStatus.FORBIDDEN, "FORBIDDEN", "해당 리소스에 대한 권한이 없습니다."),

--- a/src/main/java/com/mamoki/ieojuda/global/ratelimit/PublicLinkAuditor.java
+++ b/src/main/java/com/mamoki/ieojuda/global/ratelimit/PublicLinkAuditor.java
@@ -1,0 +1,24 @@
+package com.mamoki.ieojuda.global.ratelimit;
+
+import com.mamoki.ieojuda.domain.audit.entity.AuthAuditEventType;
+import com.mamoki.ieojuda.domain.audit.service.AuthAuditService;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import com.mamoki.ieojuda.global.util.ClientIpResolver;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+// issue #55 - 공개 링크(사망신고/증빙/이의제기/역할 수락) 토큰은 진짜지만 상태가 안 맞아 실패하는 경우
+// (만료/재사용/미검증/미수락 등)를 감사 로그에 남긴다. 존재하지 않는 토큰 추측은 TokenLookupGuard가 별도로 담당.
+@Component
+@RequiredArgsConstructor
+public class PublicLinkAuditor {
+
+    private final AuthAuditService authAuditService;
+    private final HttpServletRequest httpServletRequest;
+
+    public void recordStateFailure(ErrorCode errorCode) {
+        authAuditService.record(null, ClientIpResolver.resolve(httpServletRequest),
+                AuthAuditEventType.PUBLIC_LINK_STATE_FAILURE, errorCode.getCode());
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/global/ratelimit/RateLimitFilter.java
+++ b/src/main/java/com/mamoki/ieojuda/global/ratelimit/RateLimitFilter.java
@@ -1,0 +1,58 @@
+package com.mamoki.ieojuda.global.ratelimit;
+
+import com.mamoki.ieojuda.domain.audit.entity.AuthAuditEventType;
+import com.mamoki.ieojuda.domain.audit.service.AuthAuditService;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import com.mamoki.ieojuda.global.jwt.filter.SecurityErrorResponseWriter;
+import com.mamoki.ieojuda.global.util.ClientIpResolver;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+// issue #55 - 로그인/회원가입/공개 토큰 링크(사망신고·증빙·이의제기 등)에 대한 경로별 rate limit.
+// JwtAuthenticationFilter보다 앞단에서 IP 기준으로 막아, 인증/토큰 검증 로직까지 갈 필요 없이 조기 차단한다.
+public class RateLimitFilter extends OncePerRequestFilter {
+
+    private final RateLimiter rateLimiter;
+    private final List<RateLimitRule> rules;
+    private final AuthAuditService authAuditService;
+    private final AntPathMatcher pathMatcher = new AntPathMatcher();
+
+    public RateLimitFilter(RateLimiter rateLimiter, List<RateLimitRule> rules, AuthAuditService authAuditService) {
+        this.rateLimiter = rateLimiter;
+        this.rules = rules;
+        this.authAuditService = authAuditService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String path = request.getServletPath();
+
+        for (RateLimitRule rule : rules) {
+            if (matches(rule, request, path)) {
+                String ip = ClientIpResolver.resolve(request);
+                String key = rule.label() + ":" + ip;
+                if (!rateLimiter.tryConsume(key, rule.limit(), rule.window())) {
+                    authAuditService.record(null, ip, AuthAuditEventType.RATE_LIMIT_EXCEEDED, rule.label() + " " + path);
+                    SecurityErrorResponseWriter.write(response, ErrorCode.TOO_MANY_REQUESTS);
+                    return;
+                }
+                break; // 가장 먼저 매치된 규칙 하나만 적용
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private boolean matches(RateLimitRule rule, HttpServletRequest request, String path) {
+        boolean methodMatches = rule.method() == null || rule.method().equalsIgnoreCase(request.getMethod());
+        return methodMatches && pathMatcher.match(rule.pattern(), path);
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/global/ratelimit/RateLimitRule.java
+++ b/src/main/java/com/mamoki/ieojuda/global/ratelimit/RateLimitRule.java
@@ -1,0 +1,8 @@
+package com.mamoki.ieojuda.global.ratelimit;
+
+import java.time.Duration;
+
+// method가 null이면 메서드 무관하게 적용. RateLimitFilter가 위에서부터 순서대로 첫 매치만 적용하므로
+// 더 구체적인(민감한) 경로를 먼저, 넓은 catch-all 경로를 나중에 등록해야 한다.
+public record RateLimitRule(String label, String pattern, String method, int limit, Duration window) {
+}

--- a/src/main/java/com/mamoki/ieojuda/global/ratelimit/RateLimiter.java
+++ b/src/main/java/com/mamoki/ieojuda/global/ratelimit/RateLimiter.java
@@ -1,0 +1,41 @@
+package com.mamoki.ieojuda.global.ratelimit;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+// 경로별 rate limit(issue #55) - 고정 윈도우 카운터. 단일 인스턴스 배포를 전제로 메모리에 상태를 둔다
+// (Redis 등 외부 세션 저장소 도입은 이슈 범위에서 명시적으로 제외됨).
+@Component
+public class RateLimiter {
+
+    private final Map<String, Counter> counters = new ConcurrentHashMap<>();
+
+    public boolean tryConsume(String key, int limit, Duration window) {
+        Counter counter = counters.computeIfAbsent(key, k -> new Counter());
+        synchronized (counter) {
+            long now = System.currentTimeMillis();
+            if (now - counter.windowStartMs >= window.toMillis()) {
+                counter.windowStartMs = now;
+                counter.count = 0;
+            }
+            counter.count++;
+            return counter.count <= limit;
+        }
+    }
+
+    // 오래된 카운터가 메모리에 계속 쌓이지 않도록 주기적으로 정리
+    @Scheduled(fixedRate = 3_600_000)
+    public void evictStaleCounters() {
+        long cutoff = System.currentTimeMillis() - Duration.ofHours(2).toMillis();
+        counters.entrySet().removeIf(entry -> entry.getValue().windowStartMs < cutoff);
+    }
+
+    private static final class Counter {
+        volatile long windowStartMs = System.currentTimeMillis();
+        int count = 0;
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/global/ratelimit/TokenAttemptService.java
+++ b/src/main/java/com/mamoki/ieojuda/global/ratelimit/TokenAttemptService.java
@@ -1,0 +1,59 @@
+package com.mamoki.ieojuda.global.ratelimit;
+
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+// issue #55 "토큰별 실패 횟수와 잠금" - 공개 링크(사망신고/증빙/이의제기/역할 수락 등)에서 특정 토큰 값으로
+// 반복 실패하면 그 토큰 자체를 잠근다. IP 기준 rate limit(RateLimitFilter)과는 다른 축 - IP를 바꿔가며
+// 시도해도 "같은 토큰 값"을 계속 틀리게 쓰는 패턴은 여기서 잡힌다.
+// LoginAttemptService와 알고리즘은 동일하지만, 계정(이메일)과 토큰은 서로 다른 키 공간이라 분리했다.
+@Component
+public class TokenAttemptService {
+
+    private static final int MAX_FAILURES = 5;
+    private static final Duration FAILURE_WINDOW = Duration.ofMinutes(15);
+    private static final Duration LOCK_DURATION = Duration.ofMinutes(15);
+
+    private final Map<String, Attempt> attempts = new ConcurrentHashMap<>();
+
+    public boolean isLocked(String token) {
+        Attempt attempt = attempts.get(token);
+        if (attempt == null) {
+            return false;
+        }
+        synchronized (attempt) {
+            return attempt.lockedUntilMs > System.currentTimeMillis();
+        }
+    }
+
+    // 반환값 - 이번 실패로 새로 잠금 상태에 진입했는지 여부
+    public boolean recordFailure(String token) {
+        Attempt attempt = attempts.computeIfAbsent(token, k -> new Attempt());
+        synchronized (attempt) {
+            long now = System.currentTimeMillis();
+            if (now - attempt.windowStartMs >= FAILURE_WINDOW.toMillis()) {
+                attempt.windowStartMs = now;
+                attempt.failureCount = 0;
+            }
+            attempt.failureCount++;
+            if (attempt.failureCount >= MAX_FAILURES) {
+                attempt.lockedUntilMs = now + LOCK_DURATION.toMillis();
+                return true;
+            }
+            return false;
+        }
+    }
+
+    public void recordSuccess(String token) {
+        attempts.remove(token);
+    }
+
+    private static final class Attempt {
+        long windowStartMs = System.currentTimeMillis();
+        int failureCount = 0;
+        long lockedUntilMs = 0;
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/global/ratelimit/TokenLookupGuard.java
+++ b/src/main/java/com/mamoki/ieojuda/global/ratelimit/TokenLookupGuard.java
@@ -1,0 +1,44 @@
+package com.mamoki.ieojuda.global.ratelimit;
+
+import com.mamoki.ieojuda.domain.audit.entity.AuthAuditEventType;
+import com.mamoki.ieojuda.domain.audit.service.AuthAuditService;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import com.mamoki.ieojuda.global.util.ClientIpResolver;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+// issue #55 - 공개 링크(사망신고/증빙/이의제기/역할 수락 등) 토큰 조회를 감싸서, 존재하지 않는 토큰이 반복
+// 시도되면 그 토큰 자체를 잠그고 감사 로그를 남긴다. 각 서비스의 findByToken()이 이 메서드로 조회를 위임한다.
+@Component
+@RequiredArgsConstructor
+public class TokenLookupGuard {
+
+    private final TokenAttemptService tokenAttemptService;
+    private final AuthAuditService authAuditService;
+    private final HttpServletRequest httpServletRequest;
+
+    public <T> T resolve(String plainToken, Supplier<Optional<T>> lookup) {
+        String ip = ClientIpResolver.resolve(httpServletRequest);
+
+        if (tokenAttemptService.isLocked(plainToken)) {
+            authAuditService.record(null, ip, AuthAuditEventType.PUBLIC_LINK_TOKEN_LOCKED_ATTEMPT, null);
+            throw new CustomException(ErrorCode.TOKEN_TEMPORARILY_LOCKED);
+        }
+
+        Optional<T> found = lookup.get();
+        if (found.isEmpty()) {
+            boolean nowLocked = tokenAttemptService.recordFailure(plainToken);
+            authAuditService.record(null, ip,
+                    nowLocked ? AuthAuditEventType.PUBLIC_LINK_TOKEN_LOCKED : AuthAuditEventType.PUBLIC_LINK_TOKEN_FAILURE, null);
+            throw new CustomException(ErrorCode.TOKEN_INVALID);
+        }
+
+        tokenAttemptService.recordSuccess(plainToken);
+        return found.get();
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/global/util/ClientIpResolver.java
+++ b/src/main/java/com/mamoki/ieojuda/global/util/ClientIpResolver.java
@@ -1,0 +1,20 @@
+package com.mamoki.ieojuda.global.util;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+// rate limit / 로그인 실패 감사 - 프록시 뒤에서 도는 배포 환경을 고려해 X-Forwarded-For를 우선 사용한다
+public class ClientIpResolver {
+
+    private static final String FORWARDED_HEADER = "X-Forwarded-For";
+
+    private ClientIpResolver() {
+    }
+
+    public static String resolve(HttpServletRequest request) {
+        String forwarded = request.getHeader(FORWARDED_HEADER);
+        if (forwarded != null && !forwarded.isBlank()) {
+            return forwarded.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/domain/account/service/LoginAttemptServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/account/service/LoginAttemptServiceTest.java
@@ -1,0 +1,59 @@
+package com.mamoki.ieojuda.domain.account.service;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+// issue #55 회귀 테스트 - 로그인 실패 5회까지는 잠기지 않다가 5번째 실패에서 잠기고,
+// 성공하면 카운터가 초기화됨을 검증한다.
+class LoginAttemptServiceTest {
+
+    private final LoginAttemptService loginAttemptService = new LoginAttemptService();
+
+    @Test
+    void staysUnlocked_untilTheFifthFailure() {
+        String key = "user1@test.com";
+
+        for (int i = 0; i < 4; i++) {
+            boolean lockedNow = loginAttemptService.recordFailure(key);
+            assertThat(lockedNow).isFalse();
+            assertThat(loginAttemptService.isLocked(key)).isFalse();
+        }
+
+        boolean lockedOnFifth = loginAttemptService.recordFailure(key);
+        assertThat(lockedOnFifth).isTrue();
+        assertThat(loginAttemptService.isLocked(key)).isTrue();
+    }
+
+    @Test
+    void successResetsTheFailureCounter() {
+        String key = "user2@test.com";
+
+        loginAttemptService.recordFailure(key);
+        loginAttemptService.recordFailure(key);
+        loginAttemptService.recordSuccess(key);
+
+        // 초기화됐으므로 다시 4번 실패해도(총 6번째지만 카운터는 리셋됨) 아직 잠기면 안 된다
+        for (int i = 0; i < 4; i++) {
+            assertThat(loginAttemptService.recordFailure(key)).isFalse();
+        }
+        assertThat(loginAttemptService.isLocked(key)).isFalse();
+    }
+
+    @Test
+    void differentAccountsAreTrackedIndependently() {
+        String keyA = "victim@test.com";
+        String keyB = "unrelated@test.com";
+
+        for (int i = 0; i < 5; i++) {
+            loginAttemptService.recordFailure(keyA);
+        }
+        assertThat(loginAttemptService.isLocked(keyA)).isTrue();
+        assertThat(loginAttemptService.isLocked(keyB)).isFalse();
+    }
+
+    @Test
+    void neverLocked_reportsUnlocked() {
+        assertThat(loginAttemptService.isLocked("never-tried@test.com")).isFalse();
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/global/ratelimit/RateLimitFilterTest.java
+++ b/src/test/java/com/mamoki/ieojuda/global/ratelimit/RateLimitFilterTest.java
@@ -1,0 +1,97 @@
+package com.mamoki.ieojuda.global.ratelimit;
+
+import com.mamoki.ieojuda.domain.audit.service.AuthAuditService;
+import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.time.Duration;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+// issue #55 회귀 테스트 - 규칙에 안 걸리는 경로는 그냥 통과하고(우회 확인), 걸리는 경로는 limit을 넘기면
+// 429로 직접 응답하며 그 뒤 필터 체인(컨트롤러)까지 가지 않음을 검증한다.
+class RateLimitFilterTest {
+
+    private RateLimiter rateLimiter;
+    private AuthAuditService authAuditService;
+    private RateLimitFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        rateLimiter = new RateLimiter();
+        authAuditService = mock(AuthAuditService.class);
+        List<RateLimitRule> rules = List.of(
+                new RateLimitRule("login", "/auth/login", "POST", 2, Duration.ofMinutes(15))
+        );
+        filter = new RateLimitFilter(rateLimiter, rules, authAuditService);
+    }
+
+    private MockHttpServletRequest request(String method, String path, String ip) {
+        MockHttpServletRequest request = new MockHttpServletRequest(method, path);
+        request.setServletPath(path);
+        request.setRemoteAddr(ip);
+        return request;
+    }
+
+    @Test
+    void pathNotMatchingAnyRule_passesThroughUntouched() throws Exception {
+        MockHttpServletRequest request = request("GET", "/api/plans/1", "1.1.1.1");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        filter.doFilter(request, response, chain);
+
+        verify(chain, times(1)).doFilter(request, response);
+        assertThat(response.getStatus()).isNotEqualTo(429);
+    }
+
+    @Test
+    void withinLimit_passesThroughToChain() throws Exception {
+        FilterChain chain = mock(FilterChain.class);
+
+        for (int i = 0; i < 2; i++) {
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            filter.doFilter(request("POST", "/auth/login", "1.2.3.4"), response, chain);
+            assertThat(response.getStatus()).isNotEqualTo(429);
+        }
+        verify(chain, times(2)).doFilter(any(), any());
+    }
+
+    @Test
+    void exceedingLimit_blocksWith429AndNeverReachesChain() throws Exception {
+        FilterChain chain = mock(FilterChain.class);
+
+        for (int i = 0; i < 2; i++) {
+            filter.doFilter(request("POST", "/auth/login", "5.6.7.8"), new MockHttpServletResponse(), chain);
+        }
+
+        MockHttpServletResponse thirdResponse = new MockHttpServletResponse();
+        filter.doFilter(request("POST", "/auth/login", "5.6.7.8"), thirdResponse, chain);
+
+        assertThat(thirdResponse.getStatus()).isEqualTo(429);
+        verify(chain, times(2)).doFilter(any(), any());
+    }
+
+    @Test
+    void differentIps_areRateLimitedIndependently() throws Exception {
+        FilterChain chain = mock(FilterChain.class);
+
+        for (int i = 0; i < 2; i++) {
+            filter.doFilter(request("POST", "/auth/login", "9.9.9.9"), new MockHttpServletResponse(), chain);
+        }
+
+        // 다른 IP는 완전히 별개 한도를 가지므로 여전히 통과해야 한다
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        filter.doFilter(request("POST", "/auth/login", "10.10.10.10"), response, chain);
+
+        assertThat(response.getStatus()).isNotEqualTo(429);
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/global/ratelimit/RateLimiterTest.java
+++ b/src/test/java/com/mamoki/ieojuda/global/ratelimit/RateLimiterTest.java
@@ -1,0 +1,60 @@
+package com.mamoki.ieojuda.global.ratelimit;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+// issue #55 회귀 테스트 - rate limiter 경계값(정확히 limit개까지는 통과, 그 다음은 차단)과
+// 서로 다른 키(다른 IP 등)는 완전히 독립적으로 계산됨을 검증한다.
+class RateLimiterTest {
+
+    private final RateLimiter rateLimiter = new RateLimiter();
+
+    @Test
+    void allowsExactlyUpToTheLimit_thenBlocksTheNextOne() {
+        String key = "test-key-1";
+        for (int i = 0; i < 3; i++) {
+            assertThat(rateLimiter.tryConsume(key, 3, Duration.ofMinutes(1))).isTrue();
+        }
+        // 4번째 요청은 limit(3)을 넘으므로 차단
+        assertThat(rateLimiter.tryConsume(key, 3, Duration.ofMinutes(1))).isFalse();
+    }
+
+    @Test
+    void differentKeysAreCompletelyIndependent() {
+        String keyA = "ip-a";
+        String keyB = "ip-b";
+
+        for (int i = 0; i < 3; i++) {
+            assertThat(rateLimiter.tryConsume(keyA, 3, Duration.ofMinutes(1))).isTrue();
+        }
+        assertThat(rateLimiter.tryConsume(keyA, 3, Duration.ofMinutes(1))).isFalse();
+
+        // keyA가 이미 소진됐어도 keyB는 완전히 별개로 3번 다 통과해야 한다
+        for (int i = 0; i < 3; i++) {
+            assertThat(rateLimiter.tryConsume(keyB, 3, Duration.ofMinutes(1))).isTrue();
+        }
+    }
+
+    @Test
+    void windowResetsAfterItExpires() throws InterruptedException {
+        String key = "test-key-reset";
+        Duration shortWindow = Duration.ofMillis(100);
+
+        assertThat(rateLimiter.tryConsume(key, 1, shortWindow)).isTrue();
+        assertThat(rateLimiter.tryConsume(key, 1, shortWindow)).isFalse();
+
+        Thread.sleep(150);
+
+        // 윈도우가 지났으므로 다시 처음부터 카운트되어 통과해야 한다
+        assertThat(rateLimiter.tryConsume(key, 1, shortWindow)).isTrue();
+    }
+
+    @Test
+    void limitOfZero_blocksEveryRequest() {
+        String key = "test-key-zero";
+        assertThat(rateLimiter.tryConsume(key, 0, Duration.ofMinutes(1))).isFalse();
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/global/ratelimit/TokenAttemptServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/global/ratelimit/TokenAttemptServiceTest.java
@@ -1,0 +1,53 @@
+package com.mamoki.ieojuda.global.ratelimit;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+// issue #55 회귀 테스트 - 특정 토큰 값으로 5회까지는 잠기지 않다가 5번째 실패에서 잠기고,
+// 성공하면 초기화됨을 검증한다. 계정 잠금(LoginAttemptService)과 동일 알고리즘, 별개 키 공간.
+class TokenAttemptServiceTest {
+
+    private final TokenAttemptService tokenAttemptService = new TokenAttemptService();
+
+    @Test
+    void staysUnlocked_untilTheFifthFailure() {
+        String token = "guess-token-1";
+
+        for (int i = 0; i < 4; i++) {
+            assertThat(tokenAttemptService.recordFailure(token)).isFalse();
+            assertThat(tokenAttemptService.isLocked(token)).isFalse();
+        }
+
+        assertThat(tokenAttemptService.recordFailure(token)).isTrue();
+        assertThat(tokenAttemptService.isLocked(token)).isTrue();
+    }
+
+    @Test
+    void successResetsTheFailureCounter() {
+        String token = "guess-token-2";
+
+        tokenAttemptService.recordFailure(token);
+        tokenAttemptService.recordFailure(token);
+        tokenAttemptService.recordSuccess(token);
+
+        for (int i = 0; i < 4; i++) {
+            assertThat(tokenAttemptService.recordFailure(token)).isFalse();
+        }
+        assertThat(tokenAttemptService.isLocked(token)).isFalse();
+    }
+
+    @Test
+    void differentTokensAreTrackedIndependently() {
+        String guessedToken = "attacker-guess";
+        String realToken = "real-owners-token";
+
+        for (int i = 0; i < 5; i++) {
+            tokenAttemptService.recordFailure(guessedToken);
+        }
+
+        assertThat(tokenAttemptService.isLocked(guessedToken)).isTrue();
+        // 공격자가 다른 토큰 값을 반복 실패시켜도, 실제 소유자의 토큰은 전혀 영향받지 않는다
+        assertThat(tokenAttemptService.isLocked(realToken)).isFalse();
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/global/ratelimit/TokenLookupGuardTest.java
+++ b/src/test/java/com/mamoki/ieojuda/global/ratelimit/TokenLookupGuardTest.java
@@ -1,0 +1,69 @@
+package com.mamoki.ieojuda.global.ratelimit;
+
+import com.mamoki.ieojuda.domain.audit.entity.AuthAuditEventType;
+import com.mamoki.ieojuda.domain.audit.service.AuthAuditService;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+// issue #55 회귀 테스트 - TokenLookupGuard가 존재하지 않는 토큰을 실패로 기록하고,
+// 임계치를 넘으면 조회 자체를 시도하지 않고 바로 막는지 검증한다.
+class TokenLookupGuardTest {
+
+    private TokenAttemptService tokenAttemptService;
+    private AuthAuditService authAuditService;
+    private TokenLookupGuard guard;
+
+    @BeforeEach
+    void setUp() {
+        tokenAttemptService = mock(TokenAttemptService.class);
+        authAuditService = mock(AuthAuditService.class);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRemoteAddr("1.2.3.4");
+        guard = new TokenLookupGuard(tokenAttemptService, authAuditService, request);
+    }
+
+    @Test
+    void validToken_returnsValueAndRecordsSuccess() {
+        when(tokenAttemptService.isLocked("valid-token")).thenReturn(false);
+
+        String result = guard.resolve("valid-token", () -> Optional.of("found-entity"));
+
+        assertThat(result).isEqualTo("found-entity");
+        verify(tokenAttemptService).recordSuccess("valid-token");
+    }
+
+    @Test
+    void unknownToken_recordsFailureAndThrowsTokenInvalid() {
+        when(tokenAttemptService.isLocked("bad-token")).thenReturn(false);
+        when(tokenAttemptService.recordFailure("bad-token")).thenReturn(false);
+
+        assertThatThrownBy(() -> guard.resolve("bad-token", Optional::empty))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.TOKEN_INVALID));
+
+        verify(authAuditService).record(null, "1.2.3.4", AuthAuditEventType.PUBLIC_LINK_TOKEN_FAILURE, null);
+    }
+
+    @Test
+    void alreadyLockedToken_blocksWithoutEvenAttemptingLookup() {
+        when(tokenAttemptService.isLocked("locked-token")).thenReturn(true);
+
+        assertThatThrownBy(() -> guard.resolve("locked-token", () -> {
+            throw new AssertionError("잠긴 토큰인데 실제 조회를 시도해버렸다");
+        })).isInstanceOfSatisfying(CustomException.class,
+                e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.TOKEN_TEMPORARILY_LOCKED));
+
+        verify(authAuditService).record(null, "1.2.3.4", AuthAuditEventType.PUBLIC_LINK_TOKEN_LOCKED_ATTEMPT, null);
+    }
+}


### PR DESCRIPTION
## 연관 Issue
Closes #55

## 요약
로그인과 공개 토큰 API(사망신고/증빙/이의제기/역할 수락 등)에 대한 무차별 대입·자동화 공격을 막기 위해 경로별 rate limit, 계정/토큰 단위 실패 잠금, 비밀번호 정책 강화, 인증 실패 감사 로그를 추가했습니다.

## 작업 내용
- `RateLimiter` + `RateLimitFilter` 신규 - 로그인/회원가입/토큰 재발급/사망신고/증빙제출/이의제기/역할수락 등 경로별 IP 기준 요청 제한 (JwtAuthenticationFilter 앞단에 배치)
- `LoginAttemptService` 신규 - 계정(이메일) 단위, 15분 내 5회 로그인 실패 시 15분 잠금
- `TokenAttemptService` + `TokenLookupGuard` 신규 - 토큰 값 단위, 5회 실패 시 그 토큰 자체를 15분 잠금 (사망신고/증빙제출/이의제기/역할수락/이의연락처검증 6개 서비스에 배선)
- `PasswordBreachChecker` 신규 - Have I Been Pwned k-anonymity API로 유출 비밀번호 검사 (평문 미전송, 외부 API 장애 시 fail-open), `SignupRequest`에 최소 10자 검증 추가
- `AuthAuditLog`/`AuthAuditEventType`/`AuthAuditService`/`AuthAuditController` 신규 - 로그인 실패·잠금, rate limit 초과, 공개 링크 토큰 추측 실패·잠금, 공개 링크 상태 실패(만료·재사용·미검증 등)를 감사 기록하고 `/api/admin/auth-audit-logs`로 조회
- `PublicLinkAuditor` 신규 - 토큰은 유효하지만 상태가 안 맞아 실패하는 경우(`ACCESS_LINK_EXPIRED`, `ACCESS_LINK_ALREADY_USED`, `FORBIDDEN`, `DISPUTE_CONTACT_NOT_VERIFIED`)를 감사
- `ErrorCode`에 `ACCOUNT_TEMPORARILY_LOCKED`, `TOKEN_TEMPORARILY_LOCKED`, `TOO_MANY_REQUESTS`, `BREACHED_PASSWORD` 추가
- `RateLimiterTest`, `RateLimitFilterTest`, `LoginAttemptServiceTest`, `TokenAttemptServiceTest`, `TokenLookupGuardTest` - 경계값·독립성·우회 테스트 5종 신규 작성

## 범위
### 포함:
- 로그인·회원가입·토큰 링크·사망신고·증빙·이의제기 경로별 차등 rate limit
- IP(요청 수)·계정(로그인 실패)·토큰(추측 실패) 3개 축의 실패 잠금
- 회원가입 비밀번호 길이·유출 검사
- 로그인 및 공개 링크(토큰 추측 + 상태 실패) 실패 감사, 관리자 조회 API
### 제외:
- 실시간 알림(이메일/슬랙 등) - 감사 로그 조회로 대체하기로 결정
- 점진적 지연(딜레이 백오프) - 계정/토큰 잠금으로 충분하다고 판단해 제외
- JWT 세션 저장 구조 개편, WAF 제품 선정 (이슈에서 명시적으로 제외된 항목)

## 스크린샷 / 미리 보기
백엔드 API 변경으로 스크린샷은 없습니다. 검증 내역:
- 계정 로그인 5회 실패 → 6번째는 정확한 비밀번호로도 `429 ACCOUNT_TEMPORARILY_LOCKED`
- 동일 IP로 로그인 11번째 요청 → 정확히 10개까지만 통과, 11번째부터 `429 TOO_MANY_REQUESTS`
- 존재하지 않는 토큰 5회 시도 → 6번째부터 `429 TOKEN_TEMPORARILY_LOCKED`, 다른 토큰은 영향 없음(독립성 확인)
- 실제 유출 비밀번호(`password123`)로 가입 시도 → 실제 HIBP API 조회로 거부
- 실제 S3에 업로드한 실제 파일로 가입/삭제 전 과정 검증(기존 이슈 #48 회귀 없음 확인 겸)
- 관리자 계정으로 `/api/admin/auth-audit-logs` 조회 → 로그인 실패/잠금, rate limit 초과, 토큰 추측 실패/잠금, 링크 상태 실패까지 전부 이메일/IP/시각과 함께 정확히 기록됨을 확인
- 전체 테스트 스위트(`./gradlew test`) 통과