### PR TITLE
[Refactor/#56]: 세션 토큰 회전 및 권한 폐기 구현

### DIFF
--- a/src/main/java/com/mamoki/ieojuda/domain/account/controller/AdminUserController.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/account/controller/AdminUserController.java
@@ -1,0 +1,42 @@
+package com.mamoki.ieojuda.domain.account.controller;
+
+import com.mamoki.ieojuda.domain.account.service.AdminUserService;
+import com.mamoki.ieojuda.global.rsdata.RsData;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+// issue #56 - 운영관리자 전용, 계정 정지/복구. 정지 시 그 계정의 모든 세션(Access/Refresh Token)을
+// 즉시 폐기한다.
+@Tag(name = "Admin - User", description = "운영관리자 - 계정 정지 / 복구")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/users/{userId}")
+public class AdminUserController {
+
+    private final AdminUserService adminUserService;
+
+    @Operation(summary = "계정 정지", description = "해당 계정의 모든 세션을 즉시 폐기하고 정지 상태로 전환합니다.")
+    @PostMapping("/suspend")
+    public ResponseEntity<RsData<Void>> suspend(
+            @Parameter(description = "사용자 ID") @PathVariable Long userId
+    ) {
+        adminUserService.suspend(userId);
+        return ResponseEntity.ok(RsData.success(null));
+    }
+
+    @Operation(summary = "계정 정지 해제")
+    @PostMapping("/reactivate")
+    public ResponseEntity<RsData<Void>> reactivate(
+            @Parameter(description = "사용자 ID") @PathVariable Long userId
+    ) {
+        adminUserService.reactivate(userId);
+        return ResponseEntity.ok(RsData.success(null));
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/account/dto/RefreshRequest.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/account/dto/RefreshRequest.java
@@ -6,6 +6,6 @@ import jakarta.validation.constraints.NotBlank;
 public record RefreshRequest(
         @Schema(description = "로그인 시 발급받은 Refresh Token")
         @NotBlank(message = "Refresh Token이 필요합니다.")
-        @jakarta.validation.constraints.Size(max = 255, message = "Refresh Token은 255자 이하여야 합니다.") String refreshToken
+        @jakarta.validation.constraints.Size(max = 2000, message = "Refresh Token 형식이 올바르지 않습니다.") String refreshToken
 ) {
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/account/entity/RefreshSession.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/account/entity/RefreshSession.java
@@ -1,0 +1,84 @@
+package com.mamoki.ieojuda.domain.account.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+// issue #56 - Refresh Token 1건 = 세션 1건. 로그인 1회가 "가족(family)"을 이루고, 재발급(회전)마다
+// 같은 family 안에서 새 세션이 이어진다. 이미 회전되어 사용된(usedAt != null) 세션이 다시 제시되면
+// 탈취로 간주해 family 전체를 차단한다(재사용 탐지). sessionId 자체가 Refresh Token의 jti가 된다.
+@Entity
+@Table(name = "refresh_sessions")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshSession {
+
+    @Id
+    @Column(name = "session_id", length = 36)
+    private String sessionId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    // 이 세션 lineage(로그인 1회~로그아웃/만료까지 이어지는 회전 사슬) 전체를 묶는 ID.
+    // 재사용 탐지 시 이 값으로 관련 세션을 전부 찾아서 차단한다.
+    @Column(name = "family_id", length = 36, nullable = false)
+    private String familyId;
+
+    // Refresh Token 원문은 저장하지 않고 SHA-256 해시만 저장 - DB가 유출돼도 원문을 복원할 수 없다
+    @Column(name = "token_hash", length = 64, nullable = false)
+    private String tokenHash;
+
+    @Column(name = "issued_at", nullable = false)
+    private LocalDateTime issuedAt;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    // 회전(재발급)에 사용된 시각 - null이 아니면 이미 소모된 세션. 이 상태에서 다시 제시되면 재사용 탐지.
+    @Column(name = "used_at")
+    private LocalDateTime usedAt;
+
+    // 로그아웃/재사용탐지/보안 이벤트로 명시적으로 차단된 시각
+    @Column(name = "revoked_at")
+    private LocalDateTime revokedAt;
+
+    @Column(name = "replaced_by_session_id", length = 36)
+    private String replacedBySessionId;
+
+    @Builder
+    public RefreshSession(String sessionId, User user, String familyId, String tokenHash,
+                           LocalDateTime issuedAt, LocalDateTime expiresAt) {
+        this.sessionId = sessionId;
+        this.user = user;
+        this.familyId = familyId;
+        this.tokenHash = tokenHash;
+        this.issuedAt = issuedAt;
+        this.expiresAt = expiresAt;
+    }
+
+    public boolean isActive() {
+        return revokedAt == null && usedAt == null && expiresAt.isAfter(LocalDateTime.now());
+    }
+
+    // 회전(재발급)으로 소모됨 - 다음 세션으로 이어짐을 함께 기록
+    public void markUsed(String replacedBySessionId) {
+        this.usedAt = LocalDateTime.now();
+        this.replacedBySessionId = replacedBySessionId;
+    }
+
+    public void revoke() {
+        this.revokedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/account/entity/User.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/account/entity/User.java
@@ -29,9 +29,6 @@ public class User extends BaseCreatedAtEntity {
     @Column(name = "name", length = 100)
     private String name;
 
-    @Column(name = "refresh_token", length = 255)
-    private String refreshToken;
-
     // "사후 인계 안내" 화면 - 필수 동의 완료 시각(null이면 아직 미동의). 항목이 전부 한 버튼("확인하기")으로
     // 묶여있고 동의 종류가 하나뿐이라 별도 테이블 없이 컬럼 하나로 관리한다.
     @Column(name = "consent_agreed_at")
@@ -42,16 +39,25 @@ public class User extends BaseCreatedAtEntity {
     @Column(name = "role", length = 20, nullable = false)
     private UserRole role;
 
+    // issue #56 - 정지된 계정은 Access Token이 아직 안 만료됐어도 필터에서 즉시 거부한다
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 20, nullable = false)
+    private UserStatus status;
+
+    // issue #56 - Access Token에 발급 당시 버전을 함께 실어두고, 필터에서 이 값과 대조한다.
+    // 이메일 변경/정지 등 권한에 영향을 주는 이벤트가 생기면 이 값을 올려서, 만료 전까지 유효한
+    // 기존 Access Token 전부를 한 번에 무효화한다(개별 토큰 블랙리스트 없이도 즉시 폐기 가능).
+    @Column(name = "token_version", nullable = false)
+    private Integer tokenVersion;
+
     @Builder
     public User(String email, String password, String name) {
         this.email = email;
         this.password = password;
         this.name = name;
         this.role = UserRole.USER;
-    }
-
-    public void updateRefreshToken(String refreshToken) {
-        this.refreshToken = refreshToken;
+        this.status = UserStatus.ACTIVE;
+        this.tokenVersion = 0;
     }
 
     // 마이페이지 - 이메일/이름 변경
@@ -65,5 +71,17 @@ public class User extends BaseCreatedAtEntity {
         if (this.consentAgreedAt == null) {
             this.consentAgreedAt = LocalDateTime.now();
         }
+    }
+
+    public void incrementTokenVersion() {
+        this.tokenVersion = this.tokenVersion + 1;
+    }
+
+    public void suspend() {
+        this.status = UserStatus.SUSPENDED;
+    }
+
+    public void reactivate() {
+        this.status = UserStatus.ACTIVE;
     }
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/account/entity/UserStatus.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/account/entity/UserStatus.java
@@ -1,0 +1,6 @@
+package com.mamoki.ieojuda.domain.account.entity;
+
+public enum UserStatus {
+    ACTIVE,
+    SUSPENDED
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/account/repository/RefreshSessionRepository.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/account/repository/RefreshSessionRepository.java
@@ -1,0 +1,15 @@
+package com.mamoki.ieojuda.domain.account.repository;
+
+import com.mamoki.ieojuda.domain.account.entity.RefreshSession;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface RefreshSessionRepository extends JpaRepository<RefreshSession, String> {
+
+    // 로그아웃 / 이메일 변경 등 계정 전체 세션 폐기용
+    List<RefreshSession> findByUser_UserIdAndRevokedAtIsNull(Long userId);
+
+    // 재사용 탐지 시 같은 lineage(family) 전체를 찾아 차단하기 위한 조회
+    List<RefreshSession> findByFamilyIdAndRevokedAtIsNull(String familyId);
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/account/service/AdminUserService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/account/service/AdminUserService.java
@@ -1,0 +1,38 @@
+package com.mamoki.ieojuda.domain.account.service;
+
+import com.mamoki.ieojuda.domain.account.entity.User;
+import com.mamoki.ieojuda.domain.account.repository.UserRepository;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+// issue #56 "정지 상태" - 운영관리자가 계정을 정지/복구. 정지 시 세션을 전부 폐기해 이미 발급된
+// Access Token도 만료 전에 즉시 거부되게 한다(JwtAuthenticationFilter가 매 요청마다 상태를 대조).
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminUserService {
+
+    private final UserRepository userRepository;
+    private final SessionRevocationService sessionRevocationService;
+
+    @Transactional
+    public void suspend(Long userId) {
+        User user = findUser(userId);
+        user.suspend();
+        sessionRevocationService.revokeAllSessions(user);
+    }
+
+    @Transactional
+    public void reactivate(Long userId) {
+        User user = findUser(userId);
+        user.reactivate();
+    }
+
+    private User findUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/account/service/AuthService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/account/service/AuthService.java
@@ -5,19 +5,30 @@ import com.mamoki.ieojuda.domain.account.dto.RefreshRequest;
 import com.mamoki.ieojuda.domain.account.dto.SignupRequest;
 import com.mamoki.ieojuda.domain.account.dto.SignupResponse;
 import com.mamoki.ieojuda.domain.account.dto.TokenResponse;
+import com.mamoki.ieojuda.domain.account.entity.RefreshSession;
 import com.mamoki.ieojuda.domain.account.entity.User;
+import com.mamoki.ieojuda.domain.account.repository.RefreshSessionRepository;
 import com.mamoki.ieojuda.domain.account.repository.UserRepository;
 import com.mamoki.ieojuda.domain.plan.entity.Plan;
 import com.mamoki.ieojuda.domain.plan.repository.PlanRepository;
+import com.mamoki.ieojuda.global.email.token.TokenProvider;
 import com.mamoki.ieojuda.global.exception.CustomException;
 import com.mamoki.ieojuda.global.exception.ErrorCode;
 import com.mamoki.ieojuda.global.jwt.component.JwtTokenProvider;
+import com.mamoki.ieojuda.global.jwt.config.JwtProperties;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.util.UUID;
+
 // 명세서 "회원가입 / 로그인" 화면 - 계정 생성, 로그인(AT/RT 발급), RT로 AT 재발급
+//
+// issue #56 - Refresh Token은 세션(RefreshSession) 단위로 관리한다. 로그인 1회가 하나의 family를 열고,
+// 재발급(회전)마다 같은 family 안에서 세션이 이어진다. 회전으로 이미 소모된 세션이 다시 제시되면
+// 탈취로 간주해 family 전체를 차단한다(재사용 탐지).
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -27,6 +38,9 @@ public class AuthService {
     private final PlanRepository planRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
+    private final JwtProperties jwtProperties;
+    private final RefreshSessionRepository refreshSessionRepository;
+    private final SessionRevocationService sessionRevocationService;
 
     @Transactional
     public SignupResponse signup(SignupRequest request) {
@@ -59,34 +73,47 @@ public class AuthService {
             throw new CustomException(ErrorCode.INVALID_CREDENTIALS);
         }
 
-        return issueTokens(user);
+        // 새 로그인 = 새 세션 family의 시작
+        return issueSession(user, UUID.randomUUID().toString(), null);
     }
 
     @Transactional
     public TokenResponse refresh(RefreshRequest request) {
-        String refreshToken = request.refreshToken();
+        String refreshTokenJwt = request.refreshToken();
 
-        // 서명/만료 검증은 JwtTokenProvider가 파싱하면서 자동으로 함 - 실패 시 ExpiredJwtException/JwtException이
+        // 서명/발급자/대상/만료 검증은 JwtTokenProvider가 파싱하면서 자동으로 함 - 실패 시 ExpiredJwtException/JwtException이
         // 그대로 던져지고 GlobalExceptionHandler가 TOKEN_EXPIRED/TOKEN_INVALID로 응답한다.
-        if (!jwtTokenProvider.isRefreshToken(refreshToken)) {
+        if (!jwtTokenProvider.isRefreshToken(refreshTokenJwt)) {
             throw new CustomException(ErrorCode.TOKEN_INVALID);
         }
-        Long userId = jwtTokenProvider.getUserId(refreshToken);
 
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.INVALID_CREDENTIALS));
+        String sessionId = jwtTokenProvider.getJti(refreshTokenJwt);
+        RefreshSession session = refreshSessionRepository.findById(sessionId)
+                .orElseThrow(() -> new CustomException(ErrorCode.TOKEN_INVALID));
 
-        // DB에 저장된 RT와 요청으로 들어온 RT가 달라졌다면(로그아웃/재로그인 등으로 이미 교체됨) 재사용 불가
-        if (user.getRefreshToken() == null || !user.getRefreshToken().equals(refreshToken)) {
+        if (!session.getTokenHash().equals(TokenProvider.hashToken(refreshTokenJwt))) {
+            throw new CustomException(ErrorCode.TOKEN_INVALID);
+        }
+        if (session.getRevokedAt() != null) {
             throw new CustomException(ErrorCode.REFRESH_TOKEN_REVOKED);
         }
+        if (session.getUsedAt() != null) {
+            // 이미 회전(소모)된 세션이 다시 제시됨 - 토큰 탈취로 간주하고 같은 family 전체를 차단.
+            // 아래에서 곧바로 예외를 던져 이 트랜잭션은 롤백되므로, 차단 자체는 독립 트랜잭션으로 커밋해야 살아남는다.
+            sessionRevocationService.revokeFamily(session.getFamilyId());
+            throw new CustomException(ErrorCode.REFRESH_TOKEN_REUSE_DETECTED);
+        }
 
-        return issueTokens(user);
+        User user = userRepository.findById(session.getUser().getUserId())
+                .orElseThrow(() -> new CustomException(ErrorCode.INVALID_CREDENTIALS));
+
+        return issueSession(user, session.getFamilyId(), session);
     }
 
     // /auth/**는 SecurityConfig에서 permitAll이라 토큰 없이도 요청 자체는 통과되므로, userId가 비어 있으면
     // (=Authorization 헤더 없이 호출한 경우) 여기서 직접 막는다.
-    // AT는 만료 전까지 계속 유효하지만(블랙리스트 없음), 저장된 RT를 지워서 재발급은 더 이상 못 하게 막는다.
+    // AT는 만료 전까지 계속 유효하지만 tokenVersion 대조로 걸러진다 - 로그아웃 시 tokenVersion도 함께 올려서
+    // 이미 발급된 Access Token도 즉시 폐기되게 한다.
     @Transactional
     public void logout(Long userId) {
         if (userId == null) {
@@ -94,14 +121,32 @@ public class AuthService {
         }
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-        user.updateRefreshToken(null);
+
+        sessionRevocationService.revokeAllSessions(user);
     }
 
-    // AT/RT 새로 발급하고 RT는 DB에 갱신 저장 (재발급마다 RT도 회전)
-    private TokenResponse issueTokens(User user) {
-        String accessToken = jwtTokenProvider.generateAccessToken(user.getUserId(), user.getEmail(), user.getRole().name());
-        String refreshToken = jwtTokenProvider.generateRefreshToken(user.getUserId());
-        user.updateRefreshToken(refreshToken);
-        return new TokenResponse(accessToken, refreshToken);
+    // 새 세션을 발급한다. previousSession이 있으면(재발급) 그 세션을 "소모됨" 상태로 이어붙인다.
+    private TokenResponse issueSession(User user, String familyId, RefreshSession previousSession) {
+        String sessionId = UUID.randomUUID().toString();
+        String refreshTokenJwt = jwtTokenProvider.generateRefreshToken(
+                user.getUserId(), sessionId, jwtProperties.getRefreshTokenExpirationMs());
+        String accessTokenJwt = jwtTokenProvider.generateAccessToken(
+                user.getUserId(), user.getEmail(), user.getRole().name(), user.getTokenVersion());
+
+        LocalDateTime now = LocalDateTime.now();
+        refreshSessionRepository.save(RefreshSession.builder()
+                .sessionId(sessionId)
+                .user(user)
+                .familyId(familyId)
+                .tokenHash(TokenProvider.hashToken(refreshTokenJwt))
+                .issuedAt(now)
+                .expiresAt(now.plus(java.time.Duration.ofMillis(jwtProperties.getRefreshTokenExpirationMs())))
+                .build());
+
+        if (previousSession != null) {
+            previousSession.markUsed(sessionId);
+        }
+
+        return new TokenResponse(accessTokenJwt, refreshTokenJwt);
     }
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/account/service/SessionRevocationService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/account/service/SessionRevocationService.java
@@ -1,0 +1,36 @@
+package com.mamoki.ieojuda.domain.account.service;
+
+import com.mamoki.ieojuda.domain.account.entity.RefreshSession;
+import com.mamoki.ieojuda.domain.account.entity.User;
+import com.mamoki.ieojuda.domain.account.repository.RefreshSessionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+// issue #56 - 계정에 영향을 주는 이벤트(이메일 변경, 계정 정지 등)가 생겼을 때 세션을 한 번에 정리한다.
+// tokenVersion을 올려서 이미 발급된 Access Token은 만료 전이라도 필터에서 즉시 거부되게 하고,
+// 아직 살아있는 Refresh Token들도 전부 폐기해서 재발급으로도 새 Access Token을 못 받게 막는다.
+//
+// revokeFamily()는 AuthService.refresh()가 재사용 탐지 직후 예외를 던지고 롤백하는 흐름 안에서 호출된다.
+// 같은 트랜잭션에 남아있으면 그 롤백에 차단 자체가 같이 사라지므로(#48/#55에서 이미 겪은 것과 같은 함정),
+// REQUIRES_NEW로 독립 트랜잭션에 커밋한다.
+@Service
+@RequiredArgsConstructor
+public class SessionRevocationService {
+
+    private final RefreshSessionRepository refreshSessionRepository;
+
+    @Transactional
+    public void revokeAllSessions(User user) {
+        refreshSessionRepository.findByUser_UserIdAndRevokedAtIsNull(user.getUserId())
+                .forEach(RefreshSession::revoke);
+        user.incrementTokenVersion();
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void revokeFamily(String familyId) {
+        refreshSessionRepository.findByFamilyIdAndRevokedAtIsNull(familyId)
+                .forEach(RefreshSession::revoke);
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/account/service/UserService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/account/service/UserService.java
@@ -63,6 +63,7 @@ public class UserService {
     private final DependencyRepository dependencyRepository;
     private final EvidenceStorageClient evidenceStorageClient;
     private final ReleaseCaseGuardService releaseCaseGuardService;
+    private final SessionRevocationService sessionRevocationService;
 
     @Transactional
     public UserResponse updateProfile(Long userId, UserUpdateRequest request) {
@@ -76,9 +77,11 @@ public class UserService {
         user.updateProfile(request.email(), request.name());
 
         // 로그인 이메일이 실제로 바뀌면(계정 탈취 대응) 이 계획에 걸린 담당자/확인자/이의연락처의
-        // 기존 초대 토큰을 전부 무효화한다 - 새 이메일로 재초대해야 다시 접근할 수 있다.
+        // 기존 초대 토큰을 전부 무효화하고(#48), 이 계정 자신의 세션도 전부 폐기한다(#56) -
+        // 공격자가 이미 로그인해 있던 상태였다면 이메일 변경 직후 그 세션도 끊어내기 위함.
         if (emailChanged) {
             planRepository.findByUser_UserId(userId).ifPresent(plan -> invalidatePlanInviteTokens(plan.getPlanId()));
+            sessionRevocationService.revokeAllSessions(user);
         }
 
         return UserResponse.from(user);

--- a/src/main/java/com/mamoki/ieojuda/global/config/SecurityConfig.java
+++ b/src/main/java/com/mamoki/ieojuda/global/config/SecurityConfig.java
@@ -108,7 +108,7 @@ public class SecurityConfig {
                 .exceptionHandling(exception -> exception
                         .authenticationEntryPoint(authenticationEntryPoint())
                         .accessDeniedHandler(accessDeniedHandler()))
-                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, userRepository), UsernamePasswordAuthenticationFilter.class)
                 .addFilterAfter(new ConsentCheckFilter(userRepository), JwtAuthenticationFilter.class);
 
         return http.build();

--- a/src/main/java/com/mamoki/ieojuda/global/exception/ErrorCode.java
+++ b/src/main/java/com/mamoki/ieojuda/global/exception/ErrorCode.java
@@ -46,6 +46,8 @@ public enum ErrorCode {
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "TOKEN_EXPIRED", "Access Token이 만료되었습니다."),
     TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "TOKEN_INVALID", "토큰 형식이 잘못되었거나 서명이 유효하지 않습니다."),
     REFRESH_TOKEN_REVOKED(HttpStatus.UNAUTHORIZED, "REFRESH_TOKEN_REVOKED", "이미 무효화된 Refresh Token입니다."),
+    REFRESH_TOKEN_REUSE_DETECTED(HttpStatus.UNAUTHORIZED, "REFRESH_TOKEN_REUSE_DETECTED", "이미 사용된 Refresh Token이 재사용되어 관련 세션을 모두 차단했습니다. 다시 로그인해 주세요."),
+    SESSION_REVOKED(HttpStatus.UNAUTHORIZED, "SESSION_REVOKED", "세션이 만료되었습니다. 다시 로그인해 주세요."),
     ACCESS_LINK_EXPIRED(HttpStatus.UNAUTHORIZED, "ACCESS_LINK_EXPIRED", "링크가 만료되었습니다."),
     ACCESS_LINK_ALREADY_USED(HttpStatus.UNAUTHORIZED, "ACCESS_LINK_ALREADY_USED", "이미 사용되었거나 재사용할 수 없는 링크입니다."),
     OTP_VERIFICATION_FAILED(HttpStatus.UNAUTHORIZED, "OTP_VERIFICATION_FAILED", "OTP 인증에 실패했습니다."),
@@ -54,6 +56,7 @@ public enum ErrorCode {
     FORBIDDEN(HttpStatus.FORBIDDEN, "FORBIDDEN", "해당 리소스에 대한 권한이 없습니다."),
     ROLE_PACKAGE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "ROLE_PACKAGE_ACCESS_DENIED", "본인의 역할 패키지가 아니거나 권한이 없는 요청입니다."),
     REVIEWER_CONFLICT_OF_INTEREST(HttpStatus.FORBIDDEN, "REVIEWER_CONFLICT_OF_INTEREST", "이해충돌 또는 권한 만료로 다른 검토자에게 재배정이 필요합니다."),
+    ACCOUNT_SUSPENDED(HttpStatus.FORBIDDEN, "ACCOUNT_SUSPENDED", "정지된 계정입니다."),
 
     // 리소스 없음 (404)
     RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "RESOURCE_NOT_FOUND", "요청한 리소스가 존재하지 않습니다."),

--- a/src/main/java/com/mamoki/ieojuda/global/jwt/component/JwtTokenProvider.java
+++ b/src/main/java/com/mamoki/ieojuda/global/jwt/component/JwtTokenProvider.java
@@ -11,15 +11,21 @@ import org.springframework.stereotype.Component;
 import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
+import java.util.UUID;
 
 // 회원가입/로그인 - Access/Refresh 토큰 발급과 파싱을 담당.
 // 여기서 던지는 io.jsonwebtoken.ExpiredJwtException / JwtException은
 // GlobalExceptionHandler가 이미 TOKEN_EXPIRED / TOKEN_INVALID로 잡아서 응답하므로 별도 try-catch 없이 그대로 던진다.
+//
+// issue #56 - 모든 토큰에 jti(고유 ID), iss/aud(발급자/대상)를 싣는다. Access Token에는 추가로 발급 당시
+// 사용자의 tokenVersion을 실어서, 필터가 DB의 현재 tokenVersion과 대조해 즉시 폐기 여부를 판단할 수 있게 한다.
+// Refresh Token의 jti는 그 토큰에 대응하는 RefreshSession의 sessionId 그 자체다(회전/재사용탐지 조회에 사용).
 @Component
 @RequiredArgsConstructor
 public class JwtTokenProvider {
 
     private static final String CLAIM_TOKEN_TYPE = "tokenType";
+    private static final String CLAIM_TOKEN_VERSION = "ver";
     private static final String TOKEN_TYPE_ACCESS = "ACCESS";
     private static final String TOKEN_TYPE_REFRESH = "REFRESH";
 
@@ -32,12 +38,40 @@ public class JwtTokenProvider {
         this.key = Keys.hmacShaKeyFor(jwtProperties.getSecret().getBytes(StandardCharsets.UTF_8));
     }
 
-    public String generateAccessToken(Long userId, String email, String role) {
-        return generateToken(userId, email, role, TOKEN_TYPE_ACCESS, jwtProperties.getAccessTokenExpirationMs());
+    public String generateAccessToken(Long userId, String email, String role, Integer tokenVersion) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + jwtProperties.getAccessTokenExpirationMs());
+
+        return baseBuilder(now, expiry)
+                .subject(String.valueOf(userId))
+                .claim(CLAIM_TOKEN_TYPE, TOKEN_TYPE_ACCESS)
+                .claim("email", email)
+                .claim("role", role)
+                .claim(CLAIM_TOKEN_VERSION, tokenVersion)
+                .signWith(key)
+                .compact();
     }
 
-    public String generateRefreshToken(Long userId) {
-        return generateToken(userId, null, null, TOKEN_TYPE_REFRESH, jwtProperties.getRefreshTokenExpirationMs());
+    // sessionId를 그대로 이 토큰의 jti로 사용 - refresh() 시 jti만으로 대응하는 RefreshSession을 바로 조회한다
+    public String generateRefreshToken(Long userId, String sessionId, long expirationMs) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + expirationMs);
+
+        return baseBuilder(now, expiry)
+                .id(sessionId)
+                .subject(String.valueOf(userId))
+                .claim(CLAIM_TOKEN_TYPE, TOKEN_TYPE_REFRESH)
+                .signWith(key)
+                .compact();
+    }
+
+    private io.jsonwebtoken.JwtBuilder baseBuilder(Date issuedAt, Date expiry) {
+        return Jwts.builder()
+                .id(UUID.randomUUID().toString())
+                .issuer(jwtProperties.getIssuer())
+                .audience().add(jwtProperties.getAudience()).and()
+                .issuedAt(issuedAt)
+                .expiration(expiry);
     }
 
     //토큰 -> 사용자 ID 추출
@@ -45,9 +79,18 @@ public class JwtTokenProvider {
         return Long.valueOf(parseClaims(token).getSubject());
     }
 
-    // 토큰 -> 권한(USER/ADMIN/EXTERNAL) 추출 - JwtAuthenticationFilter가 SecurityContext 권한을 채울 때 사용
+    // 토큰 -> 권한(USER/ADMIN/EXTERNAL) 추출 - 참고용. 실제 인가는 필터가 DB의 현재 role을 신뢰한다(#56).
     public String getRole(String token) {
         return parseClaims(token).get("role", String.class);
+    }
+
+    // Refresh Token의 jti = 대응하는 RefreshSession.sessionId
+    public String getJti(String token) {
+        return parseClaims(token).getId();
+    }
+
+    public Integer getTokenVersion(String token) {
+        return parseClaims(token).get(CLAIM_TOKEN_VERSION, Integer.class);
     }
 
     public boolean isRefreshToken(String token) { // RT 검증
@@ -58,33 +101,14 @@ public class JwtTokenProvider {
         return TOKEN_TYPE_ACCESS.equals(parseClaims(token).get(CLAIM_TOKEN_TYPE, String.class));
     }
 
-    //토큰 열기
+    //토큰 열기 - 서명뿐 아니라 발급자(iss)/대상(aud)도 함께 검증
     private Claims parseClaims(String token) {
         return Jwts.parser()
                 .verifyWith(key)
+                .requireIssuer(jwtProperties.getIssuer())
+                .requireAudience(jwtProperties.getAudience())
                 .build()
                 .parseSignedClaims(token)
                 .getPayload();
-    }
-
-    //토큰 생성
-    private String generateToken(Long userId, String email, String role, String tokenType, long expirationMs) {
-        Date now = new Date();
-        Date expiry = new Date(now.getTime() + expirationMs);
-
-        var builder = Jwts.builder()
-                .subject(String.valueOf(userId))
-                .claim(CLAIM_TOKEN_TYPE, tokenType)
-                .issuedAt(now)
-                .expiration(expiry);
-
-        if (email != null) {
-            builder.claim("email", email);
-        }
-        if (role != null) {
-            builder.claim("role", role);
-        }
-
-        return builder.signWith(key).compact();
     }
 }

--- a/src/main/java/com/mamoki/ieojuda/global/jwt/config/JwtProperties.java
+++ b/src/main/java/com/mamoki/ieojuda/global/jwt/config/JwtProperties.java
@@ -18,4 +18,11 @@ public class JwtProperties {
 
     @Value("${jwt.refresh-token-expiration-ms}")
     private long refreshTokenExpirationMs;
+
+    // issue #56 - 토큰이 이 서비스가 발급한 게 맞는지(iss), 이 서비스를 대상으로 한 게 맞는지(aud) 검증하기 위한 값
+    @Value("${jwt.issuer}")
+    private String issuer;
+
+    @Value("${jwt.audience}")
+    private String audience;
 }

--- a/src/main/java/com/mamoki/ieojuda/global/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/mamoki/ieojuda/global/jwt/filter/JwtAuthenticationFilter.java
@@ -1,5 +1,8 @@
 package com.mamoki.ieojuda.global.jwt.filter;
 
+import com.mamoki.ieojuda.domain.account.entity.User;
+import com.mamoki.ieojuda.domain.account.entity.UserStatus;
+import com.mamoki.ieojuda.domain.account.repository.UserRepository;
 import com.mamoki.ieojuda.global.exception.ErrorCode;
 import com.mamoki.ieojuda.global.jwt.component.JwtTokenProvider;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -16,19 +19,27 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
 
 // Authorization: Bearer {AT} 헤더를 검증해서 SecurityContext에 인증 정보(principal = userId)를 채운다.
 // 여기서 던져지는 ExpiredJwtException/JwtException은 GlobalExceptionHandler(컨트롤러 이후 계층)가 못 잡으므로
 // SecurityErrorResponseWriter로 직접 같은 포맷(RsData)의 401 응답을 만든다.
+//
+// issue #56 - 서명 검증만으로는 "권한이 이미 회수된 토큰"을 걸러낼 수 없다(만료 전까지 계속 유효했음).
+// 그래서 매 요청마다 DB에서 사용자를 다시 조회해 (1) 계정이 존재하는지 (2) 정지 상태가 아닌지
+// (3) 토큰이 실린 tokenVersion이 DB의 현재 값과 같은지 확인한다. 권한(role)도 토큰의 claim이 아니라
+// DB의 현재 값을 신뢰한다 - 토큰 발급 이후 등급이 바뀌었다면 다음 요청부터 즉시 반영되어야 하기 때문이다.
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private static final String HEADER_NAME = "Authorization";
     private static final String TOKEN_PREFIX = "Bearer ";
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final UserRepository userRepository;
 
-    public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider) {
+    public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider, UserRepository userRepository) {
         this.jwtTokenProvider = jwtTokenProvider;
+        this.userRepository = userRepository;
     }
 
     @Override
@@ -42,10 +53,25 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     SecurityErrorResponseWriter.write(response, ErrorCode.TOKEN_INVALID);
                     return;
                 }
+
                 Long userId = jwtTokenProvider.getUserId(token);
-                String role = jwtTokenProvider.getRole(token);
-                List<GrantedAuthority> authorities = List.of(
-                        new SimpleGrantedAuthority("ROLE_" + (role != null ? role : "USER")));
+                Integer tokenVersion = jwtTokenProvider.getTokenVersion(token);
+
+                User user = userRepository.findById(userId).orElse(null);
+                if (user == null) {
+                    SecurityErrorResponseWriter.write(response, ErrorCode.TOKEN_INVALID);
+                    return;
+                }
+                if (user.getStatus() == UserStatus.SUSPENDED) {
+                    SecurityErrorResponseWriter.write(response, ErrorCode.ACCOUNT_SUSPENDED);
+                    return;
+                }
+                if (!Objects.equals(user.getTokenVersion(), tokenVersion)) {
+                    SecurityErrorResponseWriter.write(response, ErrorCode.SESSION_REVOKED);
+                    return;
+                }
+
+                List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().name()));
                 SecurityContextHolder.getContext().setAuthentication(
                         new UsernamePasswordAuthenticationToken(userId, null, authorities));
             } catch (ExpiredJwtException e) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -41,6 +41,8 @@ aws.s3.secret-key=${AWS_SECRET_ACCESS_KEY}
 jwt.secret=${JWT_SECRET}
 jwt.access-token-expiration-ms=3600000
 jwt.refresh-token-expiration-ms=1209600000
+jwt.issuer=ieoduda-backend
+jwt.audience=ieoduda-client
 
 #역할 수락 링크 / 문의 주소 설정
 #프론트 주소

--- a/src/test/java/com/mamoki/ieojuda/domain/account/service/AuthServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/account/service/AuthServiceTest.java
@@ -1,0 +1,218 @@
+package com.mamoki.ieojuda.domain.account.service;
+
+import com.mamoki.ieojuda.domain.account.dto.LoginRequest;
+import com.mamoki.ieojuda.domain.account.dto.RefreshRequest;
+import com.mamoki.ieojuda.domain.account.dto.TokenResponse;
+import com.mamoki.ieojuda.domain.account.entity.RefreshSession;
+import com.mamoki.ieojuda.domain.account.entity.User;
+import com.mamoki.ieojuda.domain.account.repository.RefreshSessionRepository;
+import com.mamoki.ieojuda.domain.account.repository.UserRepository;
+import com.mamoki.ieojuda.domain.plan.repository.PlanRepository;
+import com.mamoki.ieojuda.global.email.token.TokenProvider;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import com.mamoki.ieojuda.global.jwt.component.JwtTokenProvider;
+import com.mamoki.ieojuda.global.jwt.config.JwtProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+// issue #56 회귀 테스트 - 로그인 시 세션 생성, refresh 시 회전(rotation), 이미 소모된 토큰 재사용 시
+// family 전체 차단, 로그아웃 시 전체 세션 폐기 + tokenVersion 증가를 검증한다.
+class AuthServiceTest {
+
+    private UserRepository userRepository;
+    private PlanRepository planRepository;
+    private PasswordEncoder passwordEncoder;
+    private JwtTokenProvider jwtTokenProvider;
+    private JwtProperties jwtProperties;
+    private RefreshSessionRepository refreshSessionRepository;
+    private AuthService authService;
+
+    @BeforeEach
+    void setUp() {
+        userRepository = mock(UserRepository.class);
+        planRepository = mock(PlanRepository.class);
+        passwordEncoder = mock(PasswordEncoder.class);
+        jwtTokenProvider = mock(JwtTokenProvider.class);
+        jwtProperties = mock(JwtProperties.class);
+        refreshSessionRepository = mock(RefreshSessionRepository.class);
+        // 실제 SessionRevocationService를 씀 - 재사용 탐지 시 family 전체가 진짜로 revoke()되는지까지
+        // (mock 호출 검증이 아니라 엔티티 상태로) 확인하기 위함. 이걸로 REQUIRES_NEW 분리를 빼먹는
+        // 회귀를 실제로 잡아냈다(#48/#55와 같은 롤백 함정이 refresh()에도 있었음).
+        SessionRevocationService sessionRevocationService = new SessionRevocationService(refreshSessionRepository);
+
+        when(jwtProperties.getRefreshTokenExpirationMs()).thenReturn(1_209_600_000L);
+
+        authService = new AuthService(
+                userRepository, planRepository, passwordEncoder, jwtTokenProvider, jwtProperties,
+                refreshSessionRepository, sessionRevocationService);
+    }
+
+    private User userWithId(Long id) {
+        User user = User.builder().email("owner@test.com").password("hash").name("A").build();
+        setField(user, "userId", id);
+        return user;
+    }
+
+    private static void setField(Object target, String fieldName, Object value) {
+        try {
+            Field field = target.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void login_success_createsNewSessionFamily() {
+        User user = userWithId(1L);
+        when(userRepository.findByEmail("owner@test.com")).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches("password1234", "hash")).thenReturn(true);
+        when(jwtTokenProvider.generateRefreshToken(eq(1L), any(), anyLong())).thenReturn("rt-jwt");
+        when(jwtTokenProvider.generateAccessToken(eq(1L), eq("owner@test.com"), eq("USER"), eq(0))).thenReturn("at-jwt");
+
+        TokenResponse response = authService.login(new LoginRequest("owner@test.com", "password1234"));
+
+        assertThat(response.accessToken()).isEqualTo("at-jwt");
+        assertThat(response.refreshToken()).isEqualTo("rt-jwt");
+
+        ArgumentCaptor<RefreshSession> captor = ArgumentCaptor.forClass(RefreshSession.class);
+        verify(refreshSessionRepository).save(captor.capture());
+        RefreshSession saved = captor.getValue();
+        assertThat(saved.getUser()).isEqualTo(user);
+        assertThat(saved.getFamilyId()).isNotBlank();
+        assertThat(saved.getTokenHash()).isEqualTo(TokenProvider.hashToken("rt-jwt"));
+        assertThat(saved.getUsedAt()).isNull();
+        assertThat(saved.getRevokedAt()).isNull();
+    }
+
+    @Test
+    void refresh_validUnusedSession_rotatesAndLinksToNewSession() {
+        User user = userWithId(1L);
+        RefreshSession oldSession = RefreshSession.builder()
+                .sessionId("old-id")
+                .user(user)
+                .familyId("fam-1")
+                .tokenHash(TokenProvider.hashToken("presented-rt"))
+                .issuedAt(LocalDateTime.now().minusMinutes(5))
+                .expiresAt(LocalDateTime.now().plusDays(14))
+                .build();
+
+        when(jwtTokenProvider.isRefreshToken("presented-rt")).thenReturn(true);
+        when(jwtTokenProvider.getJti("presented-rt")).thenReturn("old-id");
+        when(refreshSessionRepository.findById("old-id")).thenReturn(Optional.of(oldSession));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(jwtTokenProvider.generateRefreshToken(eq(1L), any(), anyLong())).thenReturn("new-rt-jwt");
+        when(jwtTokenProvider.generateAccessToken(eq(1L), any(), any(), any())).thenReturn("new-at-jwt");
+
+        TokenResponse response = authService.refresh(new RefreshRequest("presented-rt"));
+
+        assertThat(response.refreshToken()).isEqualTo("new-rt-jwt");
+        assertThat(oldSession.getUsedAt()).isNotNull();
+        assertThat(oldSession.getReplacedBySessionId()).isNotBlank();
+
+        ArgumentCaptor<RefreshSession> captor = ArgumentCaptor.forClass(RefreshSession.class);
+        verify(refreshSessionRepository).save(captor.capture());
+        assertThat(captor.getValue().getFamilyId()).isEqualTo("fam-1");
+        assertThat(captor.getValue().getSessionId()).isEqualTo(oldSession.getReplacedBySessionId());
+    }
+
+    @Test
+    void refresh_alreadyUsedSession_isTreatedAsTheftAndRevokesWholeFamily() {
+        User user = userWithId(1L);
+        RefreshSession reusedSession = RefreshSession.builder()
+                .sessionId("stolen-id")
+                .user(user)
+                .familyId("fam-2")
+                .tokenHash(TokenProvider.hashToken("stolen-rt"))
+                .issuedAt(LocalDateTime.now().minusDays(1))
+                .expiresAt(LocalDateTime.now().plusDays(13))
+                .build();
+        reusedSession.markUsed("some-later-session"); // 이미 한 번 회전되어 소모된 상태
+
+        RefreshSession siblingInFamily = RefreshSession.builder()
+                .sessionId("some-later-session")
+                .user(user)
+                .familyId("fam-2")
+                .tokenHash("irrelevant")
+                .issuedAt(LocalDateTime.now())
+                .expiresAt(LocalDateTime.now().plusDays(14))
+                .build();
+
+        when(jwtTokenProvider.isRefreshToken("stolen-rt")).thenReturn(true);
+        when(jwtTokenProvider.getJti("stolen-rt")).thenReturn("stolen-id");
+        when(refreshSessionRepository.findById("stolen-id")).thenReturn(Optional.of(reusedSession));
+        when(refreshSessionRepository.findByFamilyIdAndRevokedAtIsNull("fam-2"))
+                .thenReturn(List.of(reusedSession, siblingInFamily));
+
+        assertThatThrownBy(() -> authService.refresh(new RefreshRequest("stolen-rt")))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.REFRESH_TOKEN_REUSE_DETECTED));
+
+        assertThat(reusedSession.getRevokedAt()).isNotNull();
+        assertThat(siblingInFamily.getRevokedAt()).isNotNull();
+        verify(refreshSessionRepository, never()).save(any());
+    }
+
+    @Test
+    void refresh_revokedSession_isRejected() {
+        User user = userWithId(1L);
+        RefreshSession revokedSession = RefreshSession.builder()
+                .sessionId("revoked-id")
+                .user(user)
+                .familyId("fam-3")
+                .tokenHash(TokenProvider.hashToken("revoked-rt"))
+                .issuedAt(LocalDateTime.now().minusDays(1))
+                .expiresAt(LocalDateTime.now().plusDays(13))
+                .build();
+        revokedSession.revoke();
+
+        when(jwtTokenProvider.isRefreshToken("revoked-rt")).thenReturn(true);
+        when(jwtTokenProvider.getJti("revoked-rt")).thenReturn("revoked-id");
+        when(refreshSessionRepository.findById("revoked-id")).thenReturn(Optional.of(revokedSession));
+
+        assertThatThrownBy(() -> authService.refresh(new RefreshRequest("revoked-rt")))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.REFRESH_TOKEN_REVOKED));
+    }
+
+    @Test
+    void logout_revokesAllActiveSessionsAndBumpsTokenVersion() {
+        User user = userWithId(1L);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        RefreshSession sessionA = RefreshSession.builder()
+                .sessionId("a").user(user).familyId("fam-a").tokenHash("h")
+                .issuedAt(LocalDateTime.now()).expiresAt(LocalDateTime.now().plusDays(14)).build();
+        RefreshSession sessionB = RefreshSession.builder()
+                .sessionId("b").user(user).familyId("fam-b").tokenHash("h")
+                .issuedAt(LocalDateTime.now()).expiresAt(LocalDateTime.now().plusDays(14)).build();
+
+        when(refreshSessionRepository.findByUser_UserIdAndRevokedAtIsNull(1L)).thenReturn(List.of(sessionA, sessionB));
+
+        int versionBefore = user.getTokenVersion();
+        authService.logout(1L);
+
+        assertThat(sessionA.getRevokedAt()).isNotNull();
+        assertThat(sessionB.getRevokedAt()).isNotNull();
+        assertThat(user.getTokenVersion()).isEqualTo(versionBefore + 1);
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/domain/account/service/UserServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/account/service/UserServiceTest.java
@@ -69,6 +69,7 @@ class UserServiceTest {
     private DependencyRepository dependencyRepository;
     private EvidenceStorageClient evidenceStorageClient;
     private ReleaseCaseGuardService releaseCaseGuardService;
+    private SessionRevocationService sessionRevocationService;
     private UserService userService;
 
     @BeforeEach
@@ -94,13 +95,15 @@ class UserServiceTest {
         dependencyRepository = mock(DependencyRepository.class);
         evidenceStorageClient = mock(EvidenceStorageClient.class);
         releaseCaseGuardService = mock(ReleaseCaseGuardService.class);
+        sessionRevocationService = mock(SessionRevocationService.class);
 
         userService = new UserService(
                 userRepository, planRepository, conversationRepository, lifeAreaRepository, lifeAreaMessageRepository,
                 itemRepository, recipientRepository, disputeContactRepository, confirmerRepository,
                 releaseCaseRepository, planVersionRepository, evidenceRepository, emailLogRepository,
                 handoverStageRepository, objectionRepository, handoffCheckRepository, handoffCheckResponseRepository,
-                packageIssueRepository, dependencyRepository, evidenceStorageClient, releaseCaseGuardService);
+                packageIssueRepository, dependencyRepository, evidenceStorageClient, releaseCaseGuardService,
+                sessionRevocationService);
     }
 
     @Test
@@ -129,6 +132,7 @@ class UserServiceTest {
         verify(recipient).invalidateInviteToken();
         assertThat(confirmer.getInviteToken()).isNull();
         verify(disputeContact).invalidateInviteToken();
+        verify(sessionRevocationService).revokeAllSessions(user);
     }
 
     @Test
@@ -139,7 +143,8 @@ class UserServiceTest {
         userService.updateProfile(1L, new UserUpdateRequest("same@test.com", "New Name"));
 
         assertThat(user.getName()).isEqualTo("New Name");
-        verifyNoInteractions(planRepository, recipientRepository, confirmerRepository, disputeContactRepository);
+        verifyNoInteractions(planRepository, recipientRepository, confirmerRepository, disputeContactRepository,
+                sessionRevocationService);
     }
 
     @Test

--- a/src/test/java/com/mamoki/ieojuda/global/jwt/filter/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/mamoki/ieojuda/global/jwt/filter/JwtAuthenticationFilterTest.java
@@ -1,0 +1,127 @@
+package com.mamoki.ieojuda.global.jwt.filter;
+
+import com.mamoki.ieojuda.domain.account.entity.User;
+import com.mamoki.ieojuda.domain.account.entity.UserRole;
+import com.mamoki.ieojuda.domain.account.repository.UserRepository;
+import com.mamoki.ieojuda.global.jwt.component.JwtTokenProvider;
+import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.lang.reflect.Field;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+// issue #56 회귀 테스트 - 필터가 서명 검증만으로 끝내지 않고, 매 요청마다 DB의 현재 사용자 상태
+// (존재 여부/정지 여부/tokenVersion)를 대조하며, 권한(role)도 토큰의 claim이 아니라 DB 값을 신뢰함을 검증한다.
+class JwtAuthenticationFilterTest {
+
+    private JwtTokenProvider jwtTokenProvider;
+    private UserRepository userRepository;
+    private JwtAuthenticationFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        jwtTokenProvider = mock(JwtTokenProvider.class);
+        userRepository = mock(UserRepository.class);
+        filter = new JwtAuthenticationFilter(jwtTokenProvider, userRepository);
+        SecurityContextHolder.clearContext();
+
+        when(jwtTokenProvider.isAccessToken("valid-token")).thenReturn(true);
+        when(jwtTokenProvider.getUserId("valid-token")).thenReturn(1L);
+    }
+
+    private User userWithRole(UserRole role) {
+        User user = User.builder().email("u@test.com").password("hash").name("A").build();
+        setField(user, "userId", 1L);
+        setField(user, "role", role);
+        return user;
+    }
+
+    private static void setField(Object target, String fieldName, Object value) {
+        try {
+            Field field = target.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private MockHttpServletRequest requestWithToken(String token) {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer " + token);
+        return request;
+    }
+
+    @Test
+    void matchingTokenVersion_authenticatesWithDbRole_notJwtRoleClaim() throws Exception {
+        User user = userWithRole(UserRole.ADMIN); // DB는 ADMIN
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(jwtTokenProvider.getTokenVersion("valid-token")).thenReturn(0);
+        // 토큰 자체의 role claim은 USER로 낡아있다고 가정 - 그래도 DB(ADMIN)를 신뢰해야 한다
+        when(jwtTokenProvider.getRole("valid-token")).thenReturn("USER");
+
+        FilterChain chain = mock(FilterChain.class);
+        filter.doFilter(requestWithToken("valid-token"), new MockHttpServletResponse(), chain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
+        assertThat(SecurityContextHolder.getContext().getAuthentication().getAuthorities())
+                .extracting(Object::toString).containsExactly("ROLE_ADMIN");
+        verify(chain, times(1)).doFilter(any(), any());
+    }
+
+    @Test
+    void tokenVersionMismatch_isRejectedAsSessionRevoked() throws Exception {
+        User user = userWithRole(UserRole.USER); // DB tokenVersion 기본값 0
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(jwtTokenProvider.getTokenVersion("valid-token")).thenReturn(99); // 옛날에 발급된 토큰(버전 낮음/다름)
+
+        FilterChain chain = mock(FilterChain.class);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        filter.doFilter(requestWithToken("valid-token"), response, chain);
+
+        assertThat(response.getStatus()).isEqualTo(401);
+        assertThat(response.getContentAsString()).contains("SESSION_REVOKED");
+        verify(chain, times(0)).doFilter(any(), any());
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    }
+
+    @Test
+    void suspendedUser_isRejectedEvenWithValidUnexpiredToken() throws Exception {
+        User user = userWithRole(UserRole.USER);
+        user.suspend();
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(jwtTokenProvider.getTokenVersion("valid-token")).thenReturn(0);
+
+        FilterChain chain = mock(FilterChain.class);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        filter.doFilter(requestWithToken("valid-token"), response, chain);
+
+        assertThat(response.getStatus()).isEqualTo(403);
+        assertThat(response.getContentAsString()).contains("ACCOUNT_SUSPENDED");
+        verify(chain, times(0)).doFilter(any(), any());
+    }
+
+    @Test
+    void deletedUser_isRejected() throws Exception {
+        when(userRepository.findById(1L)).thenReturn(Optional.empty());
+        when(jwtTokenProvider.getTokenVersion("valid-token")).thenReturn(0);
+
+        FilterChain chain = mock(FilterChain.class);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        filter.doFilter(requestWithToken("valid-token"), response, chain);
+
+        assertThat(response.getStatus()).isEqualTo(401);
+        verify(chain, times(0)).doFilter(any(), any());
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/global/validation/InputSizeConstraintTest.java
+++ b/src/test/java/com/mamoki/ieojuda/global/validation/InputSizeConstraintTest.java
@@ -49,7 +49,8 @@ class InputSizeConstraintTest {
 
     private static final Map<Class<?>, Map<String, Integer>> EXPECTED_MAX_LENGTHS = Map.ofEntries(
             Map.entry(LoginRequest.class, Map.of("email", 255, "password", 128)),
-            Map.entry(RefreshRequest.class, Map.of("refreshToken", 255)),
+            // issue #56 - Refresh Token에 jti/iss/aud 클레임이 추가되면서 기존 255자로는 부족해져 2000자로 늘림
+            Map.entry(RefreshRequest.class, Map.of("refreshToken", 2000)),
             Map.entry(SignupRequest.class, Map.of("email", 255, "password", 128, "passwordConfirm", 128, "name", 100)),
             Map.entry(UserUpdateRequest.class, Map.of("email", 255, "name", 100)),
             Map.entry(ConfirmerRegisterRequest.class, Map.of("name", 100, "email", 255)),


### PR DESCRIPTION
## 연관 Issue
Closes #56

## 요약
평문 Refresh Token 저장과 약한 세션 폐기 구조를 개선했습니다. Refresh Token은 해시로만 저장하고 세션 단위로 회전·재사용 탐지를 하며, Access Token에는 jti/issuer/audience/token version을 실어 필터가 매 요청마다 DB의 현재 사용자 상태(권한/정지 여부/세션 유효성)를 대조하도록 바꿨습니다.

## 작업 내용
- `User.refreshToken`(평문 저장) 필드 제거, `status`(정지 여부)·`tokenVersion` 컬럼 추가
- `RefreshSession` 신규 엔티티 - Refresh Token은 SHA-256 해시만 저장, `familyId`로 로그인 1회의 회전 이력(lineage)을 묶음
- `JwtTokenProvider` 재작성 - 모든 토큰에 `jti`/`iss`/`aud` 부여, Access Token에는 발급 당시 `tokenVersion`도 함께 실음
- `AuthService` 재작성
  - 로그인: 새 세션 family 시작
  - 재발급(refresh): 세션 회전(이전 세션 소모 + 다음 세션에 연결)
  - **이미 소모된 Refresh Token이 재사용되면 탈취로 간주해 같은 family 전체를 차단**
  - 로그아웃: 계정의 모든 활성 세션 폐기 + tokenVersion 증가
- `JwtAuthenticationFilter` 재작성 - 서명 검증만으로 끝내지 않고 매 요청마다 DB에서 사용자를 재조회해 (1) 존재 여부 (2) 정지 상태 (3) tokenVersion 일치 여부를 확인하고, 권한(role)도 토큰의 claim이 아니라 **DB의 현재 값**을 사용
- `SessionRevocationService` 신규 - 이메일 변경(#48에서 하던 토큰 무효화에 추가)·계정 정지 시 세션 전체 폐기 + tokenVersion 증가. 재사용 탐지 시의 family 차단은 예외로 인한 트랜잭션 롤백에 휩쓸리지 않도록 `REQUIRES_NEW` 독립 트랜잭션으로 분리
- `AdminUserController`/`AdminUserService` 신규 - 계정 정지/복구 (정지 상태를 실제로 발생시킬 트리거가 없어서 최소 기능으로 추가)
- `AuthServiceTest`(5), `JwtAuthenticationFilterTest`(4) 신규 작성

## 범위
### 포함:
- Refresh Token 해시·회전·재사용 탐지
- 다중 세션 테이블(`RefreshSession`)과 jti·token version
- 계정(정지)·이메일 변경 시 세션 폐기
- JWT role claim이 아닌 DB의 현재 권한·사용자 상태를 신뢰하는 인가
### 제외:
- **비밀번호 변경 시 세션 폐기** - 이 코드베이스에 비밀번호 변경 API 자체가 없어서 연결할 대상이 없었음. `SessionRevocationService`는 준비되어 있어 추후 기능 추가 시 바로 연결 가능
- **역할 변경 시 명시적 세션 폐기** - 역할 승격이 API가 아니라 DB 직접 변경 방식이라 걸 트리거가 없음. 다만 필터가 매 요청 DB role을 신뢰하므로 다음 요청부터 자동 반영은 됨(조용히 반영되는 것이지, 세션을 끊는 형태는 아님)
- 소셜 로그인 추가, 공개 링크 토큰 모델 (이슈에서 명시적으로 제외된 항목)

## 스크린샷 / 미리 보기
백엔드 API 변경으로 스크린샷은 없습니다. 검증 내역(전부 실제 서버로 라이브 테스트):
- 로그인 → Access Token에 `jti`/`iss`/`aud`/`ver` 정상 포함 확인
- Refresh Token 회전 정상 동작
- 이미 소모된 Refresh Token 재사용 시도 → 차단 + 같은 family의 나머지 세션(정상 발급분 포함)도 함께 폐기됨을 확인 (최초 구현엔 이 부분이 트랜잭션 롤백으로 무효화되는 버그가 있었고, 라이브 테스트로 발견해 수정 후 재검증함)
- 로그아웃 → 아직 만료 전인 Access Token도 즉시 거부(`SESSION_REVOKED`)
- 이메일 변경 → 변경에 사용한 Access Token 자신도 즉시 거부
- 관리자 계정 정지 → 아직 만료 전인 Access Token도 즉시 거부(`ACCOUNT_SUSPENDED`)
- DB에서 role을 직접 USER→ADMIN으로 승격 → 토큰의 role claim은 여전히 USER인 상태에서도 그 토큰으로 관리자 전용 API 즉시 성공 (DB 신뢰 설계 확인)
- 전체 테스트 스위트(`./gradlew test`) 통과