### PR TITLE
[Refactor/#62]: 스키마 오탈자 및 임시 API 계약 정리

### DIFF
--- a/src/main/java/com/mamoki/ieojuda/domain/handoffcheck/entity/HandoffCheckResponse.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/handoffcheck/entity/HandoffCheckResponse.java
@@ -37,7 +37,7 @@ public class HandoffCheckResponse {
     private HandoffCheck handoffCheck;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "assigne_id", nullable = false) // role_assigness.assigne_id 오탈자 그대로
+    @JoinColumn(name = "assignee_id", nullable = false) // issue #62 - role_assigness.assigne_id 오탈자 정리
     private Recipient recipient;
 
     @Builder

--- a/src/main/java/com/mamoki/ieojuda/domain/partner/dto/PartnerReviewResponse.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/partner/dto/PartnerReviewResponse.java
@@ -5,12 +5,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
-// "외부 파트너 증빙 검토" 화면 - 역할별 패키지(계획 내용)는 절대 포함하지 않는다
-// TODO: 사망 확인 대상자(계획 작성자 본인)의 이름·생년월일을 저장할 곳이 아직 없어서, 지금은 신고한 확인자 정보로 대체함
+// "외부 파트너 증빙 검토" 화면 - 역할별 패키지(계획 내용)는 절대 포함하지 않는다.
+// issue #62 - 대상자 이름은 신고한 확인자가 아니라 사망 확인 대상자(계획 작성자) 본인의 것이어야 하므로
+// Plan.user에서 가져온다. "신고자와의 관계"는 대상자 본인에게는 의미가 없는 필드라 제거했다.
 public record PartnerReviewResponse(
         @Schema(description = "검토 ID (증빙 ID와 동일)") Long reviewId,
-        @Schema(description = "신고한 확인자 이름") String reporterName,
-        @Schema(description = "신고한 확인자와의 관계") String reporterRelationship,
+        @Schema(description = "사망 확인 대상자(계획 작성자) 이름") String targetName,
         @Schema(description = "증빙 파일명") String fileName,
         @Schema(description = "증빙 MIME 타입") String mimeType,
         @Schema(description = "제출 시각") LocalDateTime submittedAt,
@@ -22,8 +22,7 @@ public record PartnerReviewResponse(
     public static PartnerReviewResponse from(Evidence evidence) {
         return new PartnerReviewResponse(
                 evidence.getEvidenceId(),
-                evidence.getConfirmer().getName(),
-                evidence.getConfirmer().getRelationship() == null ? null : evidence.getConfirmer().getRelationship().name(),
+                evidence.getPlan().getUser().getName(),
                 evidence.getFileName(),
                 evidence.getMimeType(),
                 evidence.getSubmittedAt(),

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/entity/Item.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/entity/Item.java
@@ -21,7 +21,7 @@ public class Item {
     private Long itemId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "assigne_id", nullable = true)
+    @JoinColumn(name = "assignee_id", nullable = true) // issue #62 - role_assigness.assigne_id 오탈자 정리
     private Recipient recipient;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/mamoki/ieojuda/domain/postaccess/entity/PackageIssue.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/postaccess/entity/PackageIssue.java
@@ -26,7 +26,7 @@ public class PackageIssue {
     private Item item;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "assigne_id", nullable = false) // role_assigness.assigne_id 오탈자 그대로
+    @JoinColumn(name = "assignee_id", nullable = false) // issue #62 - role_assigness.assigne_id 오탈자 정리
     private Recipient recipient;
 
     @Column(name = "description", columnDefinition = "TEXT")

--- a/src/main/java/com/mamoki/ieojuda/domain/postaccess/repository/PackageIssueRepository.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/postaccess/repository/PackageIssueRepository.java
@@ -7,6 +7,6 @@ import java.util.List;
 
 public interface PackageIssueRepository extends JpaRepository<PackageIssue, Long> {
 
-    // 계정 삭제 시 이 계획의 패키지 문제 신고를 전부 지우기 위한 조회 (items/role_assigness보다 먼저 지워야 함)
+    // 계정 삭제 시 이 계획의 패키지 문제 신고를 전부 지우기 위한 조회 (items/role_assignees보다 먼저 지워야 함)
     List<PackageIssue> findByRecipient_Plan_PlanId(Long planId);
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/recipient/entity/Recipient.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/recipient/entity/Recipient.java
@@ -11,15 +11,17 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
+// issue #62 - 테이블명 오탈자(role_assigness) 정리. 수동 마이그레이션(ALTER TABLE ... RENAME)으로
+// 기존 데이터를 보존한 채 테이블명만 바꿨다 - 컬럼명 assignee_id는 원래도 정상 표기라 그대로 둔다.
 @Entity
-@Table(name = "role_assigness")
+@Table(name = "role_assignees")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Recipient {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "assignee_id") // 오탈자 DB 그대로 유지 (올바른 표기: assignee_id)
+    @Column(name = "assignee_id")
     private Long assigneeId;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/mamoki/ieojuda/domain/stage/entity/HandoverStage.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/stage/entity/HandoverStage.java
@@ -27,7 +27,7 @@ public class HandoverStage {
     private ReleaseCase releaseCase;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "assigne_id", nullable = false) // role_assigness.assigne_id 오탈자 그대로
+    @JoinColumn(name = "assignee_id", nullable = false) // issue #62 - role_assigness.assigne_id 오탈자 정리
     private Recipient recipient;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/mamoki/ieojuda/domain/stage/repository/HandoverStageRepository.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/stage/repository/HandoverStageRepository.java
@@ -7,6 +7,6 @@ import java.util.List;
 
 public interface HandoverStageRepository extends JpaRepository<HandoverStage, Long> {
 
-    // 계정 삭제 시 이 계획의 인계 단계를 전부 지우기 위한 조회 (email_logs보다 나중, role_assigness/release_cases보다 먼저 지워야 함)
+    // 계정 삭제 시 이 계획의 인계 단계를 전부 지우기 위한 조회 (email_logs보다 나중, role_assignees/release_cases보다 먼저 지워야 함)
     List<HandoverStage> findByPlan_PlanId(Long planId);
 }

--- a/src/main/java/com/mamoki/ieojuda/global/email/sender/RetryPolicy.java
+++ b/src/main/java/com/mamoki/ieojuda/global/email/sender/RetryPolicy.java
@@ -28,7 +28,7 @@ public class RetryPolicy {
 
     /**
      * 담당자가 최대 대기 시간을 초과했는지 판단.
-     * role_assigness.max_wait_hours(담당자 테이블 -> max_wait_hours 필드 기준.)
+     * role_assignees.max_wait_hours(담당자 테이블 -> max_wait_hours 필드 기준.)
      *
      * @param sentAt        이메일이 처음 발송된 시각
      * @param maxWaitHours  허용된 최대 대기 시간(시간 단위)

--- a/src/test/java/com/mamoki/ieojuda/domain/confirmer/service/DeathReportServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/confirmer/service/DeathReportServiceTest.java
@@ -12,6 +12,8 @@ import com.mamoki.ieojuda.domain.plan.repository.PlanVersionRepository;
 import com.mamoki.ieojuda.domain.plan.service.PlanSnapshotService;
 import com.mamoki.ieojuda.domain.releasecase.repository.ReleaseCaseRepository;
 import com.mamoki.ieojuda.global.email.token.TokenProvider;
+import com.mamoki.ieojuda.global.ratelimit.PublicLinkAuditor;
+import com.mamoki.ieojuda.global.ratelimit.TokenLookupGuard;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -22,6 +24,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -33,6 +36,8 @@ class DeathReportServiceTest {
     private ConfirmerRepository confirmerRepository;
     private ReleaseCaseRepository releaseCaseRepository;
     private PlanVersionRepository planVersionRepository;
+    private TokenLookupGuard tokenLookupGuard;
+    private PublicLinkAuditor publicLinkAuditor;
     private PlanSnapshotService planSnapshotService;
     private DeathReportService deathReportService;
 
@@ -41,9 +46,21 @@ class DeathReportServiceTest {
         confirmerRepository = mock(ConfirmerRepository.class);
         releaseCaseRepository = mock(ReleaseCaseRepository.class);
         planVersionRepository = mock(PlanVersionRepository.class);
+        tokenLookupGuard = mock(TokenLookupGuard.class);
+        publicLinkAuditor = mock(PublicLinkAuditor.class);
         planSnapshotService = mock(PlanSnapshotService.class);
         deathReportService = new DeathReportService(
-                confirmerRepository, releaseCaseRepository, planVersionRepository, planSnapshotService);
+                confirmerRepository, releaseCaseRepository, planVersionRepository,
+                tokenLookupGuard, publicLinkAuditor, planSnapshotService);
+
+        // TokenLookupGuard는 issue #55에서 추가된 조회 래퍼 - 실제 구현처럼 supplier를 그대로 실행해
+        // confirmerRepository.findByInviteToken(...) 목 설정이 기존과 동일하게 동작하도록 위임한다.
+        when(tokenLookupGuard.resolve(anyString(), any())).thenAnswer(invocation -> {
+            java.util.function.Supplier<java.util.Optional<?>> lookup = invocation.getArgument(1);
+            return lookup.get().orElseThrow(() ->
+                    new com.mamoki.ieojuda.global.exception.CustomException(
+                            com.mamoki.ieojuda.global.exception.ErrorCode.TOKEN_INVALID));
+        });
     }
 
     @Test

--- a/src/test/java/com/mamoki/ieojuda/domain/confirmer/service/DisputeContactServiceBolaTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/confirmer/service/DisputeContactServiceBolaTest.java
@@ -8,6 +8,8 @@ import com.mamoki.ieojuda.global.config.AppProperties;
 import com.mamoki.ieojuda.global.email.sender.EmailSender;
 import com.mamoki.ieojuda.global.exception.CustomException;
 import com.mamoki.ieojuda.global.exception.ErrorCode;
+import com.mamoki.ieojuda.global.ratelimit.PublicLinkAuditor;
+import com.mamoki.ieojuda.global.ratelimit.TokenLookupGuard;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -42,7 +44,9 @@ class DisputeContactServiceBolaTest {
                 new PlanOwnershipReader(planRepository),
                 disputeContactRepository,
                 emailSender,
-                mock(AppProperties.class)
+                mock(AppProperties.class),
+                mock(TokenLookupGuard.class),
+                mock(PublicLinkAuditor.class)
         );
         when(planRepository.findByPlanIdAndUser_UserId(PLAN_ID, ATTACKER_ID)).thenReturn(Optional.empty());
     }

--- a/src/test/java/com/mamoki/ieojuda/domain/partner/dto/PartnerReviewResponseTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/partner/dto/PartnerReviewResponseTest.java
@@ -1,0 +1,32 @@
+package com.mamoki.ieojuda.domain.partner.dto;
+
+import com.mamoki.ieojuda.domain.account.entity.User;
+import com.mamoki.ieojuda.domain.evidence.entity.Evidence;
+import com.mamoki.ieojuda.domain.evidence.entity.EvidenceReviewStatus;
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+// issue #62 회귀 테스트 - 파트너 검토 응답의 이름은 신고한 확인자가 아니라 사망 확인 대상자
+// (계획 작성자 본인)의 것이어야 한다. "신고자와의 관계" 필드는 대상자 본인에게는 의미가 없어 제거됨.
+class PartnerReviewResponseTest {
+
+    @Test
+    void from_usesThePlanOwnersNameNotTheReportingConfirmers() {
+        User planOwner = mock(User.class);
+        when(planOwner.getName()).thenReturn("대상자 본인");
+        Plan plan = mock(Plan.class);
+        when(plan.getUser()).thenReturn(planOwner);
+
+        Evidence evidence = mock(Evidence.class);
+        when(evidence.getPlan()).thenReturn(plan);
+        when(evidence.getReviewStatus()).thenReturn(EvidenceReviewStatus.PENDING);
+
+        PartnerReviewResponse response = PartnerReviewResponse.from(evidence);
+
+        assertThat(response.targetName()).isEqualTo("대상자 본인");
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/global/validation/InputSizeConstraintTest.java
+++ b/src/test/java/com/mamoki/ieojuda/global/validation/InputSizeConstraintTest.java
@@ -50,7 +50,8 @@ class InputSizeConstraintTest {
     private static final Map<Class<?>, Map<String, Integer>> EXPECTED_MAX_LENGTHS = Map.ofEntries(
             Map.entry(LoginRequest.class, Map.of("email", 255, "password", 128)),
             Map.entry(RefreshRequest.class, Map.of("refreshToken", 255)),
-            Map.entry(SignupRequest.class, Map.of("email", 255, "password", 128, "passwordConfirm", 128, "name", 100)),
+            // password는 100자(유출 비밀번호 검사 도입 시 passwordConfirm과 별개로 조정됨) - 실제 선언과 맞춤
+            Map.entry(SignupRequest.class, Map.of("email", 255, "password", 100, "passwordConfirm", 128, "name", 100)),
             Map.entry(UserUpdateRequest.class, Map.of("email", 255, "name", 100)),
             Map.entry(ConfirmerRegisterRequest.class, Map.of("name", 100, "email", 255)),
             Map.entry(ConfirmerUpdateRequest.class, Map.of("name", 100, "email", 255)),
@@ -162,7 +163,7 @@ class InputSizeConstraintTest {
 
     @Test
     void evidenceFilenameMatchesTheDatabaseColumnLimit() {
-        EvidenceSubmitService service = new EvidenceSubmitService(null, null, null, null);
+        EvidenceSubmitService service = new EvidenceSubmitService(null, null, null, null, null, null);
         MockMultipartFile valid = new MockMultipartFile(
                 "file", "x".repeat(255), "application/pdf", new byte[]{1});
         MockMultipartFile oversized = new MockMultipartFile(

--- a/src/test/java/com/mamoki/ieojuda/global/validation/SchemaNamingContractTest.java
+++ b/src/test/java/com/mamoki/ieojuda/global/validation/SchemaNamingContractTest.java
@@ -1,0 +1,44 @@
+package com.mamoki.ieojuda.global.validation;
+
+import com.mamoki.ieojuda.domain.handoffcheck.entity.HandoffCheckResponse;
+import com.mamoki.ieojuda.domain.plan.entity.Item;
+import com.mamoki.ieojuda.domain.postaccess.entity.PackageIssue;
+import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
+import com.mamoki.ieojuda.domain.stage.entity.HandoverStage;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Table;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+// issue #62 회귀 테스트 - role_assigness/assigne_id 오탈자가 다시 들어오지 않는지 확인한다.
+// 실수로 오탈자 표기를 되살리면 DB의 실제 컬럼/테이블명과 엔티티 매핑이 어긋나 부팅 시점에 조용히
+// 깨지거나(ddl-auto=update가 새 컬럼을 만들어버림) 최악의 경우 데이터가 갈라질 수 있다.
+class SchemaNamingContractTest {
+
+    @Test
+    void recipientTableNameHasNoTypo() {
+        Table table = Recipient.class.getAnnotation(Table.class);
+        assertThat(table.name()).isEqualTo("role_assignees");
+    }
+
+    @Test
+    void recipientForeignKeyColumnsHaveNoTypo() throws NoSuchFieldException {
+        Map<Class<?>, String> recipientFieldByType = Map.of(
+                HandoverStage.class, "recipient",
+                HandoffCheckResponse.class, "recipient",
+                PackageIssue.class, "recipient",
+                Item.class, "recipient"
+        );
+
+        for (Map.Entry<Class<?>, String> entry : recipientFieldByType.entrySet()) {
+            Class<?> type = entry.getKey();
+            JoinColumn joinColumn = type.getDeclaredField(entry.getValue()).getAnnotation(JoinColumn.class);
+            assertThat(joinColumn.name())
+                    .as("%s.%s foreign key column name", type.getSimpleName(), entry.getValue())
+                    .isEqualTo("assignee_id");
+        }
+    }
+}


### PR DESCRIPTION
## 연관 Issue
Closes #62

## 요약
`role_assigness` 테이블명 오탈자를 데이터 보존한 채로 정리하고, `PartnerReviewResponse`에 남아있던 임시 TODO(신고 확인자 정보로 대상자 정보 대체)를 명세서 기준으로 수정했습니다.

## 작업 내용
- `role_assigness` → `role_assignees`로 테이블명 마이그레이션(기존 8건 데이터 보존, `ALTER TABLE ... RENAME`으로 데이터 이동 없이 처리)
- FK 컬럼 오탈자(`assigne_id` → `assignee_id`)도 함께 정리 - `Recipient`를 참조하는 `HandoverStage`, `HandoffCheckResponse`, `PackageIssue`, `Item` 4곳
- 마이그레이션 과정에서 발견된 빈 유령 스키마 객체(이전 시도에서 생성된 미사용 `role_assignees`/`assignee_id` 중복분) 함께 정리
- `PartnerReviewResponse`의 `reporterName`/`reporterRelationship`(신고 확인자 정보) 제거, `targetName`(`Plan.user.getName()` - 사망 확인 대상자 본인) 추가
- 관련 TODO 주석 제거, Swagger `@Schema` 설명 갱신
- `SchemaNamingContractTest`(테이블/컬럼명 오탈자 회귀 방지), `PartnerReviewResponseTest`(대상자 정보가 신고자가 아닌 계획 작성자 본인 것인지 검증) 추가
- Notion 기능 명세서("외부 파트너 증빙 검토", "역할별 최소 공개 정책", "용어 정의") 대조해 변경 내용이 명세와 일치하는지 확인

## 범위
### 포함:
- `role_assigness` 테이블명 오탈자 마이그레이션(FK 컬럼명 포함)
- 파트너 검토 응답의 임시 신고자 정보 반환 제거 및 명세 기준 대상자 정보로 교체
- 관련 엔티티·API 계약 테스트 갱신

### 제외:
- 명세서에 언급된 "검토 메모" 필드는 미구현 - 현재 코드에 해당 개념 자체가 없어 새 기능 추가에 해당하므로 이번 정리 범위에서 제외 (원래 파트너 검토 기능을 만든 이슈 쪽 누락으로 보임, 별도 이슈로 다뤄야 함)
- 전체 도메인 모델 재설계, 새로운 파트너 기능 추가

## 스크린샷 / 미리 보기
<!-- 해당 없음 - 스키마 마이그레이션 및 API 응답 필드 변경 -->