### PR TITLE
[Refactor/#59]: 관리자·외부 파트너 세부 권한 분리

### DIFF
--- a/src/main/java/com/mamoki/ieojuda/domain/account/entity/AdminPermission.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/account/entity/AdminPermission.java
@@ -1,0 +1,10 @@
+package com.mamoki.ieojuda.domain.account.entity;
+
+// issue #59 - ROLE_ADMIN/ROLE_EXTERNAL 하나에 뭉쳐 있던 권한을 업무 단위로 세분화.
+// role 승격과 마찬가지로 DB에서 직접 부여한다(별도 부여 API 없음).
+public enum AdminPermission {
+    CASE_SUPERVISE,        // 사건 동결, 재시도 발송, 대체 담당자 전환, 파트너사 배정
+    EVIDENCE_REVIEW,       // 외부 파트너 증빙 검토(승인/반려/추가자료요청)
+    AUDIT_VIEW,            // 이메일 발송 감사, 인증 실패 감사, 관리자 조작 감사 조회
+    EVIDENCE_DELETE_RETRY  // 증빙 삭제 상태 조회 및 재처리
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/account/entity/User.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/account/entity/User.java
@@ -8,6 +8,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
 
 @Entity
 @Table(name = "users")
@@ -42,12 +44,23 @@ public class User extends BaseCreatedAtEntity {
     @Column(name = "role", length = 20, nullable = false)
     private UserRole role;
 
+    // issue #59 - ADMIN/EXTERNAL 안에서도 업무 단위로 세분화된 권한. USER는 항상 비어있다.
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "user_permissions", joinColumns = @JoinColumn(name = "user_id"))
+    @Enumerated(EnumType.STRING)
+    @Column(name = "permission", length = 30)
+    private Set<AdminPermission> permissions = new HashSet<>();
+
     @Builder
     public User(String email, String password, String name) {
         this.email = email;
         this.password = password;
         this.name = name;
         this.role = UserRole.USER;
+    }
+
+    public boolean hasPermission(AdminPermission permission) {
+        return permissions.contains(permission);
     }
 
     public void updateRefreshToken(String refreshToken) {

--- a/src/main/java/com/mamoki/ieojuda/domain/audit/controller/AdminActionAuditController.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/audit/controller/AdminActionAuditController.java
@@ -1,8 +1,8 @@
 package com.mamoki.ieojuda.domain.audit.controller;
 
 import com.mamoki.ieojuda.domain.account.entity.AdminPermission;
-import com.mamoki.ieojuda.domain.audit.dto.AuthAuditLogResponse;
-import com.mamoki.ieojuda.domain.audit.service.AuthAuditService;
+import com.mamoki.ieojuda.domain.audit.dto.AdminActionAuditLogResponse;
+import com.mamoki.ieojuda.domain.audit.service.AdminActionAuditService;
 import com.mamoki.ieojuda.global.rsdata.RsData;
 import com.mamoki.ieojuda.global.security.PermissionGuard;
 import io.swagger.v3.oas.annotations.Operation;
@@ -17,24 +17,23 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-// issue #55 "인증 실패 감사" 화면 - 운영관리자 전용. 로그인 실패/잠금, rate limit 초과 이력을 최신순으로 조회
-// issue #59 - ROLE_ADMIN이어도 AUDIT_VIEW 세부 권한이 있어야 조회 가능하도록 세분화
-@Tag(name = "Admin - Auth Audit", description = "운영관리자 - 로그인 실패 / 잠금 / rate limit 초과 감사")
+// issue #59 "고위험 조작 감사" 화면 - 사건 동결·파트너 배정·증빙 판정의 호출자와 결과를 조회
+@Tag(name = "Admin - Action Audit", description = "운영관리자 - 사건 동결/파트너 배정/증빙 판정 감사")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/admin/auth-audit-logs")
-public class AuthAuditController {
+@RequestMapping("/api/admin/action-audit-logs")
+public class AdminActionAuditController {
 
-    private final AuthAuditService authAuditService;
+    private final AdminActionAuditService adminActionAuditService;
     private final PermissionGuard permissionGuard;
 
-    @Operation(summary = "인증 실패 감사 조회", description = "로그인 실패/잠금, rate limit 초과 이력을 최신순으로 페이지 단위 조회합니다.")
+    @Operation(summary = "관리자 조작 감사 조회", description = "고위험 조작(사건 동결/파트너 배정/증빙 판정)의 호출자·성공 여부를 최신순으로 페이지 단위 조회합니다.")
     @GetMapping
-    public ResponseEntity<RsData<Page<AuthAuditLogResponse>>> getLogs(
+    public ResponseEntity<RsData<Page<AdminActionAuditLogResponse>>> getLogs(
             @AuthenticationPrincipal Long userId,
             @PageableDefault(size = 50) Pageable pageable
     ) {
         permissionGuard.require(userId, AdminPermission.AUDIT_VIEW);
-        return ResponseEntity.ok(RsData.success(authAuditService.getLogs(pageable)));
+        return ResponseEntity.ok(RsData.success(adminActionAuditService.getLogs(pageable)));
     }
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/audit/controller/EmailAuditController.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/audit/controller/EmailAuditController.java
@@ -1,23 +1,29 @@
 package com.mamoki.ieojuda.domain.audit.controller;
 
+import com.mamoki.ieojuda.domain.audit.dto.AssignPartnerRequest;
 import com.mamoki.ieojuda.domain.audit.dto.EmailDeliveryResponse;
+import com.mamoki.ieojuda.domain.audit.dto.ReauthRequest;
 import com.mamoki.ieojuda.domain.audit.service.EmailAuditService;
 import com.mamoki.ieojuda.global.rsdata.RsData;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
 // 명세서 "이메일 발송 감사" 화면 - 운영관리자 전용
-@Tag(name = "Admin - Email Audit", description = "운영관리자 - 이메일 발송 감사 / 재시도 / 사건 동결")
+// issue #59 - CASE_SUPERVISE 세부 권한 검사, 사건 동결은 비밀번호 재인증 필요, 파트너사 배정 API 추가
+@Tag(name = "Admin - Email Audit", description = "운영관리자 - 이메일 발송 감사 / 재시도 / 사건 동결 / 파트너사 배정")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/admin/release-cases/{caseId}")
@@ -28,26 +34,41 @@ public class EmailAuditController {
     @Operation(summary = "이메일 발송 감사 조회", description = "사건에 속한 모든 발송 이력을 조회합니다. 이메일 본문·패키지 내용은 포함하지 않습니다.")
     @GetMapping("/email-deliveries")
     public ResponseEntity<RsData<List<EmailDeliveryResponse>>> getDeliveries(
+            @AuthenticationPrincipal Long userId,
             @Parameter(description = "사건 ID") @PathVariable Long caseId
     ) {
-        return ResponseEntity.ok(RsData.success(emailAuditService.getDeliveries(caseId)));
+        return ResponseEntity.ok(RsData.success(emailAuditService.getDeliveries(userId, caseId)));
     }
 
     @Operation(summary = "재시도 정책 실행하기", description = "반송·실패한 발송 건에 대해 새 링크를 발급해 재발송합니다.")
     @PostMapping("/email-deliveries/{logId}/retry")
     public ResponseEntity<RsData<EmailDeliveryResponse>> retry(
+            @AuthenticationPrincipal Long userId,
             @Parameter(description = "사건 ID") @PathVariable Long caseId,
             @Parameter(description = "발송 로그 ID") @PathVariable Long logId
     ) {
-        return ResponseEntity.ok(RsData.success(emailAuditService.retry(caseId, logId)));
+        return ResponseEntity.ok(RsData.success(emailAuditService.retry(userId, caseId, logId)));
     }
 
-    @Operation(summary = "사건 동결하기", description = "이 사건의 이후 발송·단계 전환을 전부 중지합니다.")
+    @Operation(summary = "사건 동결하기", description = "이 사건의 이후 발송·단계 전환을 전부 중지합니다. 되돌리기 어려운 조작이라 비밀번호 재확인이 필요합니다.")
     @PostMapping("/freeze")
     public ResponseEntity<RsData<Void>> freeze(
-            @Parameter(description = "사건 ID") @PathVariable Long caseId
+            @AuthenticationPrincipal Long userId,
+            @Parameter(description = "사건 ID") @PathVariable Long caseId,
+            @Valid @RequestBody ReauthRequest request
     ) {
-        emailAuditService.freeze(caseId);
+        emailAuditService.freeze(userId, caseId, request.password());
+        return ResponseEntity.ok(RsData.success(null));
+    }
+
+    @Operation(summary = "파트너사 배정", description = "이 사건의 증빙 검토를 담당할 외부 파트너사를 배정합니다. 배정 전까지는 어떤 파트너 검토자도 이 사건의 증빙을 조작할 수 없습니다.")
+    @PostMapping("/assign-partner")
+    public ResponseEntity<RsData<Void>> assignPartner(
+            @AuthenticationPrincipal Long userId,
+            @Parameter(description = "사건 ID") @PathVariable Long caseId,
+            @Valid @RequestBody AssignPartnerRequest request
+    ) {
+        emailAuditService.assignPartner(userId, caseId, request.partnerId());
         return ResponseEntity.ok(RsData.success(null));
     }
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/audit/dto/AdminActionAuditLogResponse.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/audit/dto/AdminActionAuditLogResponse.java
@@ -1,0 +1,23 @@
+package com.mamoki.ieojuda.domain.audit.dto;
+
+import com.mamoki.ieojuda.domain.audit.entity.AdminActionAuditLog;
+import com.mamoki.ieojuda.domain.audit.entity.AdminActionType;
+
+import java.time.LocalDateTime;
+
+public record AdminActionAuditLogResponse(
+        Long logId,
+        Long actorUserId,
+        String actorEmail,
+        AdminActionType actionType,
+        Long targetId,
+        Boolean success,
+        String detail,
+        LocalDateTime occurredAt
+) {
+    public static AdminActionAuditLogResponse from(AdminActionAuditLog log) {
+        return new AdminActionAuditLogResponse(
+                log.getLogId(), log.getActorUserId(), log.getActorEmail(), log.getActionType(),
+                log.getTargetId(), log.getSuccess(), log.getDetail(), log.getOccurredAt());
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/audit/dto/AssignPartnerRequest.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/audit/dto/AssignPartnerRequest.java
@@ -1,0 +1,11 @@
+package com.mamoki.ieojuda.domain.audit.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+// issue #59 - 사건의 증빙 검토를 담당할 외부 파트너사를 운영자가 수동으로 배정
+public record AssignPartnerRequest(
+        @Schema(description = "배정할 외부 파트너사 ID")
+        @NotNull(message = "파트너사를 선택해 주세요.") Long partnerId
+) {
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/audit/dto/ReauthRequest.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/audit/dto/ReauthRequest.java
@@ -1,0 +1,11 @@
+package com.mamoki.ieojuda.domain.audit.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+// issue #59 - 고위험 조작(사건 동결 등) 직전 비밀번호 재확인용
+public record ReauthRequest(
+        @Schema(description = "본인 확인용 현재 비밀번호")
+        @NotBlank(message = "비밀번호를 입력해 주세요.") String password
+) {
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/audit/entity/AdminActionAuditLog.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/audit/entity/AdminActionAuditLog.java
@@ -1,0 +1,64 @@
+package com.mamoki.ieojuda.domain.audit.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+// issue #59 - 사건 동결·파트너 배정·증빙 판정 같은 고위험 조작의 호출자와 결과를 감사할 수 있게 남기는 로그
+@Entity
+@Table(name = "admin_action_audit_logs")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AdminActionAuditLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "log_id")
+    private Long logId;
+
+    @Column(name = "actor_user_id")
+    private Long actorUserId;
+
+    @Column(name = "actor_email", length = 255)
+    private String actorEmail;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "action_type", length = 50)
+    private AdminActionType actionType;
+
+    // 조작 대상(사건 ID, 증빙 ID 등) - 대상 종류마다 테이블이 달라서 ID만 남기고 종류는 actionType으로 유추한다
+    @Column(name = "target_id")
+    private Long targetId;
+
+    @Column(name = "success")
+    private Boolean success;
+
+    @Column(name = "detail", length = 255)
+    private String detail;
+
+    @Column(name = "occurred_at")
+    private LocalDateTime occurredAt;
+
+    @Builder
+    public AdminActionAuditLog(Long actorUserId, String actorEmail, AdminActionType actionType,
+                                Long targetId, Boolean success, String detail) {
+        this.actorUserId = actorUserId;
+        this.actorEmail = actorEmail;
+        this.actionType = actionType;
+        this.targetId = targetId;
+        this.success = success;
+        this.detail = detail;
+        this.occurredAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/audit/entity/AdminActionType.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/audit/entity/AdminActionType.java
@@ -1,0 +1,8 @@
+package com.mamoki.ieojuda.domain.audit.entity;
+
+// issue #59 - 감사 대상 고위험 관리자/파트너 조작
+public enum AdminActionType {
+    CASE_FREEZE,          // 사건 동결
+    CASE_ASSIGN_PARTNER,  // 사건에 파트너사 배정
+    EVIDENCE_DECISION     // 증빙 승인/반려/추가자료요청
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/audit/repository/AdminActionAuditLogRepository.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/audit/repository/AdminActionAuditLogRepository.java
@@ -1,0 +1,12 @@
+package com.mamoki.ieojuda.domain.audit.repository;
+
+import com.mamoki.ieojuda.domain.audit.entity.AdminActionAuditLog;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AdminActionAuditLogRepository extends JpaRepository<AdminActionAuditLog, Long> {
+
+    // "관리자 조작 감사" 화면 - 운영관리자가 최신순으로 조회
+    Page<AdminActionAuditLog> findAllByOrderByOccurredAtDesc(Pageable pageable);
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/audit/service/AdminActionAuditService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/audit/service/AdminActionAuditService.java
@@ -1,0 +1,41 @@
+package com.mamoki.ieojuda.domain.audit.service;
+
+import com.mamoki.ieojuda.domain.account.entity.User;
+import com.mamoki.ieojuda.domain.audit.dto.AdminActionAuditLogResponse;
+import com.mamoki.ieojuda.domain.audit.entity.AdminActionAuditLog;
+import com.mamoki.ieojuda.domain.audit.entity.AdminActionType;
+import com.mamoki.ieojuda.domain.audit.repository.AdminActionAuditLogRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+// issue #59 - 고위험 조작 감사 기록/조회.
+// record()는 호출자가 이어서 예외를 던지고 롤백되는 경우에도(예: 재인증 실패) 시도 자체는 남아야 하므로
+// AuthAuditService와 같은 이유로 독립 트랜잭션(REQUIRES_NEW)으로 커밋한다.
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminActionAuditService {
+
+    private final AdminActionAuditLogRepository adminActionAuditLogRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void record(User actor, AdminActionType actionType, Long targetId, boolean success, String detail) {
+        adminActionAuditLogRepository.save(AdminActionAuditLog.builder()
+                .actorUserId(actor.getUserId())
+                .actorEmail(actor.getEmail())
+                .actionType(actionType)
+                .targetId(targetId)
+                .success(success)
+                .detail(detail)
+                .build());
+    }
+
+    // "관리자 조작 감사" 화면 - 운영관리자 전용
+    public Page<AdminActionAuditLogResponse> getLogs(Pageable pageable) {
+        return adminActionAuditLogRepository.findAllByOrderByOccurredAtDesc(pageable).map(AdminActionAuditLogResponse::from);
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/audit/service/EmailAuditService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/audit/service/EmailAuditService.java
@@ -1,8 +1,13 @@
 package com.mamoki.ieojuda.domain.audit.service;
 
+import com.mamoki.ieojuda.domain.account.entity.AdminPermission;
+import com.mamoki.ieojuda.domain.account.entity.User;
 import com.mamoki.ieojuda.domain.audit.dto.EmailDeliveryResponse;
+import com.mamoki.ieojuda.domain.audit.entity.AdminActionType;
 import com.mamoki.ieojuda.domain.audit.entity.EmailLog;
 import com.mamoki.ieojuda.domain.audit.repository.EmailLogRepository;
+import com.mamoki.ieojuda.domain.partner.entity.ExternalPartner;
+import com.mamoki.ieojuda.domain.partner.repository.ExternalPartnerRepository;
 import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
 import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCase;
 import com.mamoki.ieojuda.domain.releasecase.repository.ReleaseCaseRepository;
@@ -15,6 +20,8 @@ import com.mamoki.ieojuda.global.email.template.EmailBuilder;
 import com.mamoki.ieojuda.global.email.token.TokenProvider;
 import com.mamoki.ieojuda.global.exception.CustomException;
 import com.mamoki.ieojuda.global.exception.ErrorCode;
+import com.mamoki.ieojuda.global.security.PermissionGuard;
+import com.mamoki.ieojuda.global.security.ReauthGuard;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,6 +31,7 @@ import java.time.ZoneId;
 import java.util.List;
 
 // 명세서 "이메일 발송 감사" 화면 - 서비스 운영자가 발송·반송·열람 이력을 조회하고 재시도/동결만 수행 (본문·패키지 내용은 접근 불가)
+// issue #59 - CASE_SUPERVISE 세부 권한 검사, 사건 동결은 재인증 필요 + 감사 기록. 파트너사 배정도 여기서 담당.
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -31,10 +39,15 @@ public class EmailAuditService {
 
     private final ReleaseCaseRepository releaseCaseRepository;
     private final EmailLogRepository emailLogRepository;
+    private final ExternalPartnerRepository externalPartnerRepository;
     private final EmailSender emailSender;
     private final AppProperties appProperties;
+    private final PermissionGuard permissionGuard;
+    private final ReauthGuard reauthGuard;
+    private final AdminActionAuditService adminActionAuditService;
 
-    public List<EmailDeliveryResponse> getDeliveries(Long caseId) {
+    public List<EmailDeliveryResponse> getDeliveries(Long userId, Long caseId) {
+        permissionGuard.require(userId, AdminPermission.CASE_SUPERVISE);
         ReleaseCase releaseCase = findCase(caseId);
         return emailLogRepository.findByPlan_PlanIdOrderBySentAtDesc(releaseCase.getPlan().getPlanId()).stream()
                 .map(EmailDeliveryResponse::from)
@@ -43,7 +56,8 @@ public class EmailAuditService {
 
     // "재시도 정책 실행하기" - 이 발송 건과 연결된 담당자에게 새 초대 링크를 발급해 재발송
     @Transactional
-    public EmailDeliveryResponse retry(Long caseId, Long logId) {
+    public EmailDeliveryResponse retry(Long userId, Long caseId, Long logId) {
+        permissionGuard.require(userId, AdminPermission.CASE_SUPERVISE);
         ReleaseCase releaseCase = findCase(caseId);
         if (Boolean.TRUE.equals(releaseCase.getFrozen())) {
             throw new CustomException(ErrorCode.RELEASE_CASE_FROZEN);
@@ -79,10 +93,33 @@ public class EmailAuditService {
         return EmailDeliveryResponse.from(log);
     }
 
-    // "사건 동결하기" - 이후 발송·단계 전환을 전부 막음
+    // "사건 동결하기" - 이후 발송·단계 전환을 전부 막음. 되돌리기 까다로운 고위험 조작이라
+    // 비밀번호 재확인(reauth) 없이는 실행하지 않고, 성공/실패 여부를 감사 로그에 남긴다.
     @Transactional
-    public void freeze(Long caseId) {
+    public void freeze(Long userId, Long caseId, String password) {
+        User actor = permissionGuard.require(userId, AdminPermission.CASE_SUPERVISE);
+        try {
+            reauthGuard.verify(actor, password);
+        } catch (CustomException e) {
+            adminActionAuditService.record(actor, AdminActionType.CASE_FREEZE, caseId, false, "재인증 실패");
+            throw e;
+        }
+
         findCase(caseId).freeze();
+        adminActionAuditService.record(actor, AdminActionType.CASE_FREEZE, caseId, true, null);
+    }
+
+    // issue #59 - 사건의 증빙 검토를 담당할 외부 파트너사를 운영자가 수동으로 배정
+    @Transactional
+    public void assignPartner(Long userId, Long caseId, Long partnerId) {
+        User actor = permissionGuard.require(userId, AdminPermission.CASE_SUPERVISE);
+        ReleaseCase releaseCase = findCase(caseId);
+        ExternalPartner partner = externalPartnerRepository.findById(partnerId)
+                .orElseThrow(() -> new CustomException(ErrorCode.EXTERNAL_PARTNER_NOT_FOUND));
+
+        releaseCase.assignPartner(partner);
+        adminActionAuditService.record(actor, AdminActionType.CASE_ASSIGN_PARTNER, caseId, true,
+                "partnerId=" + partnerId);
     }
 
     private ReleaseCase findCase(Long caseId) {

--- a/src/main/java/com/mamoki/ieojuda/domain/evidence/controller/EvidenceDeletionController.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/evidence/controller/EvidenceDeletionController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 // 명세서 "증빙 삭제 감사" 화면 - 서비스 운영자·외부 파트너 공용
+// issue #59 - EVIDENCE_DELETE_RETRY 세부 권한 검사
 @Tag(name = "Evidence Deletion Audit", description = "증빙 삭제 감사 조회 / 재처리")
 @RestController
 @RequiredArgsConstructor
@@ -26,16 +28,18 @@ public class EvidenceDeletionController {
     @Operation(summary = "증빙 삭제 상태 조회", description = "검토완료일·삭제예정일·삭제상태·무결성해시·실패사유를 조회합니다.")
     @GetMapping("/deletion-status")
     public ResponseEntity<RsData<EvidenceDeletionStatusResponse>> getStatus(
+            @AuthenticationPrincipal Long userId,
             @Parameter(description = "증빙 ID") @PathVariable Long evidenceId
     ) {
-        return ResponseEntity.ok(RsData.success(evidenceDeletionService.getStatus(evidenceId)));
+        return ResponseEntity.ok(RsData.success(evidenceDeletionService.getStatus(userId, evidenceId)));
     }
 
     @Operation(summary = "삭제 재처리 요청", description = "자동 삭제가 실패한 증빙을 다시 삭제 시도합니다.")
     @PostMapping("/deletion-retry")
     public ResponseEntity<RsData<EvidenceDeletionStatusResponse>> retryDeletion(
+            @AuthenticationPrincipal Long userId,
             @Parameter(description = "증빙 ID") @PathVariable Long evidenceId
     ) {
-        return ResponseEntity.ok(RsData.success(evidenceDeletionService.retryDeletion(evidenceId)));
+        return ResponseEntity.ok(RsData.success(evidenceDeletionService.retryDeletion(userId, evidenceId)));
     }
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/evidence/service/EvidenceDeletionService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/evidence/service/EvidenceDeletionService.java
@@ -1,16 +1,19 @@
 package com.mamoki.ieojuda.domain.evidence.service;
 
+import com.mamoki.ieojuda.domain.account.entity.AdminPermission;
 import com.mamoki.ieojuda.domain.evidence.dto.EvidenceDeletionStatusResponse;
 import com.mamoki.ieojuda.domain.evidence.entity.Evidence;
 import com.mamoki.ieojuda.domain.evidence.repository.EvidenceRepository;
 import com.mamoki.ieojuda.global.exception.CustomException;
 import com.mamoki.ieojuda.global.exception.ErrorCode;
+import com.mamoki.ieojuda.global.security.PermissionGuard;
 import com.mamoki.ieojuda.global.storage.EvidenceStorageClient;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 // 명세서 "증빙 삭제 감사" 화면 - 서비스 운영자·외부 파트너 공용
+// issue #59 - EVIDENCE_DELETE_RETRY 세부 권한 검사
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -18,14 +21,17 @@ public class EvidenceDeletionService {
 
     private final EvidenceRepository evidenceRepository;
     private final EvidenceStorageClient evidenceStorageClient;
+    private final PermissionGuard permissionGuard;
 
-    public EvidenceDeletionStatusResponse getStatus(Long evidenceId) {
+    public EvidenceDeletionStatusResponse getStatus(Long userId, Long evidenceId) {
+        permissionGuard.require(userId, AdminPermission.EVIDENCE_DELETE_RETRY);
         return EvidenceDeletionStatusResponse.from(findEvidence(evidenceId));
     }
 
     // "재처리 요청하기" - 자동 삭제가 실패한 증빙을 다시 삭제 시도
     @Transactional
-    public EvidenceDeletionStatusResponse retryDeletion(Long evidenceId) {
+    public EvidenceDeletionStatusResponse retryDeletion(Long userId, Long evidenceId) {
+        permissionGuard.require(userId, AdminPermission.EVIDENCE_DELETE_RETRY);
         Evidence evidence = findEvidence(evidenceId);
 
         if (evidence.getDeletedAt() != null) {

--- a/src/main/java/com/mamoki/ieojuda/domain/partner/controller/PartnerReviewController.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/partner/controller/PartnerReviewController.java
@@ -31,17 +31,19 @@ public class PartnerReviewController {
     @Operation(summary = "검토 대상 조회", description = "대상자(신고 확인자) 정보와 증빙 메타데이터를 조회합니다. 역할별 패키지는 포함하지 않습니다.")
     @GetMapping
     public ResponseEntity<RsData<PartnerReviewResponse>> getReview(
+            @AuthenticationPrincipal Long userId,
             @Parameter(description = "검토 ID (증빙 ID)") @PathVariable Long reviewId
     ) {
-        return ResponseEntity.ok(RsData.success(partnerReviewService.getReview(reviewId)));
+        return ResponseEntity.ok(RsData.success(partnerReviewService.getReview(userId, reviewId)));
     }
 
     @Operation(summary = "증빙 원본 다운로드")
     @GetMapping("/file")
     public ResponseEntity<byte[]> getFile(
+            @AuthenticationPrincipal Long userId,
             @Parameter(description = "검토 ID (증빙 ID)") @PathVariable Long reviewId
     ) {
-        byte[] file = partnerReviewService.getFile(reviewId);
+        byte[] file = partnerReviewService.getFile(userId, reviewId);
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_OCTET_STREAM)
                 .body(file);

--- a/src/main/java/com/mamoki/ieojuda/domain/partner/dto/PartnerReviewDecisionRequest.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/partner/dto/PartnerReviewDecisionRequest.java
@@ -1,15 +1,19 @@
 package com.mamoki.ieojuda.domain.partner.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 // "외부 파트너 증빙 검토" 화면 - 승인/반려 요청/추가 자료 요청
 // 검토자는 요청 바디가 아니라 로그인한 계정(JWT principal)에서 식별한다.
+// issue #59 - 증빙 판정은 고위험 조작이라 비밀번호 재확인(password)을 함께 받는다.
 public record PartnerReviewDecisionRequest(
         @Schema(description = "결정", example = "APPROVE", allowableValues = {"APPROVE", "REJECT", "ADDITIONAL_INFO_REQUESTED"})
         @NotNull(message = "결정을 선택해 주세요.") PartnerReviewDecision decision,
         @Schema(description = "반려 사유 (REJECT일 때 필수)")
-        @jakarta.validation.constraints.Size(max = 1000, message = "반려 사유는 1,000자 이하여야 합니다.") String failureReason
+        @jakarta.validation.constraints.Size(max = 1000, message = "반려 사유는 1,000자 이하여야 합니다.") String failureReason,
+        @Schema(description = "본인 확인용 현재 비밀번호")
+        @NotBlank(message = "비밀번호를 입력해 주세요.") String password
 ) {
     public enum PartnerReviewDecision {
         APPROVE, REJECT, ADDITIONAL_INFO_REQUESTED

--- a/src/main/java/com/mamoki/ieojuda/domain/partner/repository/ExternalPartnerRepository.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/partner/repository/ExternalPartnerRepository.java
@@ -1,0 +1,7 @@
+package com.mamoki.ieojuda.domain.partner.repository;
+
+import com.mamoki.ieojuda.domain.partner.entity.ExternalPartner;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ExternalPartnerRepository extends JpaRepository<ExternalPartner, Long> {
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/partner/service/PartnerReviewService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/partner/service/PartnerReviewService.java
@@ -1,13 +1,20 @@
 package com.mamoki.ieojuda.domain.partner.service;
 
+import com.mamoki.ieojuda.domain.account.entity.AdminPermission;
+import com.mamoki.ieojuda.domain.account.entity.User;
+import com.mamoki.ieojuda.domain.audit.entity.AdminActionType;
+import com.mamoki.ieojuda.domain.audit.service.AdminActionAuditService;
 import com.mamoki.ieojuda.domain.evidence.entity.Evidence;
 import com.mamoki.ieojuda.domain.evidence.repository.EvidenceRepository;
 import com.mamoki.ieojuda.domain.partner.dto.PartnerReviewDecisionRequest;
 import com.mamoki.ieojuda.domain.partner.dto.PartnerReviewResponse;
 import com.mamoki.ieojuda.domain.partner.entity.PartnerReviewer;
 import com.mamoki.ieojuda.domain.partner.repository.PartnerReviewerRepository;
+import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCase;
 import com.mamoki.ieojuda.global.exception.CustomException;
 import com.mamoki.ieojuda.global.exception.ErrorCode;
+import com.mamoki.ieojuda.global.security.PermissionGuard;
+import com.mamoki.ieojuda.global.security.ReauthGuard;
 import com.mamoki.ieojuda.global.storage.EvidenceStorageClient;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 // 명세서 "외부 파트너 증빙 검토" 화면 - 외부 법무·장례 파트너 전용. 역할별 패키지(계획 내용)는 절대 노출하지 않는다.
 // reviewId는 evidenceId와 1:1로 취급한다(증빙 1건 = 검토 1건).
+// issue #59 - EVIDENCE_REVIEW 세부 권한 + 소속 파트너사가 배정된 사건만 조작 가능(조직 경계) + 판정은 재인증 필요
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -23,24 +31,43 @@ public class PartnerReviewService {
     private final EvidenceRepository evidenceRepository;
     private final PartnerReviewerRepository partnerReviewerRepository;
     private final EvidenceStorageClient evidenceStorageClient;
+    private final PermissionGuard permissionGuard;
+    private final ReauthGuard reauthGuard;
+    private final AdminActionAuditService adminActionAuditService;
 
-    public PartnerReviewResponse getReview(Long reviewId) {
-        return PartnerReviewResponse.from(findEvidence(reviewId));
+    public PartnerReviewResponse getReview(Long userId, Long reviewId) {
+        permissionGuard.require(userId, AdminPermission.EVIDENCE_REVIEW);
+        Evidence evidence = findEvidence(reviewId);
+        requireAssignedPartner(findReviewerByUser(userId), evidence);
+        return PartnerReviewResponse.from(evidence);
     }
 
     // 증빙 원본 다운로드 - JSON 응답에 바이너리를 섞지 않기 위해 별도 엔드포인트로 분리
-    public byte[] getFile(Long reviewId) {
-        return evidenceStorageClient.load(findEvidence(reviewId).getStorageKey());
+    public byte[] getFile(Long userId, Long reviewId) {
+        permissionGuard.require(userId, AdminPermission.EVIDENCE_REVIEW);
+        Evidence evidence = findEvidence(reviewId);
+        requireAssignedPartner(findReviewerByUser(userId), evidence);
+        return evidenceStorageClient.load(evidence.getStorageKey());
     }
 
     @Transactional
     public PartnerReviewResponse decide(Long reviewId, Long userId, PartnerReviewDecisionRequest request) {
+        User actor = permissionGuard.require(userId, AdminPermission.EVIDENCE_REVIEW);
         Evidence evidence = findEvidence(reviewId);
         PartnerReviewer reviewer = findReviewerByUser(userId);
 
         // 이해충돌·권한 만료로 비활성화된 검토자는 결정할 수 없음 (명세서 "다른 검토자에게 재배정")
         if (!Boolean.TRUE.equals(reviewer.getIsActive())) {
             throw new CustomException(ErrorCode.REVIEWER_CONFLICT_OF_INTEREST);
+        }
+        requireAssignedPartner(reviewer, evidence);
+
+        // 되돌리기 까다로운 고위험 조작이라 비밀번호 재확인 없이는 실행하지 않고, 성공/실패를 감사 로그에 남긴다.
+        try {
+            reauthGuard.verify(actor, request.password());
+        } catch (CustomException e) {
+            adminActionAuditService.record(actor, AdminActionType.EVIDENCE_DECISION, reviewId, false, "재인증 실패");
+            throw e;
         }
 
         evidence.assignReviewer(reviewer);
@@ -61,7 +88,21 @@ public class PartnerReviewService {
             case ADDITIONAL_INFO_REQUESTED -> evidence.reAdditionalInfo();
         }
 
+        adminActionAuditService.record(actor, AdminActionType.EVIDENCE_DECISION, reviewId, true,
+                request.decision().name());
         return PartnerReviewResponse.from(evidence);
+    }
+
+    // issue #59 - 검토자 소속 파트너사와 사건에 배정된 파트너사가 같아야만 조작 가능. 아직 배정되지 않은
+    // 사건은 어떤 검토자도 손댈 수 없다(운영자 배정이 먼저 있어야 함).
+    private void requireAssignedPartner(PartnerReviewer reviewer, Evidence evidence) {
+        ReleaseCase releaseCase = evidence.getReleaseCase();
+        if (releaseCase.getAssignedPartner() == null) {
+            throw new CustomException(ErrorCode.PARTNER_NOT_ASSIGNED);
+        }
+        if (!releaseCase.getAssignedPartner().getPartnerId().equals(reviewer.getPartner().getPartnerId())) {
+            throw new CustomException(ErrorCode.PARTNER_SCOPE_DENIED);
+        }
     }
 
     private Evidence findEvidence(Long reviewId) {

--- a/src/main/java/com/mamoki/ieojuda/domain/releasecase/entity/ReleaseCase.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/releasecase/entity/ReleaseCase.java
@@ -1,5 +1,6 @@
 package com.mamoki.ieojuda.domain.releasecase.entity;
 
+import com.mamoki.ieojuda.domain.partner.entity.ExternalPartner;
 import com.mamoki.ieojuda.domain.plan.entity.Plan;
 import com.mamoki.ieojuda.domain.plan.entity.PlanVersion;
 import jakarta.persistence.*;
@@ -51,6 +52,12 @@ public class ReleaseCase {
     @Column(name = "completed_at")
     private LocalDateTime completedAt;
 
+    // issue #59 - 이 사건의 증빙 검토를 담당하는 외부 파트너사. 운영자가 수동으로 배정하며(#59 시점 기준
+    // 조직/업무 자동 배정 규칙은 기획에 없음), 배정 전까지는 어떤 파트너 검토자도 이 사건을 조작할 수 없다.
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "assigned_partner_id")
+    private ExternalPartner assignedPartner;
+
     @Builder
     public ReleaseCase(Plan plan, PlanVersion planVersion) {
         this.plan = plan;
@@ -62,6 +69,11 @@ public class ReleaseCase {
     // "이메일 발송 감사" 화면 - 운영자가 발송 절차 전체를 동결
     public void freeze() {
         this.frozen = true;
+    }
+
+    // issue #59 - 이 사건의 증빙 검토를 특정 외부 파트너사에 배정(운영자 수동 배정)
+    public void assignPartner(ExternalPartner partner) {
+        this.assignedPartner = partner;
     }
 
     public void unfreeze() {

--- a/src/main/java/com/mamoki/ieojuda/domain/stage/controller/HandoverStageController.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/stage/controller/HandoverStageController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 // 명세서 "단계 완료 / 대체 담당자" 화면 - 역할 담당자·서비스 운영자 공용
+// issue #59 - CASE_SUPERVISE 세부 권한 검사
 @Tag(name = "Handover Stage", description = "단계 완료 확인 / 대체 담당자 전환")
 @RestController
 @RequiredArgsConstructor
@@ -26,18 +28,20 @@ public class HandoverStageController {
     @Operation(summary = "단계 상태 조회", description = "현재 단계, 완료 조건, 남은 시간, 담당자 정보를 조회합니다.")
     @GetMapping
     public ResponseEntity<RsData<HandoverStageResponse>> getStage(
+            @AuthenticationPrincipal Long userId,
             @Parameter(description = "사건 ID") @PathVariable Long caseId,
             @Parameter(description = "단계 ID") @PathVariable Long stageId
     ) {
-        return ResponseEntity.ok(RsData.success(handoverStageService.getStage(caseId, stageId)));
+        return ResponseEntity.ok(RsData.success(handoverStageService.getStage(userId, caseId, stageId)));
     }
 
     @Operation(summary = "대체 담당자 전환", description = "무응답·영구 반송·문제 신고 시 사전 등록된 대체 담당자로 전환하고 안내 메일을 발송합니다. 대체 담당자가 없으면 사건을 차단 상태로 유지합니다.")
     @PostMapping("/fallback")
     public ResponseEntity<RsData<HandoverStageResponse>> fallback(
+            @AuthenticationPrincipal Long userId,
             @Parameter(description = "사건 ID") @PathVariable Long caseId,
             @Parameter(description = "단계 ID") @PathVariable Long stageId
     ) {
-        return ResponseEntity.ok(RsData.success(handoverStageService.fallback(caseId, stageId)));
+        return ResponseEntity.ok(RsData.success(handoverStageService.fallback(userId, caseId, stageId)));
     }
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/stage/service/HandoverStageService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/stage/service/HandoverStageService.java
@@ -1,5 +1,6 @@
 package com.mamoki.ieojuda.domain.stage.service;
 
+import com.mamoki.ieojuda.domain.account.entity.AdminPermission;
 import com.mamoki.ieojuda.domain.audit.entity.EmailLog;
 import com.mamoki.ieojuda.domain.audit.entity.EmailType;
 import com.mamoki.ieojuda.domain.audit.repository.EmailLogRepository;
@@ -18,6 +19,7 @@ import com.mamoki.ieojuda.global.email.template.EmailBuilder;
 import com.mamoki.ieojuda.global.email.token.TokenProvider;
 import com.mamoki.ieojuda.global.exception.CustomException;
 import com.mamoki.ieojuda.global.exception.ErrorCode;
+import com.mamoki.ieojuda.global.security.PermissionGuard;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,6 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 // 명세서 "단계 완료 / 대체 담당자" 화면 - 역할 담당자·서비스 운영자 공용
+// issue #59 - 운영자 경로(getStage/fallback)는 CASE_SUPERVISE 세부 권한 검사
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -39,8 +42,10 @@ public class HandoverStageService {
     private final EmailLogRepository emailLogRepository;
     private final EmailSender emailSender;
     private final AppProperties appProperties;
+    private final PermissionGuard permissionGuard;
 
-    public HandoverStageResponse getStage(Long caseId, Long stageId) {
+    public HandoverStageResponse getStage(Long userId, Long caseId, Long stageId) {
+        permissionGuard.require(userId, AdminPermission.CASE_SUPERVISE);
         ReleaseCase releaseCase = releaseCaseRepository.findById(caseId)
                 .orElseThrow(() -> new CustomException(ErrorCode.RELEASE_CASE_NOT_FOUND));
         return HandoverStageResponse.from(findStage(releaseCase, stageId));
@@ -48,7 +53,8 @@ public class HandoverStageService {
 
     // 무응답·영구반송·문제신고로 대체 담당자에게 전환. 대체 담당자가 없으면 사건을 차단 상태로 유지한다.
     @Transactional
-    public HandoverStageResponse fallback(Long caseId, Long stageId) {
+    public HandoverStageResponse fallback(Long userId, Long caseId, Long stageId) {
+        permissionGuard.require(userId, AdminPermission.CASE_SUPERVISE);
         ReleaseCase releaseCase = releaseCaseRepository.findById(caseId)
                 .orElseThrow(() -> new CustomException(ErrorCode.RELEASE_CASE_NOT_FOUND));
         if (Boolean.TRUE.equals(releaseCase.getFrozen())) {

--- a/src/main/java/com/mamoki/ieojuda/global/exception/ErrorCode.java
+++ b/src/main/java/com/mamoki/ieojuda/global/exception/ErrorCode.java
@@ -53,11 +53,14 @@ public enum ErrorCode {
     ACCOUNT_TEMPORARILY_LOCKED(HttpStatus.TOO_MANY_REQUESTS, "ACCOUNT_TEMPORARILY_LOCKED", "로그인 실패 횟수가 많아 잠시 후 다시 시도해 주세요."),
     TOKEN_TEMPORARILY_LOCKED(HttpStatus.TOO_MANY_REQUESTS, "TOKEN_TEMPORARILY_LOCKED", "이 링크로 실패 횟수가 많아 잠시 후 다시 시도해 주세요."),
     TOO_MANY_REQUESTS(HttpStatus.TOO_MANY_REQUESTS, "TOO_MANY_REQUESTS", "요청이 너무 많습니다. 잠시 후 다시 시도해 주세요."),
+    REAUTH_FAILED(HttpStatus.UNAUTHORIZED, "REAUTH_FAILED", "비밀번호가 일치하지 않아 이 작업을 진행할 수 없습니다."),
 
     // 권한 에러 (403)
     FORBIDDEN(HttpStatus.FORBIDDEN, "FORBIDDEN", "해당 리소스에 대한 권한이 없습니다."),
     ROLE_PACKAGE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "ROLE_PACKAGE_ACCESS_DENIED", "본인의 역할 패키지가 아니거나 권한이 없는 요청입니다."),
     REVIEWER_CONFLICT_OF_INTEREST(HttpStatus.FORBIDDEN, "REVIEWER_CONFLICT_OF_INTEREST", "이해충돌 또는 권한 만료로 다른 검토자에게 재배정이 필요합니다."),
+    INSUFFICIENT_PERMISSION(HttpStatus.FORBIDDEN, "INSUFFICIENT_PERMISSION", "이 작업을 수행할 세부 권한이 없습니다."),
+    PARTNER_SCOPE_DENIED(HttpStatus.FORBIDDEN, "PARTNER_SCOPE_DENIED", "소속 파트너사에 배정되지 않은 증빙·사건입니다."),
 
     // 리소스 없음 (404)
     RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "RESOURCE_NOT_FOUND", "요청한 리소스가 존재하지 않습니다."),
@@ -73,6 +76,7 @@ public enum ErrorCode {
     DISPUTE_CONTACT_NOT_FOUND(HttpStatus.NOT_FOUND, "DISPUTE_CONTACT_NOT_FOUND", "해당 이의 제기 연락처가 존재하지 않습니다."),
     HANDOVER_STAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "HANDOVER_STAGE_NOT_FOUND", "해당 인계 단계가 존재하지 않습니다."),
     PARTNER_REVIEWER_NOT_FOUND(HttpStatus.NOT_FOUND, "PARTNER_REVIEWER_NOT_FOUND", "해당 파트너 검토자가 존재하지 않습니다."),
+    EXTERNAL_PARTNER_NOT_FOUND(HttpStatus.NOT_FOUND, "EXTERNAL_PARTNER_NOT_FOUND", "해당 외부 파트너사가 존재하지 않습니다."),
 
     // 상태 충돌 (409)
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "DUPLICATE_EMAIL", "이미 사용 중인 이메일입니다."),
@@ -85,6 +89,7 @@ public enum ErrorCode {
     RECIPIENT_RESEND_NOT_ALLOWED(HttpStatus.CONFLICT, "RECIPIENT_RESEND_NOT_ALLOWED", "현재 수락 상태에서는 수락 요청을 다시 보낼 수 없습니다."),
     CONFIRMER_RESEND_NOT_ALLOWED(HttpStatus.CONFLICT, "CONFIRMER_RESEND_NOT_ALLOWED", "현재 수락 상태에서는 수락 요청을 다시 보낼 수 없습니다."),
     ITEM_ORDER_CONFLICT(HttpStatus.CONFLICT, "ITEM_ORDER_CONFLICT", "순서 충돌이 있어 확정할 수 없습니다."),
+    PARTNER_NOT_ASSIGNED(HttpStatus.CONFLICT, "PARTNER_NOT_ASSIGNED", "이 사건에는 아직 담당 파트너사가 배정되지 않았습니다."),
 
     // 서버 에러 (500)
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR","서버 오류가 발생했습니다.");

--- a/src/main/java/com/mamoki/ieojuda/global/security/PermissionGuard.java
+++ b/src/main/java/com/mamoki/ieojuda/global/security/PermissionGuard.java
@@ -1,0 +1,28 @@
+package com.mamoki.ieojuda.global.security;
+
+import com.mamoki.ieojuda.domain.account.entity.AdminPermission;
+import com.mamoki.ieojuda.domain.account.entity.User;
+import com.mamoki.ieojuda.domain.account.repository.UserRepository;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+// issue #59 - ROLE_ADMIN/ROLE_EXTERNAL 하나로 뭉쳐 있던 권한을 업무 단위로 세분화해서 검사한다.
+// SecurityConfig의 role 기반 URL 게이팅은 그대로 두고(1차 방어선), 이 가드는 서비스 계층에서
+// "그 역할 중에서도 이 업무를 할 수 있는 사람인지"를 최소 권한 원칙에 따라 한 번 더 검사한다(2차 방어선).
+@Component
+@RequiredArgsConstructor
+public class PermissionGuard {
+
+    private final UserRepository userRepository;
+
+    public User require(Long userId, AdminPermission permission) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        if (!user.hasPermission(permission)) {
+            throw new CustomException(ErrorCode.INSUFFICIENT_PERMISSION);
+        }
+        return user;
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/global/security/ReauthGuard.java
+++ b/src/main/java/com/mamoki/ieojuda/global/security/ReauthGuard.java
@@ -1,0 +1,23 @@
+package com.mamoki.ieojuda.global.security;
+
+import com.mamoki.ieojuda.domain.account.entity.User;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+// issue #59 - 사건 동결·증빙 판정 같은 고위험 조작은 로그인 세션이 살아있다는 것만으로는 부족하다고 보고,
+// 실행 직전 비밀번호를 다시 확인시킨다(방법 A: 재인증). 실패하면 아무 상태도 바꾸지 않고 그대로 막는다.
+@Component
+@RequiredArgsConstructor
+public class ReauthGuard {
+
+    private final PasswordEncoder passwordEncoder;
+
+    public void verify(User user, String password) {
+        if (password == null || !passwordEncoder.matches(password, user.getPassword())) {
+            throw new CustomException(ErrorCode.REAUTH_FAILED);
+        }
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/domain/confirmer/service/DeathReportServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/confirmer/service/DeathReportServiceTest.java
@@ -12,6 +12,8 @@ import com.mamoki.ieojuda.domain.plan.repository.PlanVersionRepository;
 import com.mamoki.ieojuda.domain.plan.service.PlanSnapshotService;
 import com.mamoki.ieojuda.domain.releasecase.repository.ReleaseCaseRepository;
 import com.mamoki.ieojuda.global.email.token.TokenProvider;
+import com.mamoki.ieojuda.global.ratelimit.PublicLinkAuditor;
+import com.mamoki.ieojuda.global.ratelimit.TokenLookupGuard;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -22,6 +24,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -33,17 +36,32 @@ class DeathReportServiceTest {
     private ConfirmerRepository confirmerRepository;
     private ReleaseCaseRepository releaseCaseRepository;
     private PlanVersionRepository planVersionRepository;
+    private TokenLookupGuard tokenLookupGuard;
+    private PublicLinkAuditor publicLinkAuditor;
     private PlanSnapshotService planSnapshotService;
     private DeathReportService deathReportService;
 
     @BeforeEach
+    @SuppressWarnings("unchecked")
     void setUp() {
         confirmerRepository = mock(ConfirmerRepository.class);
         releaseCaseRepository = mock(ReleaseCaseRepository.class);
         planVersionRepository = mock(PlanVersionRepository.class);
+        tokenLookupGuard = mock(TokenLookupGuard.class);
+        publicLinkAuditor = mock(PublicLinkAuditor.class);
         planSnapshotService = mock(PlanSnapshotService.class);
         deathReportService = new DeathReportService(
-                confirmerRepository, releaseCaseRepository, planVersionRepository, planSnapshotService);
+                confirmerRepository, releaseCaseRepository, planVersionRepository,
+                tokenLookupGuard, publicLinkAuditor, planSnapshotService);
+
+        // TokenLookupGuard는 issue #55에서 추가된 조회 래퍼 - 실제 구현처럼 supplier를 그대로 실행해
+        // confirmerRepository.findByInviteToken(...) 목 설정이 기존과 동일하게 동작하도록 위임한다.
+        when(tokenLookupGuard.resolve(anyString(), any())).thenAnswer(invocation -> {
+            java.util.function.Supplier<java.util.Optional<?>> lookup = invocation.getArgument(1);
+            return lookup.get().orElseThrow(() ->
+                    new com.mamoki.ieojuda.global.exception.CustomException(
+                            com.mamoki.ieojuda.global.exception.ErrorCode.TOKEN_INVALID));
+        });
     }
 
     @Test

--- a/src/test/java/com/mamoki/ieojuda/domain/confirmer/service/DisputeContactServiceBolaTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/confirmer/service/DisputeContactServiceBolaTest.java
@@ -8,6 +8,8 @@ import com.mamoki.ieojuda.global.config.AppProperties;
 import com.mamoki.ieojuda.global.email.sender.EmailSender;
 import com.mamoki.ieojuda.global.exception.CustomException;
 import com.mamoki.ieojuda.global.exception.ErrorCode;
+import com.mamoki.ieojuda.global.ratelimit.PublicLinkAuditor;
+import com.mamoki.ieojuda.global.ratelimit.TokenLookupGuard;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -42,7 +44,9 @@ class DisputeContactServiceBolaTest {
                 new PlanOwnershipReader(planRepository),
                 disputeContactRepository,
                 emailSender,
-                mock(AppProperties.class)
+                mock(AppProperties.class),
+                mock(TokenLookupGuard.class),
+                mock(PublicLinkAuditor.class)
         );
         when(planRepository.findByPlanIdAndUser_UserId(PLAN_ID, ATTACKER_ID)).thenReturn(Optional.empty());
     }

--- a/src/test/java/com/mamoki/ieojuda/domain/partner/service/PartnerReviewServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/partner/service/PartnerReviewServiceTest.java
@@ -1,0 +1,158 @@
+package com.mamoki.ieojuda.domain.partner.service;
+
+import com.mamoki.ieojuda.domain.account.entity.AdminPermission;
+import com.mamoki.ieojuda.domain.account.entity.User;
+import com.mamoki.ieojuda.domain.audit.entity.AdminActionType;
+import com.mamoki.ieojuda.domain.audit.service.AdminActionAuditService;
+import com.mamoki.ieojuda.domain.confirmer.entity.Confirmer;
+import com.mamoki.ieojuda.domain.evidence.entity.Evidence;
+import com.mamoki.ieojuda.domain.evidence.entity.EvidenceReviewStatus;
+import com.mamoki.ieojuda.domain.evidence.repository.EvidenceRepository;
+import com.mamoki.ieojuda.domain.partner.dto.PartnerReviewDecisionRequest;
+import com.mamoki.ieojuda.domain.partner.entity.ExternalPartner;
+import com.mamoki.ieojuda.domain.partner.entity.PartnerReviewer;
+import com.mamoki.ieojuda.domain.partner.repository.PartnerReviewerRepository;
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCase;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import com.mamoki.ieojuda.global.security.PermissionGuard;
+import com.mamoki.ieojuda.global.security.ReauthGuard;
+import com.mamoki.ieojuda.global.storage.EvidenceStorageClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+// issue #59 회귀 테스트 - 역할(EXTERNAL) 하나만으로는 소속 파트너사에 배정되지 않은 사건·증빙을
+// 조작할 수 없어야 하고(조직 경계), 증빙 판정은 재인증 없이는 실행되지 않아야 한다.
+class PartnerReviewServiceTest {
+
+    private static final Long USER_ID = 1L;
+    private static final Long REVIEW_ID = 10L;
+
+    private EvidenceRepository evidenceRepository;
+    private PartnerReviewerRepository partnerReviewerRepository;
+    private EvidenceStorageClient evidenceStorageClient;
+    private PermissionGuard permissionGuard;
+    private ReauthGuard reauthGuard;
+    private AdminActionAuditService adminActionAuditService;
+    private PartnerReviewService partnerReviewService;
+
+    private User actor;
+    private Evidence evidence;
+    private ReleaseCase releaseCase;
+    private PartnerReviewer reviewer;
+    private ExternalPartner reviewerPartner;
+
+    @BeforeEach
+    void setUp() {
+        evidenceRepository = mock(EvidenceRepository.class);
+        partnerReviewerRepository = mock(PartnerReviewerRepository.class);
+        evidenceStorageClient = mock(EvidenceStorageClient.class);
+        permissionGuard = mock(PermissionGuard.class);
+        reauthGuard = mock(ReauthGuard.class);
+        adminActionAuditService = mock(AdminActionAuditService.class);
+        partnerReviewService = new PartnerReviewService(
+                evidenceRepository, partnerReviewerRepository, evidenceStorageClient,
+                permissionGuard, reauthGuard, adminActionAuditService);
+
+        actor = mock(User.class);
+        when(permissionGuard.require(USER_ID, AdminPermission.EVIDENCE_REVIEW)).thenReturn(actor);
+
+        reviewerPartner = mock(ExternalPartner.class);
+        when(reviewerPartner.getPartnerId()).thenReturn(100L);
+        reviewer = mock(PartnerReviewer.class);
+        when(reviewer.getIsActive()).thenReturn(true);
+        when(reviewer.getPartner()).thenReturn(reviewerPartner);
+        when(partnerReviewerRepository.findByUser_UserId(USER_ID)).thenReturn(Optional.of(reviewer));
+
+        releaseCase = mock(ReleaseCase.class);
+        Plan plan = mock(Plan.class);
+        Confirmer confirmer = mock(Confirmer.class);
+        when(confirmer.getName()).thenReturn("확인자");
+        evidence = mock(Evidence.class);
+        when(evidence.getReleaseCase()).thenReturn(releaseCase);
+        when(evidence.getPlan()).thenReturn(plan);
+        when(evidence.getConfirmer()).thenReturn(confirmer);
+        when(evidence.getReviewStatus()).thenReturn(EvidenceReviewStatus.PENDING);
+        when(evidenceRepository.findById(REVIEW_ID)).thenReturn(Optional.of(evidence));
+    }
+
+    @Test
+    void decide_whenCaseHasNoAssignedPartner_isBlocked() {
+        when(releaseCase.getAssignedPartner()).thenReturn(null);
+        PartnerReviewDecisionRequest request = new PartnerReviewDecisionRequest(
+                PartnerReviewDecisionRequest.PartnerReviewDecision.APPROVE, null, "pw");
+
+        assertThatThrownBy(() -> partnerReviewService.decide(REVIEW_ID, USER_ID, request))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.PARTNER_NOT_ASSIGNED));
+        verify(evidence, never()).approve();
+    }
+
+    @Test
+    void decide_whenCaseAssignedToAnotherPartner_isBlockedByOrgBoundary() {
+        ExternalPartner otherPartner = mock(ExternalPartner.class);
+        when(otherPartner.getPartnerId()).thenReturn(999L); // reviewerPartner는 100L - 다른 조직
+        when(releaseCase.getAssignedPartner()).thenReturn(otherPartner);
+        PartnerReviewDecisionRequest request = new PartnerReviewDecisionRequest(
+                PartnerReviewDecisionRequest.PartnerReviewDecision.APPROVE, null, "pw");
+
+        assertThatThrownBy(() -> partnerReviewService.decide(REVIEW_ID, USER_ID, request))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.PARTNER_SCOPE_DENIED));
+        verify(evidence, never()).approve();
+    }
+
+    @Test
+    void decide_whenCaseAssignedToReviewersOwnPartner_proceeds() {
+        when(releaseCase.getAssignedPartner()).thenReturn(reviewerPartner); // 같은 조직(100L)
+        PartnerReviewDecisionRequest request = new PartnerReviewDecisionRequest(
+                PartnerReviewDecisionRequest.PartnerReviewDecision.APPROVE, null, "correct-pw");
+
+        partnerReviewService.decide(REVIEW_ID, USER_ID, request);
+
+        verify(evidence).approve();
+        verify(releaseCase).approveEvidenceAndStartWaiting(any());
+        verify(adminActionAuditService).record(actor, AdminActionType.EVIDENCE_DECISION, REVIEW_ID, true, "APPROVE");
+    }
+
+    @Test
+    void decide_whenReauthFails_blocksTheDecisionAndRecordsTheFailure() {
+        when(releaseCase.getAssignedPartner()).thenReturn(reviewerPartner);
+        doThrow(new CustomException(ErrorCode.REAUTH_FAILED))
+                .when(reauthGuard).verify(actor, "wrong-pw");
+        PartnerReviewDecisionRequest request = new PartnerReviewDecisionRequest(
+                PartnerReviewDecisionRequest.PartnerReviewDecision.APPROVE, null, "wrong-pw");
+
+        assertThatThrownBy(() -> partnerReviewService.decide(REVIEW_ID, USER_ID, request))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.REAUTH_FAILED));
+
+        verify(evidence, never()).approve();
+        verify(adminActionAuditService).record(actor, AdminActionType.EVIDENCE_DECISION, REVIEW_ID, false, "재인증 실패");
+    }
+
+    @Test
+    void decide_whenUserLacksEvidenceReviewPermission_isBlockedBeforeAnyLookup() {
+        when(permissionGuard.require(USER_ID, AdminPermission.EVIDENCE_REVIEW))
+                .thenThrow(new CustomException(ErrorCode.INSUFFICIENT_PERMISSION));
+        PartnerReviewDecisionRequest request = new PartnerReviewDecisionRequest(
+                PartnerReviewDecisionRequest.PartnerReviewDecision.APPROVE, null, "pw");
+
+        assertThatThrownBy(() -> partnerReviewService.decide(REVIEW_ID, USER_ID, request))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.INSUFFICIENT_PERMISSION));
+        verify(evidenceRepository, never()).findById(any());
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/global/security/PermissionGuardTest.java
+++ b/src/test/java/com/mamoki/ieojuda/global/security/PermissionGuardTest.java
@@ -1,0 +1,60 @@
+package com.mamoki.ieojuda.global.security;
+
+import com.mamoki.ieojuda.domain.account.entity.AdminPermission;
+import com.mamoki.ieojuda.domain.account.entity.User;
+import com.mamoki.ieojuda.domain.account.repository.UserRepository;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+// issue #59 회귀 테스트 - ROLE_ADMIN/ROLE_EXTERNAL 하나만으로는 세부 업무 권한이 없으면 막혀야 한다.
+class PermissionGuardTest {
+
+    private UserRepository userRepository;
+    private PermissionGuard permissionGuard;
+
+    @BeforeEach
+    void setUp() {
+        userRepository = mock(UserRepository.class);
+        permissionGuard = new PermissionGuard(userRepository);
+    }
+
+    @Test
+    void require_whenUserHasThePermission_returnsTheUser() {
+        User admin = mock(User.class);
+        when(admin.hasPermission(AdminPermission.CASE_SUPERVISE)).thenReturn(true);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(admin));
+
+        User result = permissionGuard.require(1L, AdminPermission.CASE_SUPERVISE);
+
+        assertThat(result).isSameAs(admin);
+    }
+
+    @Test
+    void require_whenUserLacksThePermission_throwsInsufficientPermission() {
+        User admin = mock(User.class);
+        when(admin.hasPermission(AdminPermission.CASE_SUPERVISE)).thenReturn(false);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(admin));
+
+        assertThatThrownBy(() -> permissionGuard.require(1L, AdminPermission.CASE_SUPERVISE))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.INSUFFICIENT_PERMISSION));
+    }
+
+    @Test
+    void require_whenUserDoesNotExist_throwsUserNotFound() {
+        when(userRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> permissionGuard.require(99L, AdminPermission.AUDIT_VIEW))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.USER_NOT_FOUND));
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/global/security/ReauthGuardTest.java
+++ b/src/test/java/com/mamoki/ieojuda/global/security/ReauthGuardTest.java
@@ -1,0 +1,53 @@
+package com.mamoki.ieojuda.global.security;
+
+import com.mamoki.ieojuda.domain.account.entity.User;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+// issue #59 회귀 테스트 - 사건 동결·증빙 판정 같은 고위험 조작은 비밀번호 재확인 없이는 실행되지 않아야 한다.
+class ReauthGuardTest {
+
+    private PasswordEncoder passwordEncoder;
+    private ReauthGuard reauthGuard;
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        passwordEncoder = mock(PasswordEncoder.class);
+        reauthGuard = new ReauthGuard(passwordEncoder);
+        user = mock(User.class);
+        when(user.getPassword()).thenReturn("hashed");
+    }
+
+    @Test
+    void verify_whenPasswordMatches_doesNotThrow() {
+        when(passwordEncoder.matches("correct", "hashed")).thenReturn(true);
+
+        assertThatCode(() -> reauthGuard.verify(user, "correct")).doesNotThrowAnyException();
+    }
+
+    @Test
+    void verify_whenPasswordDoesNotMatch_throwsReauthFailed() {
+        when(passwordEncoder.matches("wrong", "hashed")).thenReturn(false);
+
+        assertThatThrownBy(() -> reauthGuard.verify(user, "wrong"))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.REAUTH_FAILED));
+    }
+
+    @Test
+    void verify_whenPasswordIsNull_throwsReauthFailedWithoutCallingEncoder() {
+        assertThatThrownBy(() -> reauthGuard.verify(user, null))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.REAUTH_FAILED));
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/global/validation/InputSizeConstraintTest.java
+++ b/src/test/java/com/mamoki/ieojuda/global/validation/InputSizeConstraintTest.java
@@ -50,7 +50,8 @@ class InputSizeConstraintTest {
     private static final Map<Class<?>, Map<String, Integer>> EXPECTED_MAX_LENGTHS = Map.ofEntries(
             Map.entry(LoginRequest.class, Map.of("email", 255, "password", 128)),
             Map.entry(RefreshRequest.class, Map.of("refreshToken", 255)),
-            Map.entry(SignupRequest.class, Map.of("email", 255, "password", 128, "passwordConfirm", 128, "name", 100)),
+            // password는 100자(유출 비밀번호 검사 도입 시 passwordConfirm과 별개로 조정됨) - 실제 선언과 맞춤
+            Map.entry(SignupRequest.class, Map.of("email", 255, "password", 100, "passwordConfirm", 128, "name", 100)),
             Map.entry(UserUpdateRequest.class, Map.of("email", 255, "name", 100)),
             Map.entry(ConfirmerRegisterRequest.class, Map.of("name", 100, "email", 255)),
             Map.entry(ConfirmerUpdateRequest.class, Map.of("name", 100, "email", 255)),
@@ -162,7 +163,7 @@ class InputSizeConstraintTest {
 
     @Test
     void evidenceFilenameMatchesTheDatabaseColumnLimit() {
-        EvidenceSubmitService service = new EvidenceSubmitService(null, null, null, null);
+        EvidenceSubmitService service = new EvidenceSubmitService(null, null, null, null, null, null);
         MockMultipartFile valid = new MockMultipartFile(
                 "file", "x".repeat(255), "application/pdf", new byte[]{1});
         MockMultipartFile oversized = new MockMultipartFile(


### PR DESCRIPTION
## 연관 Issue
Closes #59

## 요약
`ROLE_ADMIN`/`ROLE_EXTERNAL` 하나에 뭉쳐 있던 권한을 업무 단위 세부 권한으로 분리하고, 외부 파트너의 조직 경계 검사와 고위험 조작(사건 동결·증빙 판정) 재인증·감사를 추가했습니다.

## 작업 내용
- `AdminPermission` enum(`CASE_SUPERVISE`/`EVIDENCE_REVIEW`/`AUDIT_VIEW`/`EVIDENCE_DELETE_RETRY`) 4종 추가, `User`에 `@ElementCollection`으로 부여(role 승격과 동일하게 DB에서 직접 부여, 별도 API 없음)
- `PermissionGuard` 신설 - 관리자/파트너 API 8개(이메일 발송 감사 조회·재시도·사건 동결·파트너 배정, 인증 실패 감사 조회, 관리자 조작 감사 조회, 증빙 삭제 상태 조회·재처리, 단계 조회·대체 담당자 전환, 파트너 검토 조회·파일·판정)에 세부 권한 검사 적용
- `ReleaseCase`에 `assignedPartner`(외부 파트너사) 필드 추가, `POST /api/admin/release-cases/{caseId}/assign-partner`로 운영자가 수동 배정
- `PartnerReviewService`에 조직 경계 검사 추가 - 검토자 소속 파트너사와 사건에 배정된 파트너사가 다르면 `PARTNER_SCOPE_DENIED`, 아직 배정 안 된 사건은 `PARTNER_NOT_ASSIGNED`로 전부 차단
- `ReauthGuard` 신설 - 사건 동결(`freeze`), 증빙 판정(`decide`)은 비밀번호 재확인 없이 실행되지 않음. `PartnerReviewDecisionRequest`에 `password` 필드 추가
- `AdminActionAuditLog`/`AdminActionAuditService` 신설 - 사건 동결·파트너 배정·증빙 판정의 호출자·성공여부·시각 기록, `GET /api/admin/action-audit-logs`(AUDIT_VIEW)로 조회. 재인증 실패 시도도 감사에 남김
- 신규 ErrorCode 6개 추가(`INSUFFICIENT_PERMISSION`, `PARTNER_SCOPE_DENIED`, `REAUTH_FAILED`, `EXTERNAL_PARTNER_NOT_FOUND`, `PARTNER_NOT_ASSIGNED`)
- `PermissionGuardTest`, `ReauthGuardTest`, `PartnerReviewServiceTest`(조직 경계 통과/차단, 재인증 성공/실패, 권한 없음) 추가
- 기존 테스트(`DeathReportServiceTest`, `DisputeContactServiceBolaTest`, `InputSizeConstraintTest`) - 이 브랜치와 무관한 `TokenLookupGuard`/`PublicLinkAuditor` 생성자 변경 때문에 컴파일이 깨져 있던 것을 같이 수정. `SignupRequest.password` 테스트 기대값(128→100)도 실제 선언에 맞게 수정

## 범위
### 포함:
- 관리자·외부 파트너 세부 권한 정의, 사건 동결·증빙 판정 재인증(방법: 비밀번호 재확인), 고위험 조작 감사
- 외부 파트너(EXTERNAL)의 조직 경계 인가

### 제외:
- **ADMIN 쪽 조직 경계는 구현하지 않음** - "이 관리자가 어느 조직/팀 소속인지"에 대한 데이터 모델 자체가 없어서, CASE_SUPERVISE 권한이 있는 ADMIN은 여전히 모든 사건을 조작할 수 있습니다. 조직 경계는 EXTERNAL 파트너 리뷰어에만 적용됨
- 역할별 API 권한 매트릭스는 대화로만 정리했고 별도 문서로 남기지 않음
- 역할·조직 조합 테스트는 서비스 레이어 단위 테스트(Mockito)로만 작성 - 실제 HTTP로 역할별 403을 검증하는 통합 테스트는 없음
- 파트너 배정(`assign-partner`)은 고위험으로 분류하지 않아 재인증·실패 감사 대상에서 제외
- 일반 사용자 계획 소유권 검사, 운영자 UI 디자인

## 스크린샷 / 미리 보기
<!-- 해당 없음 - 백엔드 인가/감사 로직 변경 -->