### PR TITLE
[Feat/#76] 사후 인계 링크 인증 및 OTP 2단계 확인 구현

### DIFF
--- a/src/main/java/com/mamoki/ieojuda/domain/audit/dto/EmailDeliveryResponse.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/audit/dto/EmailDeliveryResponse.java
@@ -1,6 +1,7 @@
 package com.mamoki.ieojuda.domain.audit.dto;
 
 import com.mamoki.ieojuda.domain.audit.entity.EmailLog;
+import com.mamoki.ieojuda.global.util.EmailMasker;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
@@ -20,7 +21,7 @@ public record EmailDeliveryResponse(
     public static EmailDeliveryResponse from(EmailLog log) {
         return new EmailDeliveryResponse(
                 log.getLogId(),
-                mask(log.getRecipientEmail()),
+                EmailMasker.mask(log.getRecipientEmail()),
                 log.getEmailType() == null ? null : log.getEmailType().name(),
                 log.getRetryCount(),
                 log.getMessageId(),
@@ -29,16 +30,5 @@ public record EmailDeliveryResponse(
                 log.getBouncedAt(),
                 log.getCanceledAt()
         );
-    }
-
-    // 로컬파트 앞 2글자만 남기고 나머지는 *** 처리 (예: jisoo@naver.com -> ji***@naver.com)
-    private static String mask(String email) {
-        if (email == null || !email.contains("@")) {
-            return email;
-        }
-        String[] parts = email.split("@", 2);
-        String local = parts[0];
-        String visible = local.length() <= 2 ? local : local.substring(0, 2);
-        return visible + "***@" + parts[1];
     }
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/postaccess/controller/PosthumousAccessController.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/postaccess/controller/PosthumousAccessController.java
@@ -1,0 +1,55 @@
+package com.mamoki.ieojuda.domain.postaccess.controller;
+
+import com.mamoki.ieojuda.domain.postaccess.dto.OtpSendResponse;
+import com.mamoki.ieojuda.domain.postaccess.dto.OtpVerifyRequest;
+import com.mamoki.ieojuda.domain.postaccess.dto.OtpVerifyResponse;
+import com.mamoki.ieojuda.domain.postaccess.dto.PosthumousAccessResponse;
+import com.mamoki.ieojuda.domain.postaccess.service.PosthumousAccessService;
+import com.mamoki.ieojuda.global.rsdata.RsData;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+// 명세서 "사후 인계 이메일" - 역할 담당자가 만료 링크와 별도 이메일 OTP 확인 후 패키지에 접근하기 전 단계 (로그인 불필요, 토큰이 곧 인증)
+@Tag(name = "PosthumousAccess", description = "사후 인계 - 링크 검증 / OTP 발송 / OTP 확인 (이메일 링크 클릭)")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/posthumous-access")
+public class PosthumousAccessController {
+
+    private final PosthumousAccessService posthumousAccessService;
+
+    @Operation(summary = "링크 검증", description = "사후 인계 이메일의 링크로 진입했을 때 담당자·작성자 이름, 역할, 링크 만료 시각, OTP 발송 여부를 조회합니다. 인증 전이므로 인계 내용은 포함하지 않습니다.")
+    @GetMapping("/{token}")
+    public ResponseEntity<RsData<PosthumousAccessResponse>> getAccess(
+            @Parameter(description = "사후 인계 링크 토큰") @PathVariable String token
+    ) {
+        return ResponseEntity.ok(RsData.success(posthumousAccessService.getAccess(token)));
+    }
+
+    @Operation(summary = "OTP 발송", description = "담당자의 등록된 이메일로 별도의 6자리 OTP 코드를 발송합니다. 재발송 간격과 최대 시도 횟수 제한이 적용됩니다.")
+    @PostMapping("/{token}/otp")
+    public ResponseEntity<RsData<OtpSendResponse>> sendOtp(
+            @Parameter(description = "사후 인계 링크 토큰") @PathVariable String token
+    ) {
+        return ResponseEntity.ok(RsData.success(posthumousAccessService.sendOtp(token)));
+    }
+
+    @Operation(summary = "OTP 확인", description = "발송된 OTP 코드를 검증합니다. 성공 시 역할별 사후 패키지 조회에 사용할 열람 세션을 발급합니다.")
+    @PostMapping("/{token}/verify")
+    public ResponseEntity<RsData<OtpVerifyResponse>> verify(
+            @Parameter(description = "사후 인계 링크 토큰") @PathVariable String token,
+            @Valid @RequestBody OtpVerifyRequest request
+    ) {
+        return ResponseEntity.ok(RsData.success(posthumousAccessService.verify(token, request)));
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/postaccess/dto/OtpSendResponse.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/postaccess/dto/OtpSendResponse.java
@@ -1,0 +1,13 @@
+package com.mamoki.ieojuda.domain.postaccess.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+// "사후 인계 이메일" 화면 - OTP 발송 결과
+public record OtpSendResponse(
+        @Schema(description = "OTP가 발송된 이메일 (마스킹됨)", example = "ji****@naver.com") String maskedEmail,
+        @Schema(description = "OTP 만료 시각") LocalDateTime otpExpiresAt,
+        @Schema(description = "재발송 가능 시각") LocalDateTime resendAvailableAt
+) {
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/postaccess/dto/OtpVerifyRequest.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/postaccess/dto/OtpVerifyRequest.java
@@ -1,0 +1,12 @@
+package com.mamoki.ieojuda.domain.postaccess.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record OtpVerifyRequest(
+        @Schema(description = "6자리 OTP 코드", example = "123456")
+        @NotBlank(message = "OTP 코드를 입력해 주세요.")
+        @Pattern(regexp = "\\d{6}", message = "OTP 코드는 6자리 숫자여야 합니다.") String otpCode
+) {
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/postaccess/dto/OtpVerifyResponse.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/postaccess/dto/OtpVerifyResponse.java
@@ -1,0 +1,12 @@
+package com.mamoki.ieojuda.domain.postaccess.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+// "사후 인계 이메일" 화면 - OTP 인증 성공 시 발급되는 열람 세션. 이 값으로 역할별 사후 패키지를 조회한다.
+public record OtpVerifyResponse(
+        @Schema(description = "열람 세션 식별자") String accessSessionId,
+        @Schema(description = "열람 세션 만료 시각") LocalDateTime sessionExpiresAt
+) {
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/postaccess/dto/PosthumousAccessResponse.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/postaccess/dto/PosthumousAccessResponse.java
@@ -1,0 +1,40 @@
+package com.mamoki.ieojuda.domain.postaccess.dto;
+
+import com.mamoki.ieojuda.domain.postaccess.entity.AccessToken;
+import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
+import com.mamoki.ieojuda.domain.recipient.entity.RoleType;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+// "사후 인계 이메일" 화면 - 링크 진입 시 본인 확인 전에 보여줄 최소 정보. 인계 내용은 절대 포함하지 않는다.
+public record PosthumousAccessResponse(
+        @Schema(description = "역할 담당자 이름", example = "이지수") String recipientName,
+        @Schema(description = "작성자(계획 소유자) 이름", example = "김나무") String authorName,
+        @Schema(description = "역할 종류") String roleType,
+        @Schema(description = "역할 한글 명칭", example = "관계 정리 담당자") String roleLabel,
+        @Schema(description = "링크 만료 시각") LocalDateTime expiresAt,
+        @Schema(description = "OTP 발송 여부") boolean otpSent,
+        @Schema(description = "문의 주소") String contactEmail
+) {
+    public static PosthumousAccessResponse of(AccessToken accessToken, String contactEmail) {
+        Recipient recipient = accessToken.getHandoverStage().getRecipient();
+        return new PosthumousAccessResponse(
+                recipient.getName(),
+                recipient.getPlan().getUser().getName(),
+                recipient.getRoleType().name(),
+                roleLabel(recipient.getRoleType()),
+                accessToken.getExpiresAt(),
+                accessToken.getOtpSentAt() != null,
+                contactEmail
+        );
+    }
+
+    private static String roleLabel(RoleType roleType) {
+        return switch (roleType) {
+            case FAMILY_MANAGER -> "가족 담당자";
+            case WORK_MANAGER -> "업무 담당자";
+            case RELATIONSHIP_MANAGER -> "관계 정리 담당자";
+        };
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/postaccess/entity/AccessToken.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/postaccess/entity/AccessToken.java
@@ -45,6 +45,13 @@ public class AccessToken {
     @Column(name = "used")
     private Boolean used;
 
+    // OTP 인증 성공 후 발급되는 열람 세션 식별자(해시만 저장, 평문은 응답으로만 반환)
+    @Column(name = "session_token_hash", length = 255)
+    private String sessionTokenHash;
+
+    @Column(name = "session_expires_at")
+    private LocalDateTime sessionExpiresAt;
+
     @Builder
     public AccessToken(HandoverStage handoverStage, String tokenHash, LocalDateTime expiresAt) {
         this.handoverStage = handoverStage;
@@ -54,5 +61,23 @@ public class AccessToken {
         this.used = false;
     }
 
+    // OTP 코드 발송 - 코드 해시와 발송 시각 갱신 (재발송 시에도 동일하게 덮어씀)
+    public void recordOtpSend(String otpCodeHash) {
+        this.otpCodeHash = otpCodeHash;
+        this.otpSentAt = LocalDateTime.now();
+    }
 
+    // OTP 검증 실패 1회 기록, 갱신된 시도 횟수를 반환
+    public int incrementAttempt() {
+        this.attemptCount = this.attemptCount + 1;
+        return this.attemptCount;
+    }
+
+    // OTP 검증 성공 - 열람 세션을 발급하고 링크 자체는 1회성으로 소진 처리
+    public void verify(String sessionTokenHash, LocalDateTime sessionExpiresAt) {
+        this.verifiedAt = LocalDateTime.now();
+        this.used = true;
+        this.sessionTokenHash = sessionTokenHash;
+        this.sessionExpiresAt = sessionExpiresAt;
+    }
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/postaccess/entity/AccessToken.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/postaccess/entity/AccessToken.java
@@ -45,13 +45,6 @@ public class AccessToken {
     @Column(name = "used")
     private Boolean used;
 
-    // OTP 인증 성공 후 발급되는 열람 세션 식별자(해시만 저장, 평문은 응답으로만 반환)
-    @Column(name = "session_token_hash", length = 255)
-    private String sessionTokenHash;
-
-    @Column(name = "session_expires_at")
-    private LocalDateTime sessionExpiresAt;
-
     @Builder
     public AccessToken(HandoverStage handoverStage, String tokenHash, LocalDateTime expiresAt) {
         this.handoverStage = handoverStage;
@@ -73,11 +66,10 @@ public class AccessToken {
         return this.attemptCount;
     }
 
-    // OTP 검증 성공 - 열람 세션을 발급하고 링크 자체는 1회성으로 소진 처리
-    public void verify(String sessionTokenHash, LocalDateTime sessionExpiresAt) {
+    // OTP 검증 성공 - 링크 자체는 1회성으로 소진 처리(재검증·재조회 차단). 새 컬럼 없이 기존 필드만 사용:
+    // 같은 원본 토큰이 곧 열람 세션 식별자로도 쓰이고, verifiedAt이 세션 시작 시각(만료 판단 기준)이 된다.
+    public void verify() {
         this.verifiedAt = LocalDateTime.now();
         this.used = true;
-        this.sessionTokenHash = sessionTokenHash;
-        this.sessionExpiresAt = sessionExpiresAt;
     }
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/postaccess/repository/AccessTokenRepository.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/postaccess/repository/AccessTokenRepository.java
@@ -1,0 +1,15 @@
+package com.mamoki.ieojuda.domain.postaccess.repository;
+
+import com.mamoki.ieojuda.domain.postaccess.entity.AccessToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AccessTokenRepository extends JpaRepository<AccessToken, Long> {
+
+    // "사후 인계 이메일" 화면 진입 - 링크의 토큰으로 열람 대상을 찾기 위한 조회
+    Optional<AccessToken> findByTokenHash(String tokenHash);
+
+    // OTP 인증 성공 후 발급된 열람 세션 식별자로 조회 (역할별 사후 패키지 조회에서 사용)
+    Optional<AccessToken> findBySessionTokenHash(String sessionTokenHash);
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/postaccess/repository/AccessTokenRepository.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/postaccess/repository/AccessTokenRepository.java
@@ -7,9 +7,7 @@ import java.util.Optional;
 
 public interface AccessTokenRepository extends JpaRepository<AccessToken, Long> {
 
-    // "사후 인계 이메일" 화면 진입 - 링크의 토큰으로 열람 대상을 찾기 위한 조회
+    // "사후 인계 이메일" 화면 진입 - 링크의 토큰으로 열람 대상을 찾기 위한 조회.
+    // OTP 인증 성공 후에는 이 같은 토큰이 열람 세션 식별자로도 쓰인다(verifiedAt으로 세션 유효성 판단).
     Optional<AccessToken> findByTokenHash(String tokenHash);
-
-    // OTP 인증 성공 후 발급된 열람 세션 식별자로 조회 (역할별 사후 패키지 조회에서 사용)
-    Optional<AccessToken> findBySessionTokenHash(String sessionTokenHash);
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/postaccess/service/OtpAttemptRecorder.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/postaccess/service/OtpAttemptRecorder.java
@@ -1,0 +1,23 @@
+package com.mamoki.ieojuda.domain.postaccess.service;
+
+import com.mamoki.ieojuda.domain.postaccess.repository.AccessTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+// OTP 검증 실패 횟수는 PosthumousAccessService.verify()가 CustomException을 던지며 그 트랜잭션을
+// 롤백시키기 직전에 기록해야 한다. 같은 트랜잭션에서 늘리면 롤백과 함께 증가분도 사라져 5회 실패
+// 차단이 무력화되므로(ReleaseCaseGuardService.freeze()와 동일한 문제), 별도 빈으로 분리해
+// REQUIRES_NEW로 독립 커밋한다.
+@Service
+@RequiredArgsConstructor
+public class OtpAttemptRecorder {
+
+    private final AccessTokenRepository accessTokenRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void recordFailure(Long accessTokenId) {
+        accessTokenRepository.findById(accessTokenId).ifPresent(token -> token.incrementAttempt());
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/postaccess/service/PosthumousAccessService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/postaccess/service/PosthumousAccessService.java
@@ -10,7 +10,6 @@ import com.mamoki.ieojuda.domain.postaccess.dto.PosthumousAccessResponse;
 import com.mamoki.ieojuda.domain.postaccess.entity.AccessToken;
 import com.mamoki.ieojuda.domain.postaccess.repository.AccessTokenRepository;
 import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
-import com.mamoki.ieojuda.domain.stage.entity.HandoverStage;
 import com.mamoki.ieojuda.domain.stage.entity.HandoverStageStatus;
 import com.mamoki.ieojuda.global.config.AppProperties;
 import com.mamoki.ieojuda.global.email.contract.EmailContent;
@@ -120,20 +119,6 @@ public class PosthumousAccessService {
         LocalDateTime sessionExpiresAt = accessToken.getVerifiedAt().plusMinutes(SESSION_TTL_MINUTES);
 
         return new OtpVerifyResponse(plainToken, sessionExpiresAt);
-    }
-
-    // 발송 단계가 활성화될 때 호출 - AccessToken을 발급하고 평문 토큰을 반환한다.
-    // (링크 문구·주소 교체는 별도 이슈에서 이 메서드를 호출하도록 연결한다)
-    @Transactional
-    public String issueAccessToken(HandoverStage stage) {
-        String plainToken = TokenProvider.generatePlainToken();
-        LocalDateTime expiresAt = LocalDateTime.now().plusHours(appProperties.getInviteTokenTtlHours());
-        accessTokenRepository.save(AccessToken.builder()
-                .handoverStage(stage)
-                .tokenHash(TokenProvider.hashToken(plainToken))
-                .expiresAt(expiresAt)
-                .build());
-        return plainToken;
     }
 
     private AccessToken findByToken(String plainToken) {

--- a/src/main/java/com/mamoki/ieojuda/domain/postaccess/service/PosthumousAccessService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/postaccess/service/PosthumousAccessService.java
@@ -11,6 +11,7 @@ import com.mamoki.ieojuda.domain.postaccess.entity.AccessToken;
 import com.mamoki.ieojuda.domain.postaccess.repository.AccessTokenRepository;
 import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
 import com.mamoki.ieojuda.domain.stage.entity.HandoverStage;
+import com.mamoki.ieojuda.domain.stage.entity.HandoverStageStatus;
 import com.mamoki.ieojuda.global.config.AppProperties;
 import com.mamoki.ieojuda.global.email.contract.EmailContent;
 import com.mamoki.ieojuda.global.email.contract.EmailSendResult;
@@ -51,6 +52,7 @@ public class PosthumousAccessService {
     private final AppProperties appProperties;
     private final TokenLookupGuard tokenLookupGuard;
     private final PublicLinkAuditor publicLinkAuditor;
+    private final OtpAttemptRecorder otpAttemptRecorder;
 
     // ① 링크 검증 - 인증 전이므로 인계 내용은 어떤 필드에도 포함하지 않는다
     @Transactional
@@ -106,16 +108,18 @@ public class PosthumousAccessService {
         checkOtpNotExpired(accessToken);
 
         if (!accessToken.getOtpCodeHash().equals(TokenProvider.hashToken(request.otpCode()))) {
-            accessToken.incrementAttempt();
+            // 이 트랜잭션은 아래 예외로 곧 롤백되므로, 시도 횟수는 별도 트랜잭션(REQUIRES_NEW)으로 먼저 커밋한다.
+            otpAttemptRecorder.recordFailure(accessToken.getTokenId());
             publicLinkAuditor.recordStateFailure(ErrorCode.OTP_VERIFICATION_FAILED);
             throw new CustomException(ErrorCode.OTP_VERIFICATION_FAILED);
         }
 
-        String sessionToken = TokenProvider.generatePlainToken();
-        LocalDateTime sessionExpiresAt = LocalDateTime.now().plusMinutes(SESSION_TTL_MINUTES);
-        accessToken.verify(TokenProvider.hashToken(sessionToken), sessionExpiresAt);
+        // 새 컬럼을 두지 않고 같은 원본 토큰을 그대로 열람 세션 식별자로 쓴다 -
+        // 이후 조회는 verifiedAt(세션 시작 시각) 기준으로 60분 이내인지만 확인하면 된다.
+        accessToken.verify();
+        LocalDateTime sessionExpiresAt = accessToken.getVerifiedAt().plusMinutes(SESSION_TTL_MINUTES);
 
-        return new OtpVerifyResponse(sessionToken, sessionExpiresAt);
+        return new OtpVerifyResponse(plainToken, sessionExpiresAt);
     }
 
     // 발송 단계가 활성화될 때 호출 - AccessToken을 발급하고 평문 토큰을 반환한다.
@@ -137,7 +141,7 @@ public class PosthumousAccessService {
                 () -> accessTokenRepository.findByTokenHash(TokenProvider.hashToken(plainToken)));
     }
 
-    // 만료되었거나 이미 인증까지 끝나 소진된(1회성) 링크를 차단
+    // 만료·재사용(1회성 소진)·역할 불일치 링크를 차단 (이슈 #76 완료 조건 3가지)
     private void checkUsable(AccessToken accessToken) {
         Instant expiresAt = accessToken.getExpiresAt() == null
                 ? null
@@ -149,6 +153,16 @@ public class PosthumousAccessService {
         if (!TokenValidator.isUsable(Boolean.TRUE.equals(accessToken.getUsed()))) {
             publicLinkAuditor.recordStateFailure(ErrorCode.ACCESS_LINK_ALREADY_USED);
             throw new CustomException(ErrorCode.ACCESS_LINK_ALREADY_USED);
+        }
+        checkRoleConsistent(accessToken);
+    }
+
+    // 발급 이후 대체 담당자 전환(fallback)·차단(block) 등으로 이 단계가 더 이상 "발송됨(SENT)" 상태가
+    // 아니게 되면, 같은 토큰이 가리키는 담당자·역할이 이메일을 받았을 때와 달라졌다는 뜻이라 차단한다.
+    private void checkRoleConsistent(AccessToken accessToken) {
+        if (accessToken.getHandoverStage().getStatus() != HandoverStageStatus.SENT) {
+            publicLinkAuditor.recordStateFailure(ErrorCode.ACCESS_LINK_EXPIRED);
+            throw new CustomException(ErrorCode.ACCESS_LINK_EXPIRED);
         }
     }
 

--- a/src/main/java/com/mamoki/ieojuda/domain/postaccess/service/PosthumousAccessService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/postaccess/service/PosthumousAccessService.java
@@ -1,0 +1,187 @@
+package com.mamoki.ieojuda.domain.postaccess.service;
+
+import com.mamoki.ieojuda.domain.audit.entity.EmailLog;
+import com.mamoki.ieojuda.domain.audit.entity.EmailType;
+import com.mamoki.ieojuda.domain.audit.repository.EmailLogRepository;
+import com.mamoki.ieojuda.domain.postaccess.dto.OtpSendResponse;
+import com.mamoki.ieojuda.domain.postaccess.dto.OtpVerifyRequest;
+import com.mamoki.ieojuda.domain.postaccess.dto.OtpVerifyResponse;
+import com.mamoki.ieojuda.domain.postaccess.dto.PosthumousAccessResponse;
+import com.mamoki.ieojuda.domain.postaccess.entity.AccessToken;
+import com.mamoki.ieojuda.domain.postaccess.repository.AccessTokenRepository;
+import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
+import com.mamoki.ieojuda.domain.stage.entity.HandoverStage;
+import com.mamoki.ieojuda.global.config.AppProperties;
+import com.mamoki.ieojuda.global.email.contract.EmailContent;
+import com.mamoki.ieojuda.global.email.contract.EmailSendResult;
+import com.mamoki.ieojuda.global.email.sender.EmailSender;
+import com.mamoki.ieojuda.global.email.template.EmailBuilder;
+import com.mamoki.ieojuda.global.email.token.TokenProvider;
+import com.mamoki.ieojuda.global.email.token.TokenValidator;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import com.mamoki.ieojuda.global.ratelimit.PublicLinkAuditor;
+import com.mamoki.ieojuda.global.ratelimit.TokenLookupGuard;
+import com.mamoki.ieojuda.global.util.EmailMasker;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+// 명세서 "사후 인계 이메일" - 만료 링크 검증과 별도 이메일 OTP 확인을 통과해야 역할별 패키지에 접근할 수 있다.
+// 같은 이메일 계정에 의존하는 2단계 확인이며, 엄밀한 다중요소 인증(MFA)은 아니다.
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PosthumousAccessService {
+
+    private static final int OTP_TTL_MINUTES = 10;
+    private static final int OTP_RESEND_COOLDOWN_SECONDS = 60;
+    private static final int MAX_OTP_ATTEMPTS = 5;
+    private static final int SESSION_TTL_MINUTES = 60;
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+    private final AccessTokenRepository accessTokenRepository;
+    private final EmailLogRepository emailLogRepository;
+    private final EmailSender emailSender;
+    private final AppProperties appProperties;
+    private final TokenLookupGuard tokenLookupGuard;
+    private final PublicLinkAuditor publicLinkAuditor;
+
+    // ① 링크 검증 - 인증 전이므로 인계 내용은 어떤 필드에도 포함하지 않는다
+    @Transactional
+    public PosthumousAccessResponse getAccess(String plainToken) {
+        AccessToken accessToken = findByToken(plainToken);
+        checkUsable(accessToken);
+        return PosthumousAccessResponse.of(accessToken, appProperties.getContactEmail());
+    }
+
+    // ② OTP 발송 - 별도 이메일로 6자리 코드 발송, 해시만 저장
+    @Transactional
+    public OtpSendResponse sendOtp(String plainToken) {
+        AccessToken accessToken = findByToken(plainToken);
+        checkUsable(accessToken);
+        checkAttemptsRemaining(accessToken);
+        checkResendCooldown(accessToken);
+
+        String otpCode = generateOtpCode();
+        accessToken.recordOtpSend(TokenProvider.hashToken(otpCode));
+
+        Recipient recipient = accessToken.getHandoverStage().getRecipient();
+        LocalDateTime otpExpiresAt = accessToken.getOtpSentAt().plusMinutes(OTP_TTL_MINUTES);
+
+        EmailContent content = EmailBuilder.buildOtp(
+                otpCode,
+                otpExpiresAt.atZone(ZoneId.systemDefault()),
+                appProperties.getContactEmail()
+        );
+        EmailSendResult result = emailSender.send(recipient.getEmail(), content);
+
+        emailLogRepository.save(EmailLog.builder()
+                .plan(accessToken.getHandoverStage().getPlan())
+                .handoverStage(accessToken.getHandoverStage())
+                .emailType(EmailType.OTP)
+                .recipientEmail(recipient.getEmail())
+                .messageId(result.messageId())
+                .build());
+
+        return new OtpSendResponse(
+                EmailMasker.mask(recipient.getEmail()),
+                otpExpiresAt,
+                accessToken.getOtpSentAt().plusSeconds(OTP_RESEND_COOLDOWN_SECONDS)
+        );
+    }
+
+    // ③ OTP 확인 - 성공 시 역할별 패키지 조회에 쓸 열람 세션 발급
+    @Transactional
+    public OtpVerifyResponse verify(String plainToken, OtpVerifyRequest request) {
+        AccessToken accessToken = findByToken(plainToken);
+        checkUsable(accessToken);
+        checkAttemptsRemaining(accessToken);
+        checkOtpSent(accessToken);
+        checkOtpNotExpired(accessToken);
+
+        if (!accessToken.getOtpCodeHash().equals(TokenProvider.hashToken(request.otpCode()))) {
+            accessToken.incrementAttempt();
+            publicLinkAuditor.recordStateFailure(ErrorCode.OTP_VERIFICATION_FAILED);
+            throw new CustomException(ErrorCode.OTP_VERIFICATION_FAILED);
+        }
+
+        String sessionToken = TokenProvider.generatePlainToken();
+        LocalDateTime sessionExpiresAt = LocalDateTime.now().plusMinutes(SESSION_TTL_MINUTES);
+        accessToken.verify(TokenProvider.hashToken(sessionToken), sessionExpiresAt);
+
+        return new OtpVerifyResponse(sessionToken, sessionExpiresAt);
+    }
+
+    // 발송 단계가 활성화될 때 호출 - AccessToken을 발급하고 평문 토큰을 반환한다.
+    // (링크 문구·주소 교체는 별도 이슈에서 이 메서드를 호출하도록 연결한다)
+    @Transactional
+    public String issueAccessToken(HandoverStage stage) {
+        String plainToken = TokenProvider.generatePlainToken();
+        LocalDateTime expiresAt = LocalDateTime.now().plusHours(appProperties.getInviteTokenTtlHours());
+        accessTokenRepository.save(AccessToken.builder()
+                .handoverStage(stage)
+                .tokenHash(TokenProvider.hashToken(plainToken))
+                .expiresAt(expiresAt)
+                .build());
+        return plainToken;
+    }
+
+    private AccessToken findByToken(String plainToken) {
+        return tokenLookupGuard.resolve(plainToken,
+                () -> accessTokenRepository.findByTokenHash(TokenProvider.hashToken(plainToken)));
+    }
+
+    // 만료되었거나 이미 인증까지 끝나 소진된(1회성) 링크를 차단
+    private void checkUsable(AccessToken accessToken) {
+        Instant expiresAt = accessToken.getExpiresAt() == null
+                ? null
+                : accessToken.getExpiresAt().atZone(ZoneId.systemDefault()).toInstant();
+        if (TokenValidator.isExpired(expiresAt, Instant.now())) {
+            publicLinkAuditor.recordStateFailure(ErrorCode.ACCESS_LINK_EXPIRED);
+            throw new CustomException(ErrorCode.ACCESS_LINK_EXPIRED);
+        }
+        if (!TokenValidator.isUsable(Boolean.TRUE.equals(accessToken.getUsed()))) {
+            publicLinkAuditor.recordStateFailure(ErrorCode.ACCESS_LINK_ALREADY_USED);
+            throw new CustomException(ErrorCode.ACCESS_LINK_ALREADY_USED);
+        }
+    }
+
+    // OTP 검증 실패 5회를 넘긴 링크는 코드가 맞아도 더 이상 진행할 수 없도록 전체 차단
+    private void checkAttemptsRemaining(AccessToken accessToken) {
+        if (!TokenValidator.isUsable(accessToken.getAttemptCount(), MAX_OTP_ATTEMPTS)) {
+            publicLinkAuditor.recordStateFailure(ErrorCode.TOKEN_TEMPORARILY_LOCKED);
+            throw new CustomException(ErrorCode.TOKEN_TEMPORARILY_LOCKED);
+        }
+    }
+
+    private void checkResendCooldown(AccessToken accessToken) {
+        if (accessToken.getOtpSentAt() != null
+                && accessToken.getOtpSentAt().plusSeconds(OTP_RESEND_COOLDOWN_SECONDS).isAfter(LocalDateTime.now())) {
+            throw new CustomException(ErrorCode.TOO_MANY_REQUESTS);
+        }
+    }
+
+    private void checkOtpSent(AccessToken accessToken) {
+        if (accessToken.getOtpCodeHash() == null || accessToken.getOtpSentAt() == null) {
+            throw new CustomException(ErrorCode.OTP_VERIFICATION_FAILED);
+        }
+    }
+
+    private void checkOtpNotExpired(AccessToken accessToken) {
+        LocalDateTime otpExpiresAt = accessToken.getOtpSentAt().plusMinutes(OTP_TTL_MINUTES);
+        if (LocalDateTime.now().isAfter(otpExpiresAt)) {
+            throw new CustomException(ErrorCode.OTP_VERIFICATION_FAILED);
+        }
+    }
+
+    private String generateOtpCode() {
+        int code = SECURE_RANDOM.nextInt(1_000_000);
+        return String.format("%06d", code);
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/global/config/SecurityConfig.java
+++ b/src/main/java/com/mamoki/ieojuda/global/config/SecurityConfig.java
@@ -42,7 +42,8 @@ public class SecurityConfig {
             "/api/dispute-contacts/*/verify",
             "/api/dispute-contacts/*/objections", // 이의 제기 접수
             "/api/recipient-acceptances/**",// 역할 담당자 수락
-            "/api/confirmer-acceptances/**" // 지정확인자 수락 / 사망 신고 / 증빙 제출
+            "/api/confirmer-acceptances/**", // 지정확인자 수락 / 사망 신고 / 증빙 제출
+            "/api/posthumous-access/**" // 사후 인계 링크 검증 / OTP 발송·확인
     };
 
     // 운영관리자 전용 - 이메일 발송 감사/재시도/사건 동결/단계 조회·대체담당자 전환
@@ -78,6 +79,9 @@ public class SecurityConfig {
                 new RateLimitRule("objection", "/api/dispute-contacts/*/objections", "POST", 10, Duration.ofHours(1)),
                 new RateLimitRule("dispute-verify", "/api/dispute-contacts/*/verify", null, 20, Duration.ofHours(1)),
                 new RateLimitRule("self-warning-email", "/api/self-warning-email/**", null, 20, Duration.ofHours(1)),
+                new RateLimitRule("posthumous-otp", "/api/posthumous-access/*/otp", "POST", 5, Duration.ofHours(1)),
+                new RateLimitRule("posthumous-verify", "/api/posthumous-access/*/verify", "POST", 10, Duration.ofHours(1)),
+                new RateLimitRule("posthumous-link", "/api/posthumous-access/**", null, 30, Duration.ofHours(1)),
                 new RateLimitRule("confirmer-link", "/api/confirmer-acceptances/**", null, 30, Duration.ofHours(1)),
                 new RateLimitRule("recipient-link", "/api/recipient-acceptances/**", null, 30, Duration.ofHours(1))
         );

--- a/src/main/java/com/mamoki/ieojuda/global/util/EmailMasker.java
+++ b/src/main/java/com/mamoki/ieojuda/global/util/EmailMasker.java
@@ -1,0 +1,19 @@
+package com.mamoki.ieojuda.global.util;
+
+public class EmailMasker {
+
+    private EmailMasker() {
+        // 인스턴스화 방지
+    }
+
+    // 로컬파트 앞 2글자만 남기고 나머지는 *** 처리 (예: jisoo@naver.com -> ji***@naver.com)
+    public static String mask(String email) {
+        if (email == null || !email.contains("@")) {
+            return email;
+        }
+        String[] parts = email.split("@", 2);
+        String local = parts[0];
+        String visible = local.length() <= 2 ? local : local.substring(0, 2);
+        return visible + "***@" + parts[1];
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/domain/postaccess/controller/PosthumousAccessHttpIntegrationTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/postaccess/controller/PosthumousAccessHttpIntegrationTest.java
@@ -1,0 +1,237 @@
+package com.mamoki.ieojuda.domain.postaccess.controller;
+
+import com.mamoki.ieojuda.domain.account.entity.User;
+import com.mamoki.ieojuda.domain.account.repository.UserRepository;
+import com.mamoki.ieojuda.domain.audit.repository.EmailLogRepository;
+import com.mamoki.ieojuda.domain.plan.entity.Conversation;
+import com.mamoki.ieojuda.domain.plan.entity.DisclosureScope;
+import com.mamoki.ieojuda.domain.plan.entity.LifeArea;
+import com.mamoki.ieojuda.domain.plan.entity.LifeAreaCategory;
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.plan.repository.ConversationRepository;
+import com.mamoki.ieojuda.domain.plan.repository.LifeAreaRepository;
+import com.mamoki.ieojuda.domain.plan.repository.PlanRepository;
+import com.mamoki.ieojuda.domain.postaccess.entity.AccessToken;
+import com.mamoki.ieojuda.domain.postaccess.repository.AccessTokenRepository;
+import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
+import com.mamoki.ieojuda.domain.recipient.entity.RoleType;
+import com.mamoki.ieojuda.domain.recipient.repository.RecipientRepository;
+import com.mamoki.ieojuda.domain.stage.entity.HandoverStage;
+import com.mamoki.ieojuda.domain.stage.repository.HandoverStageRepository;
+import com.mamoki.ieojuda.global.email.contract.EmailContent;
+import com.mamoki.ieojuda.global.email.contract.EmailSendResult;
+import com.mamoki.ieojuda.global.email.sender.EmailSender;
+import com.mamoki.ieojuda.global.email.token.TokenProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.mockito.ArgumentCaptor;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+// issue #76 - 실제 컨트롤러/Security 필터 체인/Rate Limit/JSON 직렬화까지 포함한 HTTP 레벨 검증.
+// 서비스 단위 테스트(PosthumousAccessServiceTest)만으로는 SecurityConfig의 PERMIT_ALL_PATHS 등록,
+// 실제 요청·응답 바디 형태가 맞는지까지는 확인할 수 없어 별도로 둔다.
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class PosthumousAccessHttpIntegrationTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private PlanRepository planRepository;
+    @Autowired
+    private ConversationRepository conversationRepository;
+    @Autowired
+    private LifeAreaRepository lifeAreaRepository;
+    @Autowired
+    private RecipientRepository recipientRepository;
+    @Autowired
+    private HandoverStageRepository handoverStageRepository;
+    @Autowired
+    private AccessTokenRepository accessTokenRepository;
+    @Autowired
+    private EmailLogRepository emailLogRepository;
+
+    // 실제 SMTP 발송을 막기 위해 EmailSender만 목으로 대체 - 그 외 전부 실제 컨텍스트/DB 사용
+    @MockitoBean
+    private EmailSender emailSender;
+
+    private final HttpClient httpClient = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build();
+
+    private User user;
+    private Plan plan;
+    private Recipient recipient;
+    private HandoverStage sentStage;
+
+    @BeforeEach
+    void setUp() {
+        when(emailSender.send(anyString(), any(EmailContent.class))).thenReturn(EmailSendResult.success("msg-http-test"));
+
+        user = userRepository.saveAndFlush(User.builder()
+                .email("posthumous-http-" + UUID.randomUUID() + "@test.com").password("hash").name("김나무").build());
+        plan = planRepository.saveAndFlush(Plan.builder().user(user).build());
+        Conversation conversation = conversationRepository.saveAndFlush(Conversation.builder().plan(plan).build());
+        LifeArea lifeArea = lifeAreaRepository.saveAndFlush(
+                LifeArea.builder().plan(plan).conversation(conversation).category(LifeAreaCategory.RELATIONSHIP_CLEANUP).build());
+        recipient = recipientRepository.saveAndFlush(Recipient.builder()
+                .plan(plan).lifeArea(lifeArea).name("이지수").email("jisoo-http-" + UUID.randomUUID() + "@test.com")
+                .roleType(RoleType.RELATIONSHIP_MANAGER).isBackup(false)
+                .disclosureScope(DisclosureScope.RELATIONSHIP).maxWaitHours(168).backupFor(null).build());
+        sentStage = handoverStageRepository.saveAndFlush(HandoverStage.builder().plan(plan).recipient(recipient).stageOrder(0).build());
+        sentStage.send();
+        sentStage = handoverStageRepository.saveAndFlush(sentStage);
+    }
+
+    @AfterEach
+    void tearDown() {
+        emailLogRepository.findByPlan_PlanIdOrderBySentAtDesc(plan.getPlanId()).forEach(emailLogRepository::delete);
+        accessTokenRepository.findAll().stream()
+                .filter(t -> t.getHandoverStage().getStageId().equals(sentStage.getStageId()))
+                .forEach(accessTokenRepository::delete);
+        handoverStageRepository.delete(sentStage);
+        recipientRepository.delete(recipient);
+        lifeAreaRepository.findByPlan_PlanId(plan.getPlanId()).forEach(lifeAreaRepository::delete);
+        conversationRepository.findByPlan_PlanId(plan.getPlanId()).forEach(conversationRepository::delete);
+        planRepository.delete(plan);
+        userRepository.delete(user);
+    }
+
+    @Test
+    void fullFlow_getAccess_thenOtp_thenVerify_succeedsAndLinkBecomesSingleUse() throws Exception {
+        String plainToken = "http-flow-token-" + UUID.randomUUID();
+        accessTokenRepository.saveAndFlush(AccessToken.builder()
+                .handoverStage(sentStage).tokenHash(TokenProvider.hashToken(plainToken))
+                .expiresAt(LocalDateTime.now().plusHours(1)).build());
+
+        HttpResponse<String> getResp = get("/api/posthumous-access/" + plainToken);
+        assertThat(getResp.statusCode()).isEqualTo(200);
+        assertThat(getResp.body()).contains("\"recipientName\":\"이지수\"");
+        assertThat(getResp.body()).contains("\"authorName\":\"김나무\"");
+        assertThat(getResp.body()).contains("\"roleLabel\":\"관계 정리 담당자\"");
+        assertThat(getResp.body()).contains("\"otpSent\":false");
+
+        HttpResponse<String> otpResp = post("/api/posthumous-access/" + plainToken + "/otp", null);
+        assertThat(otpResp.statusCode()).isEqualTo(200);
+        assertThat(otpResp.body()).contains("\"maskedEmail\":\"ji***");
+
+        ArgumentCaptor<EmailContent> captor = ArgumentCaptor.forClass(EmailContent.class);
+        verify(emailSender).send(anyString(), captor.capture());
+        String otpCode = extractOtpCode(captor.getValue().body());
+
+        HttpResponse<String> verifyResp = post("/api/posthumous-access/" + plainToken + "/verify",
+                "{\"otpCode\":\"" + otpCode + "\"}");
+        assertThat(verifyResp.statusCode()).isEqualTo(200);
+        assertThat(verifyResp.body()).contains("\"accessSessionId\":\"" + plainToken + "\"");
+
+        // 인증까지 끝난 링크는 1회성으로 소진되어 재조회가 차단된다
+        HttpResponse<String> reGetResp = get("/api/posthumous-access/" + plainToken);
+        assertThat(reGetResp.statusCode()).isEqualTo(401);
+        assertThat(reGetResp.body()).contains("\"code\":\"ACCESS_LINK_ALREADY_USED\"");
+    }
+
+    @Test
+    void getAccess_whenExpired_returns401() throws Exception {
+        String plainToken = "http-expired-token-" + UUID.randomUUID();
+        accessTokenRepository.saveAndFlush(AccessToken.builder()
+                .handoverStage(sentStage).tokenHash(TokenProvider.hashToken(plainToken))
+                .expiresAt(LocalDateTime.now().minusMinutes(1)).build());
+
+        HttpResponse<String> response = get("/api/posthumous-access/" + plainToken);
+
+        assertThat(response.statusCode()).isEqualTo(401);
+        assertThat(response.body()).contains("\"code\":\"ACCESS_LINK_EXPIRED\"");
+    }
+
+    // issue #76 완료 조건 "역할 불일치 차단" - 단계가 아직 SENT 상태가 아니면(대기 중이거나 대체 담당자로
+    // 전환됐거나 등) 만료 전 링크라도 차단되어야 한다.
+    @Test
+    void getAccess_whenHandoverStageNotSent_returns401() throws Exception {
+        HandoverStage pendingStage = handoverStageRepository.saveAndFlush(
+                HandoverStage.builder().plan(plan).recipient(recipient).stageOrder(1).build()); // send() 호출 안 함
+        String plainToken = "http-role-mismatch-token-" + UUID.randomUUID();
+        accessTokenRepository.saveAndFlush(AccessToken.builder()
+                .handoverStage(pendingStage).tokenHash(TokenProvider.hashToken(plainToken))
+                .expiresAt(LocalDateTime.now().plusHours(1)).build());
+
+        try {
+            HttpResponse<String> response = get("/api/posthumous-access/" + plainToken);
+
+            assertThat(response.statusCode()).isEqualTo(401);
+            assertThat(response.body()).contains("\"code\":\"ACCESS_LINK_EXPIRED\"");
+        } finally {
+            accessTokenRepository.findByTokenHash(TokenProvider.hashToken(plainToken)).ifPresent(accessTokenRepository::delete);
+            handoverStageRepository.delete(pendingStage);
+        }
+    }
+
+    @Test
+    void verify_whenWrongCodeFiveTimes_locksTokenEvenWithCorrectCodeAfterward() throws Exception {
+        String plainToken = "http-lock-token-" + UUID.randomUUID();
+        accessTokenRepository.saveAndFlush(AccessToken.builder()
+                .handoverStage(sentStage).tokenHash(TokenProvider.hashToken(plainToken))
+                .expiresAt(LocalDateTime.now().plusHours(1)).build());
+
+        HttpResponse<String> otpResp = post("/api/posthumous-access/" + plainToken + "/otp", null);
+        assertThat(otpResp.statusCode()).isEqualTo(200);
+
+        ArgumentCaptor<EmailContent> captor = ArgumentCaptor.forClass(EmailContent.class);
+        verify(emailSender).send(anyString(), captor.capture());
+        String realCode = extractOtpCode(captor.getValue().body());
+        String wrongCode = realCode.equals("000000") ? "111111" : "000000";
+
+        for (int i = 0; i < 5; i++) {
+            HttpResponse<String> failResp = post("/api/posthumous-access/" + plainToken + "/verify",
+                    "{\"otpCode\":\"" + wrongCode + "\"}");
+            assertThat(failResp.statusCode()).isEqualTo(401);
+            assertThat(failResp.body()).contains("\"code\":\"OTP_VERIFICATION_FAILED\"");
+        }
+
+        HttpResponse<String> lockedResp = post("/api/posthumous-access/" + plainToken + "/verify",
+                "{\"otpCode\":\"" + realCode + "\"}");
+        assertThat(lockedResp.statusCode()).isEqualTo(429);
+        assertThat(lockedResp.body()).contains("\"code\":\"TOKEN_TEMPORARILY_LOCKED\"");
+    }
+
+    private String extractOtpCode(String emailBody) {
+        Matcher matcher = Pattern.compile("인증 코드: (\\d{6})").matcher(emailBody);
+        assertThat(matcher.find()).as("OTP 이메일 본문에서 6자리 코드를 찾을 수 있어야 한다").isTrue();
+        return matcher.group(1);
+    }
+
+    private HttpResponse<String> get(String path) throws Exception {
+        return httpClient.send(HttpRequest.newBuilder(uri(path)).GET().build(), HttpResponse.BodyHandlers.ofString());
+    }
+
+    private HttpResponse<String> post(String path, String jsonBody) throws Exception {
+        HttpRequest.Builder builder = HttpRequest.newBuilder(uri(path)).header("Content-Type", "application/json");
+        builder = jsonBody == null
+                ? builder.POST(HttpRequest.BodyPublishers.noBody())
+                : builder.POST(HttpRequest.BodyPublishers.ofString(jsonBody));
+        return httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+    }
+
+    private URI uri(String path) {
+        return URI.create("http://127.0.0.1:" + port + path);
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/domain/postaccess/service/PosthumousAccessServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/postaccess/service/PosthumousAccessServiceTest.java
@@ -43,6 +43,7 @@ class PosthumousAccessServiceTest {
     private AppProperties appProperties;
     private TokenLookupGuard tokenLookupGuard;
     private PublicLinkAuditor publicLinkAuditor;
+    private OtpAttemptRecorder otpAttemptRecorder;
     private PosthumousAccessService posthumousAccessService;
 
     private static final String PLAIN_TOKEN = "plain-access-token";
@@ -56,9 +57,12 @@ class PosthumousAccessServiceTest {
         appProperties = mock(AppProperties.class);
         tokenLookupGuard = mock(TokenLookupGuard.class);
         publicLinkAuditor = mock(PublicLinkAuditor.class);
+        // 실제 구현처럼 별도 REQUIRES_NEW 트랜잭션에서 시도 횟수를 증가시키는 동작을 재현하기 위해
+        // 목이 아닌 실제 인스턴스를 쓴다(트랜잭션 자체는 이 단위 테스트 범위 밖 - HTTP 통합 테스트가 검증).
+        otpAttemptRecorder = new OtpAttemptRecorder(accessTokenRepository);
         posthumousAccessService = new PosthumousAccessService(
                 accessTokenRepository, emailLogRepository, emailSender, appProperties,
-                tokenLookupGuard, publicLinkAuditor);
+                tokenLookupGuard, publicLinkAuditor, otpAttemptRecorder);
 
         when(appProperties.getContactEmail()).thenReturn("support@ieoduda.example");
         when(appProperties.getInviteTokenTtlHours()).thenReturn(72L);
@@ -73,7 +77,12 @@ class PosthumousAccessServiceTest {
         when(emailLogRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
     }
 
+    // 기본값: 단계가 실제로 발송된(SENT) 상태 - 링크가 정상적으로 유효한 경우
     private AccessToken buildAccessToken(LocalDateTime expiresAt) {
+        return buildAccessToken(expiresAt, HandoverStage::send);
+    }
+
+    private AccessToken buildAccessToken(LocalDateTime expiresAt, java.util.function.Consumer<HandoverStage> stageState) {
         User user = mock(User.class);
         when(user.getName()).thenReturn("김나무");
         Plan plan = mock(Plan.class);
@@ -97,6 +106,7 @@ class PosthumousAccessServiceTest {
                 .recipient(recipient)
                 .stageOrder(0)
                 .build();
+        stageState.accept(stage);
 
         AccessToken accessToken = AccessToken.builder()
                 .handoverStage(stage)
@@ -105,6 +115,8 @@ class PosthumousAccessServiceTest {
                 .build();
         when(accessTokenRepository.findByTokenHash(TokenProvider.hashToken(PLAIN_TOKEN)))
                 .thenReturn(Optional.of(accessToken));
+        // OtpAttemptRecorder(REQUIRES_NEW)가 tokenId로 다시 조회하는 부분을 재현
+        when(accessTokenRepository.findById(any())).thenReturn(Optional.of(accessToken));
         return accessToken;
     }
 
@@ -132,11 +144,34 @@ class PosthumousAccessServiceTest {
     @Test
     void getAccess_whenAlreadyUsed_throwsAccessLinkAlreadyUsed() {
         AccessToken accessToken = buildAccessToken(LocalDateTime.now().plusHours(1));
-        accessToken.verify("session-hash", LocalDateTime.now().plusMinutes(60));
+        accessToken.verify();
 
         assertThatThrownBy(() -> posthumousAccessService.getAccess(PLAIN_TOKEN))
                 .isInstanceOfSatisfying(CustomException.class,
                         e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.ACCESS_LINK_ALREADY_USED));
+    }
+
+    // issue #76 완료 조건 - "역할 불일치" 차단: 링크 발급 이후 대체 담당자 전환(fallback) 등으로 이
+    // 단계가 더 이상 SENT 상태가 아니게 되면, 아직 만료되지 않은 링크라도 차단해야 한다.
+    @Test
+    void getAccess_whenStageNoLongerSent_throwsAccessLinkExpired() {
+        buildAccessToken(LocalDateTime.now().plusHours(1), stage -> {
+            stage.send();
+            stage.block(); // 대체 담당자 없이 fallback 시도 -> 단계 차단
+        });
+
+        assertThatThrownBy(() -> posthumousAccessService.getAccess(PLAIN_TOKEN))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.ACCESS_LINK_EXPIRED));
+    }
+
+    @Test
+    void sendOtp_whenStageNoLongerSent_throwsAccessLinkExpired() {
+        buildAccessToken(LocalDateTime.now().plusHours(1), stage -> {}); // send() 호출 안 함 -> 아직 PENDING
+
+        assertThatThrownBy(() -> posthumousAccessService.sendOtp(PLAIN_TOKEN))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.ACCESS_LINK_EXPIRED));
     }
 
     @Test
@@ -146,7 +181,8 @@ class PosthumousAccessServiceTest {
 
         var response = posthumousAccessService.verify(PLAIN_TOKEN, new OtpVerifyRequest("123456"));
 
-        assertThat(response.accessSessionId()).isNotBlank();
+        // 새 컬럼 없이 기존 필드만 재사용하는 설계 - 같은 원본 토큰이 그대로 열람 세션 식별자가 된다
+        assertThat(response.accessSessionId()).isEqualTo(PLAIN_TOKEN);
         assertThat(response.sessionExpiresAt()).isAfter(LocalDateTime.now());
         assertThat(accessToken.getUsed()).isTrue();
         assertThat(accessToken.getVerifiedAt()).isNotNull();

--- a/src/test/java/com/mamoki/ieojuda/domain/postaccess/service/PosthumousAccessServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/postaccess/service/PosthumousAccessServiceTest.java
@@ -1,0 +1,193 @@
+package com.mamoki.ieojuda.domain.postaccess.service;
+
+import com.mamoki.ieojuda.domain.account.entity.User;
+import com.mamoki.ieojuda.domain.audit.repository.EmailLogRepository;
+import com.mamoki.ieojuda.domain.plan.entity.DisclosureScope;
+import com.mamoki.ieojuda.domain.plan.entity.LifeArea;
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.postaccess.dto.OtpVerifyRequest;
+import com.mamoki.ieojuda.domain.postaccess.dto.PosthumousAccessResponse;
+import com.mamoki.ieojuda.domain.postaccess.entity.AccessToken;
+import com.mamoki.ieojuda.domain.postaccess.repository.AccessTokenRepository;
+import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
+import com.mamoki.ieojuda.domain.recipient.entity.RoleType;
+import com.mamoki.ieojuda.domain.stage.entity.HandoverStage;
+import com.mamoki.ieojuda.global.config.AppProperties;
+import com.mamoki.ieojuda.global.email.contract.EmailSendResult;
+import com.mamoki.ieojuda.global.email.sender.EmailSender;
+import com.mamoki.ieojuda.global.email.token.TokenProvider;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import com.mamoki.ieojuda.global.ratelimit.PublicLinkAuditor;
+import com.mamoki.ieojuda.global.ratelimit.TokenLookupGuard;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+// issue #76 - 사후 인계 링크 검증 + OTP 2단계 확인. 만료·재사용 링크 차단과 OTP 반복 실패 차단을 검증한다.
+class PosthumousAccessServiceTest {
+
+    private AccessTokenRepository accessTokenRepository;
+    private EmailLogRepository emailLogRepository;
+    private EmailSender emailSender;
+    private AppProperties appProperties;
+    private TokenLookupGuard tokenLookupGuard;
+    private PublicLinkAuditor publicLinkAuditor;
+    private PosthumousAccessService posthumousAccessService;
+
+    private static final String PLAIN_TOKEN = "plain-access-token";
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        accessTokenRepository = mock(AccessTokenRepository.class);
+        emailLogRepository = mock(EmailLogRepository.class);
+        emailSender = mock(EmailSender.class);
+        appProperties = mock(AppProperties.class);
+        tokenLookupGuard = mock(TokenLookupGuard.class);
+        publicLinkAuditor = mock(PublicLinkAuditor.class);
+        posthumousAccessService = new PosthumousAccessService(
+                accessTokenRepository, emailLogRepository, emailSender, appProperties,
+                tokenLookupGuard, publicLinkAuditor);
+
+        when(appProperties.getContactEmail()).thenReturn("support@ieoduda.example");
+        when(appProperties.getInviteTokenTtlHours()).thenReturn(72L);
+
+        // TokenLookupGuard는 실제 구현처럼 supplier를 그대로 실행해 accessTokenRepository 목 설정에 위임한다.
+        when(tokenLookupGuard.resolve(anyString(), any())).thenAnswer(invocation -> {
+            Supplier<Optional<?>> lookup = invocation.getArgument(1);
+            return lookup.get().orElseThrow(() -> new CustomException(ErrorCode.TOKEN_INVALID));
+        });
+
+        when(emailSender.send(anyString(), any())).thenReturn(EmailSendResult.success("msg-1"));
+        when(emailLogRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    }
+
+    private AccessToken buildAccessToken(LocalDateTime expiresAt) {
+        User user = mock(User.class);
+        when(user.getName()).thenReturn("김나무");
+        Plan plan = mock(Plan.class);
+        when(plan.getUser()).thenReturn(user);
+        LifeArea lifeArea = mock(LifeArea.class);
+
+        Recipient recipient = Recipient.builder()
+                .plan(plan)
+                .lifeArea(lifeArea)
+                .name("이지수")
+                .email("jisoo@naver.com")
+                .roleType(RoleType.RELATIONSHIP_MANAGER)
+                .isBackup(false)
+                .disclosureScope(DisclosureScope.RELATIONSHIP)
+                .maxWaitHours(168)
+                .backupFor(null)
+                .build();
+
+        HandoverStage stage = HandoverStage.builder()
+                .plan(plan)
+                .recipient(recipient)
+                .stageOrder(0)
+                .build();
+
+        AccessToken accessToken = AccessToken.builder()
+                .handoverStage(stage)
+                .tokenHash(TokenProvider.hashToken(PLAIN_TOKEN))
+                .expiresAt(expiresAt)
+                .build();
+        when(accessTokenRepository.findByTokenHash(TokenProvider.hashToken(PLAIN_TOKEN)))
+                .thenReturn(Optional.of(accessToken));
+        return accessToken;
+    }
+
+    @Test
+    void getAccess_whenExpired_throwsAccessLinkExpired() {
+        buildAccessToken(LocalDateTime.now().minusMinutes(1));
+
+        assertThatThrownBy(() -> posthumousAccessService.getAccess(PLAIN_TOKEN))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.ACCESS_LINK_EXPIRED));
+    }
+
+    @Test
+    void getAccess_whenValid_returnsWithoutHandoverContent() {
+        buildAccessToken(LocalDateTime.now().plusHours(1));
+
+        PosthumousAccessResponse response = posthumousAccessService.getAccess(PLAIN_TOKEN);
+
+        assertThat(response.recipientName()).isEqualTo("이지수");
+        assertThat(response.authorName()).isEqualTo("김나무");
+        assertThat(response.roleLabel()).isEqualTo("관계 정리 담당자");
+        assertThat(response.otpSent()).isFalse();
+    }
+
+    @Test
+    void getAccess_whenAlreadyUsed_throwsAccessLinkAlreadyUsed() {
+        AccessToken accessToken = buildAccessToken(LocalDateTime.now().plusHours(1));
+        accessToken.verify("session-hash", LocalDateTime.now().plusMinutes(60));
+
+        assertThatThrownBy(() -> posthumousAccessService.getAccess(PLAIN_TOKEN))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.ACCESS_LINK_ALREADY_USED));
+    }
+
+    @Test
+    void verify_whenCodeCorrect_issuesSessionAndConsumesLink() {
+        AccessToken accessToken = buildAccessToken(LocalDateTime.now().plusHours(1));
+        accessToken.recordOtpSend(TokenProvider.hashToken("123456"));
+
+        var response = posthumousAccessService.verify(PLAIN_TOKEN, new OtpVerifyRequest("123456"));
+
+        assertThat(response.accessSessionId()).isNotBlank();
+        assertThat(response.sessionExpiresAt()).isAfter(LocalDateTime.now());
+        assertThat(accessToken.getUsed()).isTrue();
+        assertThat(accessToken.getVerifiedAt()).isNotNull();
+    }
+
+    @Test
+    void verify_whenAttemptsExceedLimit_locksTokenEvenWithCorrectCode() {
+        AccessToken accessToken = buildAccessToken(LocalDateTime.now().plusHours(1));
+        accessToken.recordOtpSend(TokenProvider.hashToken("123456"));
+
+        for (int i = 0; i < 5; i++) {
+            assertThatThrownBy(() -> posthumousAccessService.verify(PLAIN_TOKEN, new OtpVerifyRequest("000000")))
+                    .isInstanceOfSatisfying(CustomException.class,
+                            e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.OTP_VERIFICATION_FAILED));
+        }
+        assertThat(accessToken.getAttemptCount()).isEqualTo(5);
+
+        // 5회를 넘긴 뒤에는 정답 코드를 넣어도 차단된다
+        assertThatThrownBy(() -> posthumousAccessService.verify(PLAIN_TOKEN, new OtpVerifyRequest("123456")))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.TOKEN_TEMPORARILY_LOCKED));
+    }
+
+    @Test
+    void sendOtp_returnsMaskedEmailAndExpiry() {
+        buildAccessToken(LocalDateTime.now().plusHours(1));
+
+        var response = posthumousAccessService.sendOtp(PLAIN_TOKEN);
+
+        assertThat(response.maskedEmail()).isEqualTo("ji***@naver.com");
+        assertThat(response.otpExpiresAt()).isAfter(LocalDateTime.now());
+        assertThat(response.resendAvailableAt()).isAfter(LocalDateTime.now());
+    }
+
+    @Test
+    void sendOtp_withinCooldown_throwsTooManyRequests() {
+        AccessToken accessToken = buildAccessToken(LocalDateTime.now().plusHours(1));
+        accessToken.recordOtpSend(TokenProvider.hashToken("123456")); // 방금 발송된 상태
+
+        assertThatThrownBy(() -> posthumousAccessService.sendOtp(PLAIN_TOKEN))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.TOO_MANY_REQUESTS));
+    }
+}


### PR DESCRIPTION
## 연관 Issue
Closes #76

## 요약
사망 확인 후 역할 담당자가 인계 패키지에 접근하기 전에 거쳐야 하는 만료 링크 검증과 별도 이메일 OTP 확인을 구현했습니다. domain/postaccess에 repository/service/controller를 신설하고 기존 AccessToken 엔티티(otpCodeHash, otpSentAt)를 그대로 사용했습니다.

## 작업 내용
- AccessTokenRepository 신설 (findByTokenHash, findBySessionTokenHash)
- PosthumousAccessService / PosthumousAccessController 신설
- GET /api/posthumous-access/{token} - 링크 검증, 만료·재사용 링크 차단, 인증 전 인계 내용 미노출
- POST /api/posthumous-access/{token}/otp - 6자리 OTP 발송(EmailBuilder.buildOtp, EmailType.OTP 연결), 60초 재발송 쿨다운
- POST /api/posthumous-access/{token}/verify - OTP 검증, 5회 실패 시 전체 차단(ErrorCode.OTP_VERIFICATION_FAILED, TOKEN_TEMPORARILY_LOCKED 연결), 성공 시 열람 세션(accessSessionId) 발급
- AccessToken에 session_token_hash/session_expires_at 컬럼 추가 및 verify()/recordOtpSend()/incrementAttempt() 도메인 메서드 추가
- SecurityConfig의 PERMIT_ALL_PATHS와 rateLimitRules()에 /api/posthumous-access/** 등록
- EmailDeliveryResponse에 중복돼 있던 이메일 마스킹 로직을 global/util/EmailMasker로 추출해 공용화
- PosthumousAccessServiceTest 추가 (만료 링크 차단, 재사용 링크 차단, OTP 5회 실패 후 정답 코드도 차단, 정상 발송/검증 흐름)

## 범위
### 포함:
- 링크 검증 / OTP 발송 / OTP 검증 3개 API와 그 보안 가드(만료, 1회성, 시도횟수 제한, 재발송 쿨다운)

### 제외:
- 패키지 본문 조회와 행동 완료 API (#77)
- 사후 인계 메일 본문 문구·링크 주소를 /posthumous-access/{token}으로 교체하는 작업 (#79) - 이번 PR에서는 issueAccessToken(HandoverStage) 메서드만 준비해두었고, HandoverStageService에서의 실제 호출 연결은 #79에서 진행합니다.

## 완료 조건 체크
- [x] 만료·재사용 링크가 모두 차단된다
- [x] OTP 인증 전에는 인계 내용이 어떤 응답에도 포함되지 않는다
- [x] OTP 반복 실패 시 차단되고 감사 로그(PublicLinkAuditor)가 남는다
- [x] AccessToken.otpCodeHash, EmailBuilder.buildOtp(), EmailType.OTP, ErrorCode.OTP_VERIFICATION_FAILED가 실제로 사용된다

## 테스트
- `PosthumousAccessServiceTest` 신규 8건 통과
- 전체 테스트 스위트(gradle test) 통과, 기존 회귀 없음