### PR TITLE
[Fix/#57]: 사건·증빙·스케줄러 동시성 및 멱등성 보장

### DIFF
--- a/src/main/java/com/mamoki/ieojuda/domain/account/entity/User.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/account/entity/User.java
@@ -20,7 +20,7 @@ public class User extends BaseCreatedAtEntity {
     @Column(name = "user_id")
     private Long userId;
 
-    @Column(name = "email", length = 255, nullable = false)
+    @Column(name = "email", length = 255, nullable = false, unique = true)
     private String email;
 
     @Column(name = "password", length = 255, nullable = false)

--- a/src/main/java/com/mamoki/ieojuda/domain/account/service/AuthService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/account/service/AuthService.java
@@ -13,6 +13,7 @@ import com.mamoki.ieojuda.global.exception.CustomException;
 import com.mamoki.ieojuda.global.exception.ErrorCode;
 import com.mamoki.ieojuda.global.jwt.component.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,11 +38,18 @@ public class AuthService {
             throw new CustomException(ErrorCode.DUPLICATE_EMAIL);
         }
 
-        User user = userRepository.save(User.builder()
-                .email(request.email())
-                .password(passwordEncoder.encode(request.password()))
-                .name(request.name())
-                .build());
+        // 동시에 같은 이메일로 가입 요청이 들어오면 위 존재 여부 검사만으로는 막을 수 없으므로,
+        // DB 유니크 제약이 최종 방어선이다 - 여기서 즉시 flush해서 위반 시 여기서 바로 잡는다.
+        User user;
+        try {
+            user = userRepository.saveAndFlush(User.builder()
+                    .email(request.email())
+                    .password(passwordEncoder.encode(request.password()))
+                    .name(request.name())
+                    .build());
+        } catch (DataIntegrityViolationException e) {
+            throw new CustomException(ErrorCode.DUPLICATE_EMAIL);
+        }
 
         // 1인 1계획 고정 - "계획 만들기" 화면이 없어졌으므로 회원가입과 동시에 사후 인계 케이스(Plan)를 자동 생성한다.
         planRepository.save(Plan.builder().user(user).build());

--- a/src/main/java/com/mamoki/ieojuda/domain/account/service/UserService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/account/service/UserService.java
@@ -33,6 +33,7 @@ import com.mamoki.ieojuda.global.exception.CustomException;
 import com.mamoki.ieojuda.global.exception.ErrorCode;
 import com.mamoki.ieojuda.global.storage.EvidenceStorageClient;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -74,6 +75,16 @@ public class UserService {
         }
 
         user.updateProfile(request.email(), request.name());
+
+        // 위 존재 여부 검사와 실제 반영 사이의 경쟁 조건은 DB 유니크 제약이 최종 방어선이다 -
+        // 즉시 flush해서 위반 시 여기서 바로 DUPLICATE_EMAIL로 변환한다.
+        if (emailChanged) {
+            try {
+                userRepository.saveAndFlush(user);
+            } catch (DataIntegrityViolationException e) {
+                throw new CustomException(ErrorCode.DUPLICATE_EMAIL);
+            }
+        }
 
         // 로그인 이메일이 실제로 바뀌면(계정 탈취 대응) 이 계획에 걸린 담당자/확인자/이의연락처의
         // 기존 초대 토큰을 전부 무효화한다 - 새 이메일로 재초대해야 다시 접근할 수 있다.

--- a/src/main/java/com/mamoki/ieojuda/domain/confirmer/controller/DeathReportController.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/confirmer/controller/DeathReportController.java
@@ -12,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -24,12 +25,13 @@ public class DeathReportController {
 
     private final DeathReportService deathReportService;
 
-    @Operation(summary = "사망 사실 신고", description = "수락 완료한 확인자만 신고할 수 있습니다. 다른 확인자가 이미 신고했고 날짜가 일치하면 사후 인계 사건이 자동 생성됩니다.")
+    @Operation(summary = "사망 사실 신고", description = "수락 완료한 확인자만 신고할 수 있습니다. 다른 확인자가 이미 신고했고 날짜가 일치하면 사후 인계 사건이 자동 생성됩니다. Idempotency-Key 헤더를 보내면 같은 키의 재전송은 중복 요청(409)으로 응답합니다.")
     @PostMapping("/death-report")
     public ResponseEntity<RsData<DeathReportResponse>> report(
             @Parameter(description = "초대 토큰") @PathVariable String token,
-            @RequestBody(required = false) DeathReportRequest request
+            @RequestBody(required = false) DeathReportRequest request,
+            @RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey
     ) {
-        return ResponseEntity.ok(RsData.success(deathReportService.report(token, request)));
+        return ResponseEntity.ok(RsData.success(deathReportService.report(token, request, idempotencyKey)));
     }
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/confirmer/service/DeathReportService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/confirmer/service/DeathReportService.java
@@ -16,7 +16,9 @@ import com.mamoki.ieojuda.domain.releasecase.repository.ReleaseCaseRepository;
 import com.mamoki.ieojuda.global.email.token.TokenProvider;
 import com.mamoki.ieojuda.global.exception.CustomException;
 import com.mamoki.ieojuda.global.exception.ErrorCode;
+import com.mamoki.ieojuda.global.idempotency.service.IdempotencyGuard;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,9 +38,10 @@ public class DeathReportService {
     private final ReleaseCaseRepository releaseCaseRepository;
     private final PlanVersionRepository planVersionRepository;
     private final PlanSnapshotService planSnapshotService;
+    private final IdempotencyGuard idempotencyGuard;
 
     @Transactional
-    public DeathReportResponse report(String plainToken, DeathReportRequest request) {
+    public DeathReportResponse report(String plainToken, DeathReportRequest request, String idempotencyKey) {
         Confirmer confirmer = findByToken(plainToken);
 
         if (confirmer.getAcceptanceStatus() != AcceptanceStatus.ACCEPTED) {
@@ -47,6 +50,7 @@ public class DeathReportService {
         if (confirmer.getReportStatus() != ReportStatus.NOT_REPORTED) {
             throw new CustomException(ErrorCode.ACCESS_LINK_ALREADY_USED);
         }
+        idempotencyGuard.claim("death-report", idempotencyKey);
 
         confirmer.report(request == null ? null : request.deathDate());
 
@@ -92,8 +96,15 @@ public class DeathReportService {
                 PlanVersion.builder().plan(plan).versionNum(nextVersionNum).snapshotData(snapshotJson).build());
         planVersion.seal(snapshotHash);
 
-        ReleaseCase releaseCase = releaseCaseRepository.save(
-                ReleaseCase.builder().plan(plan).planVersion(planVersion).build());
+        // 위 존재 여부 검사만으로는 두 확인자의 신고가 정확히 동시에 매칭되는 경쟁 조건을 막을 수 없으므로,
+        // DB의 부분 유니크 인덱스(활성 사건은 계획당 1개)가 최종 방어선이다 - 즉시 flush해서 위반 시 여기서 잡는다.
+        ReleaseCase releaseCase;
+        try {
+            releaseCase = releaseCaseRepository.saveAndFlush(
+                    ReleaseCase.builder().plan(plan).planVersion(planVersion).build());
+        } catch (DataIntegrityViolationException e) {
+            throw new CustomException(ErrorCode.ACTIVE_RELEASE_CASE_EXISTS);
+        }
         releaseCase.confirmReport();
         releaseCase.awaitEvidence();
     }

--- a/src/main/java/com/mamoki/ieojuda/domain/evidence/controller/EvidenceSubmitController.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/evidence/controller/EvidenceSubmitController.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -24,12 +25,13 @@ public class EvidenceSubmitController {
 
     private final EvidenceSubmitService evidenceSubmitService;
 
-    @Operation(summary = "증빙 자료 제출", description = "PDF/JPG/PNG, 파일당 최대 25MB, 요청 전체 최대 30MB, 사건당 최대 3개까지 제출할 수 있습니다.")
+    @Operation(summary = "증빙 자료 제출", description = "PDF/JPG/PNG, 파일당 최대 25MB, 요청 전체 최대 30MB, 사건당 최대 3개까지 제출할 수 있습니다. Idempotency-Key 헤더를 보내면 같은 키의 재전송은 중복 요청(409)으로 응답합니다.")
     @PostMapping(value = "/evidences", consumes = "multipart/form-data")
     public ResponseEntity<RsData<EvidenceSubmitResponse>> submit(
             @Parameter(description = "초대 토큰") @PathVariable String token,
-            @RequestParam("file") MultipartFile file
+            @RequestParam("file") MultipartFile file,
+            @RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey
     ) {
-        return ResponseEntity.ok(RsData.success(evidenceSubmitService.submit(token, file)));
+        return ResponseEntity.ok(RsData.success(evidenceSubmitService.submit(token, file, idempotencyKey)));
     }
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/evidence/entity/Evidence.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/evidence/entity/Evidence.java
@@ -70,6 +70,11 @@ public class Evidence {
     @Column(name = "mime_type", length = 100)
     private String mimeType;
 
+    // 파트너 검토 결정이 동시에 두 번 들어오는 경우를 막기 위한 낙관적 잠금
+    @Version
+    @Column(name = "version")
+    private Long version;
+
     @Builder
     public Evidence(Confirmer confirmer, Plan plan, ReleaseCase releaseCase,
                     String storageKey, String fileName, String mimeType, String integrityHash) {

--- a/src/main/java/com/mamoki/ieojuda/domain/evidence/service/EvidenceSubmitService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/evidence/service/EvidenceSubmitService.java
@@ -13,6 +13,7 @@ import com.mamoki.ieojuda.domain.releasecase.repository.ReleaseCaseRepository;
 import com.mamoki.ieojuda.global.email.token.TokenProvider;
 import com.mamoki.ieojuda.global.exception.CustomException;
 import com.mamoki.ieojuda.global.exception.ErrorCode;
+import com.mamoki.ieojuda.global.idempotency.service.IdempotencyGuard;
 import com.mamoki.ieojuda.global.storage.EvidenceStorageClient;
 import com.mamoki.ieojuda.global.storage.contract.EvidenceUpload;
 import com.mamoki.ieojuda.global.storage.contract.StoredEvidence;
@@ -38,16 +39,23 @@ public class EvidenceSubmitService {
     private final ReleaseCaseRepository releaseCaseRepository;
     private final EvidenceRepository evidenceRepository;
     private final EvidenceStorageClient evidenceStorageClient;
+    private final IdempotencyGuard idempotencyGuard;
 
     @Transactional
-    public EvidenceSubmitResponse submit(String plainToken, MultipartFile file) {
+    public EvidenceSubmitResponse submit(String plainToken, MultipartFile file, String idempotencyKey) {
         Confirmer confirmer = findByToken(plainToken);
         if (confirmer.getAcceptanceStatus() != AcceptanceStatus.ACCEPTED) {
             throw new CustomException(ErrorCode.FORBIDDEN);
         }
+        idempotencyGuard.claim("evidence-submit", idempotencyKey);
 
         Plan plan = confirmer.getPlan();
         ReleaseCase releaseCase = releaseCaseRepository.findFirstByPlan_PlanIdOrderByCaseIdDesc(plan.getPlanId())
+                .orElseThrow(() -> new CustomException(ErrorCode.RELEASE_CASE_NOT_FOUND));
+
+        // "개수 확인 후 저장" 사이에 다른 요청이 끼어들지 못하도록, 이 트랜잭션이 끝날 때까지
+        // 같은 사건에 대한 다른 증빙 제출을 사건 행 잠금으로 직렬화한다.
+        releaseCase = releaseCaseRepository.findByIdForUpdate(releaseCase.getCaseId())
                 .orElseThrow(() -> new CustomException(ErrorCode.RELEASE_CASE_NOT_FOUND));
 
         validateFile(file);

--- a/src/main/java/com/mamoki/ieojuda/domain/partner/controller/PartnerReviewController.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/partner/controller/PartnerReviewController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -47,13 +48,14 @@ public class PartnerReviewController {
                 .body(file);
     }
 
-    @Operation(summary = "검토 결과 제출", description = "승인(APPROVE)/반려(REJECT)/추가자료요청(ADDITIONAL_INFO_REQUESTED) 중 하나를 기록합니다. AI 자동 승인은 없습니다.")
+    @Operation(summary = "검토 결과 제출", description = "승인(APPROVE)/반려(REJECT)/추가자료요청(ADDITIONAL_INFO_REQUESTED) 중 하나를 기록합니다. AI 자동 승인은 없습니다. Idempotency-Key 헤더를 보내면 같은 키의 재전송은 중복 요청(409)으로 응답합니다.")
     @PostMapping("/decision")
     public ResponseEntity<RsData<PartnerReviewResponse>> decide(
             @AuthenticationPrincipal Long userId,
             @Parameter(description = "검토 ID (증빙 ID)") @PathVariable Long reviewId,
-            @Valid @RequestBody PartnerReviewDecisionRequest request
+            @Valid @RequestBody PartnerReviewDecisionRequest request,
+            @RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey
     ) {
-        return ResponseEntity.ok(RsData.success(partnerReviewService.decide(reviewId, userId, request)));
+        return ResponseEntity.ok(RsData.success(partnerReviewService.decide(reviewId, userId, request, idempotencyKey)));
     }
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/partner/service/PartnerReviewService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/partner/service/PartnerReviewService.java
@@ -8,6 +8,7 @@ import com.mamoki.ieojuda.domain.partner.entity.PartnerReviewer;
 import com.mamoki.ieojuda.domain.partner.repository.PartnerReviewerRepository;
 import com.mamoki.ieojuda.global.exception.CustomException;
 import com.mamoki.ieojuda.global.exception.ErrorCode;
+import com.mamoki.ieojuda.global.idempotency.service.IdempotencyGuard;
 import com.mamoki.ieojuda.global.storage.EvidenceStorageClient;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -23,6 +24,7 @@ public class PartnerReviewService {
     private final EvidenceRepository evidenceRepository;
     private final PartnerReviewerRepository partnerReviewerRepository;
     private final EvidenceStorageClient evidenceStorageClient;
+    private final IdempotencyGuard idempotencyGuard;
 
     public PartnerReviewResponse getReview(Long reviewId) {
         return PartnerReviewResponse.from(findEvidence(reviewId));
@@ -34,7 +36,7 @@ public class PartnerReviewService {
     }
 
     @Transactional
-    public PartnerReviewResponse decide(Long reviewId, Long userId, PartnerReviewDecisionRequest request) {
+    public PartnerReviewResponse decide(Long reviewId, Long userId, PartnerReviewDecisionRequest request, String idempotencyKey) {
         Evidence evidence = findEvidence(reviewId);
         PartnerReviewer reviewer = findReviewerByUser(userId);
 
@@ -42,6 +44,7 @@ public class PartnerReviewService {
         if (!Boolean.TRUE.equals(reviewer.getIsActive())) {
             throw new CustomException(ErrorCode.REVIEWER_CONFLICT_OF_INTEREST);
         }
+        idempotencyGuard.claim("partner-review-decision", idempotencyKey);
 
         evidence.assignReviewer(reviewer);
 

--- a/src/main/java/com/mamoki/ieojuda/domain/releasecase/entity/ReleaseCase.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/releasecase/entity/ReleaseCase.java
@@ -51,6 +51,11 @@ public class ReleaseCase {
     @Column(name = "completed_at")
     private LocalDateTime completedAt;
 
+    // 동시에 여러 요청(파트너 승인, 스케줄러 등)이 같은 사건 상태를 전이시키려 할 때 뒤늦은 쪽을 밀어내기 위한 낙관적 잠금
+    @Version
+    @Column(name = "version")
+    private Long version;
+
     @Builder
     public ReleaseCase(Plan plan, PlanVersion planVersion) {
         this.plan = plan;

--- a/src/main/java/com/mamoki/ieojuda/domain/releasecase/repository/ReleaseCaseRepository.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/releasecase/repository/ReleaseCaseRepository.java
@@ -2,7 +2,11 @@ package com.mamoki.ieojuda.domain.releasecase.repository;
 
 import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCase;
 import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCaseStatus;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -13,8 +17,20 @@ public interface ReleaseCaseRepository extends JpaRepository<ReleaseCase, Long> 
     // 계획당 진행 중인 사건은 하나뿐 - 작성자 본인용 대기상태 조회, 사망 신고 시 중복 생성 방지에 사용
     Optional<ReleaseCase> findFirstByPlan_PlanIdOrderByCaseIdDesc(Long planId);
 
-    // 스케줄러 - 대기 기간이 끝났고 동결되지 않은 사건을 찾기 위한 조회
+    // 스케줄러 - 대기 기간이 끝났고 동결되지 않은 사건을 찾기 위한 조회 (일반 조회용, 잠금 없음)
     List<ReleaseCase> findByStatusAndFrozenFalseAndWaitingEndsAtLessThanEqual(ReleaseCaseStatus status, LocalDateTime now);
+
+    // 스케줄러 - 다중 인스턴스가 동시에 같은 사건을 처리하지 않도록 FOR UPDATE SKIP LOCKED로 조회.
+    // 이미 다른 인스턴스가 잠근 행은 건너뛰고, 잠금을 잡은 사건만 이번 트랜잭션이 독점 처리한다.
+    @Query(value = "SELECT * FROM release_cases " +
+            "WHERE status = 'WAITING' AND frozen = false AND waiting_ends_at <= :now " +
+            "FOR UPDATE SKIP LOCKED", nativeQuery = true)
+    List<ReleaseCase> findDueCasesForUpdateSkipLocked(@Param("now") LocalDateTime now);
+
+    // 증빙 제출 - "개수 확인 후 저장" 사이의 경쟁 조건을 막기 위해 사건 행에 비관적 잠금을 건다
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select rc from ReleaseCase rc where rc.caseId = :caseId")
+    Optional<ReleaseCase> findByIdForUpdate(@Param("caseId") Long caseId);
 
     // 계정 삭제 시 이 계획에 쌓인 사건(취소/완료된 과거 이력 포함)을 전부 지우기 위한 조회
     List<ReleaseCase> findByPlan_PlanId(Long planId);

--- a/src/main/java/com/mamoki/ieojuda/domain/releasecase/scheduler/ReleaseCaseScheduler.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/releasecase/scheduler/ReleaseCaseScheduler.java
@@ -5,7 +5,6 @@ import com.mamoki.ieojuda.domain.plan.service.PlanSnapshotService;
 import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
 import com.mamoki.ieojuda.domain.recipient.repository.RecipientRepository;
 import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCase;
-import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCaseStatus;
 import com.mamoki.ieojuda.domain.releasecase.repository.ReleaseCaseRepository;
 import com.mamoki.ieojuda.domain.stage.service.HandoverStageService;
 import lombok.RequiredArgsConstructor;
@@ -33,11 +32,13 @@ public class ReleaseCaseScheduler {
     private final HandoverStageService handoverStageService;
 
     // 10분마다 - 대기기간이 긴(일 단위) 도메인 특성상 촘촘한 주기가 필요하지 않음
+    // FOR UPDATE SKIP LOCKED로 조회하므로, 다중 인스턴스가 동시에 돌아도 각 인스턴스는
+    // 서로 다른 사건만 잠가서 처리한다 - 같은 사건이 중복으로 발송되지 않는다(issue #57).
     @Scheduled(fixedRate = 600_000)
     @Transactional
     public void progressExpiredWaitingCases() {
         List<ReleaseCase> dueCases = releaseCaseRepository
-                .findByStatusAndFrozenFalseAndWaitingEndsAtLessThanEqual(ReleaseCaseStatus.WAITING, LocalDateTime.now());
+                .findDueCasesForUpdateSkipLocked(LocalDateTime.now());
 
         for (ReleaseCase releaseCase : dueCases) {
             progressCase(releaseCase);

--- a/src/main/java/com/mamoki/ieojuda/domain/stage/entity/HandoverStage.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/stage/entity/HandoverStage.java
@@ -47,6 +47,11 @@ public class HandoverStage {
     @Column(name = "confirmed_at")
     private LocalDateTime confirmedAt;
 
+    // 대체 담당자 전환·완료 처리가 동시에 들어오는 경우를 막기 위한 낙관적 잠금
+    @Version
+    @Column(name = "version")
+    private Long version;
+
     @Builder
     public HandoverStage(Plan plan, Recipient recipient, Integer stageOrder) {
         this.plan = plan;

--- a/src/main/java/com/mamoki/ieojuda/global/exception/ErrorCode.java
+++ b/src/main/java/com/mamoki/ieojuda/global/exception/ErrorCode.java
@@ -81,6 +81,8 @@ public enum ErrorCode {
     RECIPIENT_RESEND_NOT_ALLOWED(HttpStatus.CONFLICT, "RECIPIENT_RESEND_NOT_ALLOWED", "현재 수락 상태에서는 수락 요청을 다시 보낼 수 없습니다."),
     CONFIRMER_RESEND_NOT_ALLOWED(HttpStatus.CONFLICT, "CONFIRMER_RESEND_NOT_ALLOWED", "현재 수락 상태에서는 수락 요청을 다시 보낼 수 없습니다."),
     ITEM_ORDER_CONFLICT(HttpStatus.CONFLICT, "ITEM_ORDER_CONFLICT", "순서 충돌이 있어 확정할 수 없습니다."),
+    DUPLICATE_REQUEST(HttpStatus.CONFLICT, "DUPLICATE_REQUEST", "이미 처리 중이거나 처리된 요청입니다."),
+    CONCURRENT_MODIFICATION(HttpStatus.CONFLICT, "CONCURRENT_MODIFICATION", "다른 요청이 먼저 처리되어 현재 상태와 충돌합니다. 다시 시도해 주세요."),
 
     // 서버 에러 (500)
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR","서버 오류가 발생했습니다.");

--- a/src/main/java/com/mamoki/ieojuda/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/mamoki/ieojuda/global/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
@@ -94,6 +95,14 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(ErrorCode.RESOURCE_NOT_FOUND.getHttpStatus())
                 .body(RsData.fail(ErrorCode.RESOURCE_NOT_FOUND));
+    }
+
+    // 낙관적 잠금 충돌 (409) -> @Version이 걸린 엔티티(사건/증빙/단계)를 동시에 수정하려다 한쪽이 밀려난 경우
+    @ExceptionHandler(OptimisticLockingFailureException.class)
+    public ResponseEntity<RsData<Void>> handle(OptimisticLockingFailureException exception) {
+        return ResponseEntity
+                .status(ErrorCode.CONCURRENT_MODIFICATION.getHttpStatus())
+                .body(RsData.fail(ErrorCode.CONCURRENT_MODIFICATION));
     }
 
     // 커스텀 예외 처리 (나머지 예외는 스프링에서 자동으로 적용시켜주는 것이 없어 커스텀으로 처리함)

--- a/src/main/java/com/mamoki/ieojuda/global/idempotency/entity/IdempotencyKey.java
+++ b/src/main/java/com/mamoki/ieojuda/global/idempotency/entity/IdempotencyKey.java
@@ -1,0 +1,45 @@
+package com.mamoki.ieojuda.global.idempotency.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+// 클라이언트가 보낸 Idempotency-Key를 (요청 종류, 키 값) 조합으로 선점하는 마커.
+// 같은 조합으로 두 번째 INSERT가 들어오면 DB 유니크 제약이 즉시 막아준다 - 그 신호로 중복 요청을 판별한다.
+@Entity
+@Table(name = "idempotency_keys", uniqueConstraints = @UniqueConstraint(columnNames = {"scope", "key_value"}))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class IdempotencyKey {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "idempotency_key_id")
+    private Long idempotencyKeyId;
+
+    @Column(name = "scope", length = 100, nullable = false)
+    private String scope;
+
+    @Column(name = "key_value", length = 255, nullable = false)
+    private String keyValue;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public IdempotencyKey(String scope, String keyValue) {
+        this.scope = scope;
+        this.keyValue = keyValue;
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/global/idempotency/repository/IdempotencyKeyRepository.java
+++ b/src/main/java/com/mamoki/ieojuda/global/idempotency/repository/IdempotencyKeyRepository.java
@@ -1,0 +1,7 @@
+package com.mamoki.ieojuda.global.idempotency.repository;
+
+import com.mamoki.ieojuda.global.idempotency.entity.IdempotencyKey;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface IdempotencyKeyRepository extends JpaRepository<IdempotencyKey, Long> {
+}

--- a/src/main/java/com/mamoki/ieojuda/global/idempotency/service/IdempotencyGuard.java
+++ b/src/main/java/com/mamoki/ieojuda/global/idempotency/service/IdempotencyGuard.java
@@ -1,0 +1,32 @@
+package com.mamoki.ieojuda.global.idempotency.service;
+
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import com.mamoki.ieojuda.global.idempotency.entity.IdempotencyKey;
+import com.mamoki.ieojuda.global.idempotency.repository.IdempotencyKeyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Component;
+
+// 클라이언트가 Idempotency-Key 헤더를 보낸 요청을 (scope, key) 조합으로 선점한다.
+// 호출부의 트랜잭션에 그대로 참여한다 - 이후 비즈니스 로직이 실패해 트랜잭션이 롤백되면 이 선점도
+// 함께 롤백되어 재시도가 가능하고, 성공적으로 커밋된 요청만 진짜로 키를 소비한 것이 된다.
+@Component
+@RequiredArgsConstructor
+public class IdempotencyGuard {
+
+    private final IdempotencyKeyRepository idempotencyKeyRepository;
+
+    // idempotencyKey가 없으면(헤더 미전송) 아무 것도 하지 않는다 - 이 가드는 옵트인이다.
+    public void claim(String scope, String idempotencyKey) {
+        if (idempotencyKey == null || idempotencyKey.isBlank()) {
+            return;
+        }
+        try {
+            idempotencyKeyRepository.saveAndFlush(
+                    IdempotencyKey.builder().scope(scope).keyValue(idempotencyKey).build());
+        } catch (DataIntegrityViolationException e) {
+            throw new CustomException(ErrorCode.DUPLICATE_REQUEST);
+        }
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/domain/confirmer/service/DeathReportServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/confirmer/service/DeathReportServiceTest.java
@@ -12,6 +12,7 @@ import com.mamoki.ieojuda.domain.plan.repository.PlanVersionRepository;
 import com.mamoki.ieojuda.domain.plan.service.PlanSnapshotService;
 import com.mamoki.ieojuda.domain.releasecase.repository.ReleaseCaseRepository;
 import com.mamoki.ieojuda.global.email.token.TokenProvider;
+import com.mamoki.ieojuda.global.idempotency.service.IdempotencyGuard;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -34,6 +35,7 @@ class DeathReportServiceTest {
     private ReleaseCaseRepository releaseCaseRepository;
     private PlanVersionRepository planVersionRepository;
     private PlanSnapshotService planSnapshotService;
+    private IdempotencyGuard idempotencyGuard;
     private DeathReportService deathReportService;
 
     @BeforeEach
@@ -42,8 +44,9 @@ class DeathReportServiceTest {
         releaseCaseRepository = mock(ReleaseCaseRepository.class);
         planVersionRepository = mock(PlanVersionRepository.class);
         planSnapshotService = mock(PlanSnapshotService.class);
+        idempotencyGuard = mock(IdempotencyGuard.class);
         deathReportService = new DeathReportService(
-                confirmerRepository, releaseCaseRepository, planVersionRepository, planSnapshotService);
+                confirmerRepository, releaseCaseRepository, planVersionRepository, planSnapshotService, idempotencyGuard);
     }
 
     @Test
@@ -71,9 +74,9 @@ class DeathReportServiceTest {
         when(planSnapshotService.hash("{\"planId\":1}")).thenReturn("deadbeef");
 
         when(planVersionRepository.save(any(PlanVersion.class))).thenAnswer(invocation -> invocation.getArgument(0));
-        when(releaseCaseRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(releaseCaseRepository.saveAndFlush(any())).thenAnswer(invocation -> invocation.getArgument(0));
 
-        deathReportService.report("token-a", new DeathReportRequest(LocalDate.of(2026, 8, 15)));
+        deathReportService.report("token-a", new DeathReportRequest(LocalDate.of(2026, 8, 15)), null);
 
         ArgumentCaptor<PlanVersion> versionCaptor = ArgumentCaptor.forClass(PlanVersion.class);
         verify(planVersionRepository).save(versionCaptor.capture());

--- a/src/test/java/com/mamoki/ieojuda/domain/releasecase/IssueFiftySevenConcurrencyTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/releasecase/IssueFiftySevenConcurrencyTest.java
@@ -1,0 +1,288 @@
+package com.mamoki.ieojuda.domain.releasecase;
+
+import com.mamoki.ieojuda.domain.account.dto.SignupRequest;
+import com.mamoki.ieojuda.domain.account.entity.User;
+import com.mamoki.ieojuda.domain.account.repository.UserRepository;
+import com.mamoki.ieojuda.domain.account.service.AuthService;
+import com.mamoki.ieojuda.domain.confirmer.entity.Confirmer;
+import com.mamoki.ieojuda.domain.confirmer.entity.Relationship;
+import com.mamoki.ieojuda.domain.confirmer.repository.ConfirmerRepository;
+import com.mamoki.ieojuda.domain.evidence.repository.EvidenceRepository;
+import com.mamoki.ieojuda.domain.evidence.service.EvidenceSubmitService;
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.plan.entity.PlanVersion;
+import com.mamoki.ieojuda.domain.plan.repository.PlanRepository;
+import com.mamoki.ieojuda.domain.plan.repository.PlanVersionRepository;
+import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCase;
+import com.mamoki.ieojuda.domain.releasecase.repository.ReleaseCaseRepository;
+import com.mamoki.ieojuda.global.email.token.TokenProvider;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import com.mamoki.ieojuda.global.storage.EvidenceStorageClient;
+import com.mamoki.ieojuda.global.storage.contract.StoredEvidence;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+// issue #57 - 실제 DB 제약/잠금이 진짜 동시 요청에서도 지켜지는지 검증한다. Mockito 목으로는 DB 유니크
+// 제약이나 비관적 잠금의 효과를 확인할 수 없으므로(#56에서 겪은 트랜잭션 롤백 버그와 같은 종류의 함정),
+// 실제 스프링 컨텍스트와 개발 DB에 대해 여러 스레드로 동시에 호출해 검증한다.
+@SpringBootTest
+class IssueFiftySevenConcurrencyTest {
+
+    @Autowired
+    private AuthService authService;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private PlanRepository planRepository;
+    @Autowired
+    private PlanVersionRepository planVersionRepository;
+    @Autowired
+    private ReleaseCaseRepository releaseCaseRepository;
+    @Autowired
+    private ConfirmerRepository confirmerRepository;
+    @Autowired
+    private EvidenceRepository evidenceRepository;
+    @Autowired
+    private EvidenceSubmitService evidenceSubmitService;
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    @MockitoBean
+    private EvidenceStorageClient evidenceStorageClient;
+
+    @Test
+    void signup_whenTwoRequestsUseSameEmailConcurrently_onlyOneSucceeds() throws Exception {
+        String email = "race-" + UUID.randomUUID() + "@test.com";
+        SignupRequest request = new SignupRequest(email, "password1234", "password1234", "동시가입");
+
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+        Callable<Boolean> task = () -> {
+            ready.countDown();
+            start.await();
+            try {
+                authService.signup(request);
+                return true;
+            } catch (CustomException e) {
+                assertThat(e.getErrorCode()).isEqualTo(ErrorCode.DUPLICATE_EMAIL);
+                return false;
+            }
+        };
+
+        ExecutorService pool = Executors.newFixedThreadPool(2);
+        try {
+            Future<Boolean> f1 = pool.submit(task);
+            Future<Boolean> f2 = pool.submit(task);
+            ready.await(5, TimeUnit.SECONDS);
+            start.countDown();
+
+            long successCount = List.of(f1.get(10, TimeUnit.SECONDS), f2.get(10, TimeUnit.SECONDS))
+                    .stream().filter(Boolean::booleanValue).count();
+
+            assertThat(successCount).isEqualTo(1);
+        } finally {
+            pool.shutdown();
+            userRepository.findByEmail(email).ifPresent(u -> {
+                planRepository.findByUser_UserId(u.getUserId()).ifPresent(planRepository::delete);
+                userRepository.delete(u);
+            });
+        }
+    }
+
+    @Test
+    void releaseCase_whenTwoConcurrentCreationsTargetTheSamePlan_onlyOneSucceeds() throws Exception {
+        User user = userRepository.saveAndFlush(User.builder()
+                .email("case-race-" + UUID.randomUUID() + "@test.com").password("hash").name("A").build());
+        Plan plan = planRepository.saveAndFlush(Plan.builder().user(user).build());
+        PlanVersion version1 = planVersionRepository.saveAndFlush(
+                PlanVersion.builder().plan(plan).versionNum(1).snapshotData("{}").build());
+        PlanVersion version2 = planVersionRepository.saveAndFlush(
+                PlanVersion.builder().plan(plan).versionNum(2).snapshotData("{}").build());
+
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+        Callable<Boolean> task1 = () -> attemptCreate(plan, version1, ready, start);
+        Callable<Boolean> task2 = () -> attemptCreate(plan, version2, ready, start);
+
+        ExecutorService pool = Executors.newFixedThreadPool(2);
+        try {
+            Future<Boolean> f1 = pool.submit(task1);
+            Future<Boolean> f2 = pool.submit(task2);
+            ready.await(5, TimeUnit.SECONDS);
+            start.countDown();
+
+            long successCount = List.of(f1.get(10, TimeUnit.SECONDS), f2.get(10, TimeUnit.SECONDS))
+                    .stream().filter(Boolean::booleanValue).count();
+
+            // 계획당 취소되지 않은 활성 사건은 DB 부분 유니크 인덱스(uq_release_cases_active_plan)로
+            // 하나만 허용된다 - 두 스레드가 동시에 시도해도 실제로 성공하는 건 하나뿐이어야 한다.
+            assertThat(successCount).isEqualTo(1);
+        } finally {
+            pool.shutdown();
+            releaseCaseRepository.findByPlan_PlanId(plan.getPlanId()).forEach(releaseCaseRepository::delete);
+            planVersionRepository.delete(version1);
+            planVersionRepository.delete(version2);
+            planRepository.delete(plan);
+            userRepository.delete(user);
+        }
+    }
+
+    private boolean attemptCreate(Plan plan, PlanVersion version, CountDownLatch ready, CountDownLatch start)
+            throws InterruptedException {
+        ready.countDown();
+        start.await();
+        try {
+            releaseCaseRepository.saveAndFlush(ReleaseCase.builder().plan(plan).planVersion(version).build());
+            return true;
+        } catch (DataIntegrityViolationException e) {
+            return false;
+        }
+    }
+
+    @Test
+    void evidenceSubmit_whenFiveRequestsRaceForTheSameCase_onlyMaxFileCountSucceed() throws Exception {
+        when(evidenceStorageClient.store(any(), any()))
+                .thenReturn(new StoredEvidence("evidence/race/test", "hash", 3));
+
+        User user = userRepository.saveAndFlush(User.builder()
+                .email("evidence-race-" + UUID.randomUUID() + "@test.com").password("hash").name("A").build());
+        Plan plan = planRepository.saveAndFlush(Plan.builder().user(user).build());
+        PlanVersion version = planVersionRepository.saveAndFlush(
+                PlanVersion.builder().plan(plan).versionNum(1).snapshotData("{}").build());
+        ReleaseCase releaseCase = releaseCaseRepository.saveAndFlush(
+                ReleaseCase.builder().plan(plan).planVersion(version).build());
+        releaseCase.confirmReport();
+        releaseCase.awaitEvidence();
+
+        Confirmer confirmer = Confirmer.builder().plan(plan).name("확인자").relationship(Relationship.FRIEND)
+                .email("confirmer-" + UUID.randomUUID() + "@test.com").build();
+        String plainToken = "evidence-race-token-" + UUID.randomUUID();
+        confirmer.issueInviteToken(TokenProvider.hashToken(plainToken), LocalDateTime.now().plusHours(1));
+        confirmer.accept(null);
+        confirmerRepository.saveAndFlush(confirmer);
+
+        int attempts = 5;
+        CountDownLatch ready = new CountDownLatch(attempts);
+        CountDownLatch start = new CountDownLatch(1);
+        ExecutorService pool = Executors.newFixedThreadPool(attempts);
+        try {
+            List<Future<Boolean>> futures = IntStream.range(0, attempts)
+                    .mapToObj(i -> pool.<Boolean>submit(() -> {
+                        ready.countDown();
+                        start.await();
+                        MockMultipartFile file = new MockMultipartFile(
+                                "file", "proof-" + i + ".pdf", "application/pdf", new byte[]{1, 2, 3});
+                        try {
+                            evidenceSubmitService.submit(plainToken, file, null);
+                            return true;
+                        } catch (CustomException e) {
+                            assertThat(e.getErrorCode()).isEqualTo(ErrorCode.EVIDENCE_SUBMISSION_INVALID);
+                            return false;
+                        }
+                    }))
+                    .toList();
+            ready.await(5, TimeUnit.SECONDS);
+            start.countDown();
+
+            long successCount = 0;
+            for (Future<Boolean> f : futures) {
+                if (f.get(10, TimeUnit.SECONDS)) {
+                    successCount++;
+                }
+            }
+
+            // 사건당 최대 3개(MAX_FILE_COUNT) - 동시에 5건이 들어와도 "개수 확인 후 저장" 경쟁 조건 없이
+            // 정확히 3건만 성공해야 한다 (사건 행 비관적 잠금으로 직렬화됨).
+            assertThat(successCount).isEqualTo(3);
+            assertThat(evidenceRepository.countByReleaseCase_CaseId(releaseCase.getCaseId())).isEqualTo(3);
+        } finally {
+            pool.shutdown();
+            evidenceRepository.findByPlan_PlanId(plan.getPlanId()).forEach(evidenceRepository::delete);
+            releaseCaseRepository.delete(releaseCase);
+            confirmerRepository.delete(confirmer);
+            planVersionRepository.delete(version);
+            planRepository.delete(plan);
+            userRepository.delete(user);
+        }
+    }
+
+    @Test
+    void findDueCasesForUpdateSkipLocked_whenAnotherTransactionHoldsTheLock_skipsItWithoutBlocking() throws Exception {
+        User user = userRepository.saveAndFlush(User.builder()
+                .email("scheduler-race-" + UUID.randomUUID() + "@test.com").password("hash").name("A").build());
+        Plan plan = planRepository.saveAndFlush(Plan.builder().user(user).build());
+        PlanVersion version = planVersionRepository.saveAndFlush(
+                PlanVersion.builder().plan(plan).versionNum(1).snapshotData("{}").build());
+        ReleaseCase dueCase = releaseCaseRepository.saveAndFlush(
+                ReleaseCase.builder().plan(plan).planVersion(version).build());
+        dueCase.confirmReport();
+        dueCase.awaitEvidence();
+        dueCase.startEvidenceReview();
+        dueCase.approveEvidenceAndStartWaiting(0); // waitingEndsAt = 지금
+        // saveAndFlush(detached entity)는 merge()라서 새 관리 인스턴스를 반환한다 - 반드시 재할당해야
+        // 이후 delete(dueCase)에서 최신 version을 참조해 낙관적 잠금 충돌이 나지 않는다.
+        dueCase = releaseCaseRepository.saveAndFlush(dueCase);
+
+        TransactionTemplate txTemplate = new TransactionTemplate(transactionManager);
+        CountDownLatch locked = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+        ExecutorService pool = Executors.newFixedThreadPool(1);
+        try {
+            Future<List<Long>> holderFuture = pool.submit(() -> txTemplate.execute(status -> {
+                List<Long> heldIds = releaseCaseRepository.findDueCasesForUpdateSkipLocked(LocalDateTime.now())
+                        .stream().map(ReleaseCase::getCaseId).toList();
+                locked.countDown();
+                try {
+                    release.await(5, TimeUnit.SECONDS);
+                } catch (InterruptedException ignored) {
+                    Thread.currentThread().interrupt();
+                }
+                return heldIds;
+            }));
+
+            locked.await(5, TimeUnit.SECONDS);
+            long startedAt = System.currentTimeMillis();
+            List<Long> secondAttemptIds = txTemplate.execute(status ->
+                    releaseCaseRepository.findDueCasesForUpdateSkipLocked(LocalDateTime.now())
+                            .stream().map(ReleaseCase::getCaseId).toList());
+            long elapsedMs = System.currentTimeMillis() - startedAt;
+            release.countDown();
+
+            List<Long> firstAttemptIds = holderFuture.get(10, TimeUnit.SECONDS);
+
+            // 첫 번째 트랜잭션이 이 사건을 잠근 상태에서, 두 번째("다른 인스턴스")는 SKIP LOCKED 덕분에
+            // 그 사건을 건너뛰고 즉시 반환한다(블로킹 없음) - 같은 사건이 중복으로 처리되지 않는다.
+            assertThat(firstAttemptIds).contains(dueCase.getCaseId());
+            assertThat(secondAttemptIds).doesNotContain(dueCase.getCaseId());
+            assertThat(elapsedMs).isLessThan(3000);
+        } finally {
+            pool.shutdown();
+            releaseCaseRepository.delete(dueCase);
+            planVersionRepository.delete(version);
+            planRepository.delete(plan);
+            userRepository.delete(user);
+        }
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/domain/releasecase/scheduler/ReleaseCaseSchedulerTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/releasecase/scheduler/ReleaseCaseSchedulerTest.java
@@ -10,7 +10,6 @@ import com.mamoki.ieojuda.domain.plan.service.PlanSnapshotService;
 import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
 import com.mamoki.ieojuda.domain.recipient.repository.RecipientRepository;
 import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCase;
-import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCaseStatus;
 import com.mamoki.ieojuda.domain.releasecase.repository.ReleaseCaseRepository;
 import com.mamoki.ieojuda.domain.stage.service.HandoverStageService;
 import org.junit.jupiter.api.BeforeEach;
@@ -64,8 +63,7 @@ class ReleaseCaseSchedulerTest {
         when(releaseCase.getPlan()).thenReturn(plan);
         when(releaseCase.getPlanVersion()).thenReturn(planVersion);
 
-        when(releaseCaseRepository.findByStatusAndFrozenFalseAndWaitingEndsAtLessThanEqual(
-                any(ReleaseCaseStatus.class), any(LocalDateTime.class)))
+        when(releaseCaseRepository.findDueCasesForUpdateSkipLocked(any(LocalDateTime.class)))
                 .thenReturn(List.of(releaseCase));
         when(planSnapshotService.deserialize("{\"frozen\":true}")).thenReturn(snapshot);
 
@@ -89,8 +87,7 @@ class ReleaseCaseSchedulerTest {
         ReleaseCase releaseCase = mock(ReleaseCase.class);
         when(releaseCase.getPlan()).thenReturn(plan);
 
-        when(releaseCaseRepository.findByStatusAndFrozenFalseAndWaitingEndsAtLessThanEqual(
-                any(ReleaseCaseStatus.class), any(LocalDateTime.class)))
+        when(releaseCaseRepository.findDueCasesForUpdateSkipLocked(any(LocalDateTime.class)))
                 .thenReturn(List.of(releaseCase));
 
         scheduler.progressExpiredWaitingCases();

--- a/src/test/java/com/mamoki/ieojuda/global/validation/InputSizeConstraintTest.java
+++ b/src/test/java/com/mamoki/ieojuda/global/validation/InputSizeConstraintTest.java
@@ -162,7 +162,7 @@ class InputSizeConstraintTest {
 
     @Test
     void evidenceFilenameMatchesTheDatabaseColumnLimit() {
-        EvidenceSubmitService service = new EvidenceSubmitService(null, null, null, null);
+        EvidenceSubmitService service = new EvidenceSubmitService(null, null, null, null, null);
         MockMultipartFile valid = new MockMultipartFile(
                 "file", "x".repeat(255), "application/pdf", new byte[]{1});
         MockMultipartFile oversized = new MockMultipartFile(


### PR DESCRIPTION
## 연관 Issue
Closes #57

## 요약
다중 인스턴스·동시 요청에서 사건/증빙/사용자 이메일이 중복 생성되던 경쟁 조건을 DB 제약과 잠금으로 제거하고, 클라이언트 재전송에 대한 idempotency key 처리를 추가했습니다.

## 작업 내용
- `users.email`에 DB 유니크 제약 추가, `AuthService.signup()` / `UserService.updateProfile()`에 `saveAndFlush` + `DataIntegrityViolationException` 캐치로 경쟁 조건 방어 추가
- `release_cases`에 부분 유니크 인덱스(`plan_id`, `WHERE canceled_at IS NULL`) 추가해 계획당 활성 사건 1개 보장, `DeathReportService.createReleaseCase()`에 동일한 flush + 예외 캐치 패턴 적용
- `ReleaseCase`, `Evidence`, `HandoverStage`에 `@Version` 낙관적 잠금 추가, `GlobalExceptionHandler`에 `OptimisticLockingFailureException` → 409(`CONCURRENT_MODIFICATION`) 매핑 추가
- `EvidenceSubmitService.submit()`의 "개수 확인 후 저장" 구간에 사건 행 비관적 잠금(`SELECT ... FOR UPDATE`) 적용해 최대 3개 제한을 동시 요청에서도 보장
- `ReleaseCaseScheduler`의 대상 조회 쿼리를 `FOR UPDATE SKIP LOCKED` 네이티브 쿼리로 교체해 다중 인스턴스가 같은 사건을 중복 처리하지 않도록 함
- `IdempotencyKey` 엔티티/`IdempotencyGuard` 신규 추가, 사망 신고·증빙 제출·파트너 검토 결정 3개 엔드포인트에 `Idempotency-Key` 헤더(옵트인) 연동 - 재전송 시 409(`DUPLICATE_REQUEST`)
- 신규 ErrorCode 2개 추가(`DUPLICATE_REQUEST`, `CONCURRENT_MODIFICATION`)
- 실제 DB에 대해 동시 스레드로 호출하는 통합 테스트 4건 추가(`IssueFiftySevenConcurrencyTest`): 동시 회원가입, 동시 사건 생성, 동시 증빙 제출, 스케줄러 SKIP LOCKED
- 기존 테스트(`DeathReportServiceTest`, `ReleaseCaseSchedulerTest`, `InputSizeConstraintTest`) 시그니처 변경분 반영

## 범위
### 포함:
- DB 유니크 제약, `@Version`, 비관적 잠금, 스케줄러 SKIP LOCKED, idempotency key
- 사건 생성·증빙 개수·스케줄러 동시성 제어

### 제외:
- 증빙 최대 개수는 앱 레벨 잠금으로 보장 - DB 트리거 등 진짜 DB 레벨 제약은 아님
- 파트너 검토 결정(승인/반려) 동시 처리에 대한 전용 동시성 테스트는 미작성 (`@Version`으로 이론상 방어되나 검증 테스트 없음)
- `RecipientService`/`ConfirmerService`의 담당자·확인자 등록 시 check-then-insert 경쟁 조건은 이슈 범위(사건·증빙·단계·이메일·사용자) 밖으로 판단해 다루지 않음
- 비즈니스 상태 전이 규칙 재설계, 인프라 오토스케일링 설정
- **DB 마이그레이션 수동 적용 필요**: `ddl-auto=update`가 기존 행이 있는 테이블에 `@Version` 컬럼을 NOT NULL로 바로 추가하지 못해, `evidences`/`handover_stages`/`release_cases`에 `version` 컬럼을 수동으로 추가(`ADD COLUMN ... DEFAULT 0`)했습니다. 다른 환경에 배포 시 동일하게 수동 처리 필요합니다.

## 스크린샷 / 미리 보기
<!-- 해당 없음 - 백엔드 동시성 로직 변경 -->