### PR TITLE
[Feat/#77] 역할별 사후 패키지 조회 및 단계 완료·문제 신고 구현

### DIFF
--- a/src/main/java/com/mamoki/ieojuda/domain/postaccess/controller/PosthumousPackageController.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/postaccess/controller/PosthumousPackageController.java
@@ -1,0 +1,60 @@
+package com.mamoki.ieojuda.domain.postaccess.controller;
+
+import com.mamoki.ieojuda.domain.postaccess.dto.PackageActionResponse;
+import com.mamoki.ieojuda.domain.postaccess.dto.PackageIssueRequest;
+import com.mamoki.ieojuda.domain.postaccess.dto.PackageIssueResponse;
+import com.mamoki.ieojuda.domain.postaccess.dto.PosthumousPackageResponse;
+import com.mamoki.ieojuda.domain.postaccess.service.PosthumousPackageService;
+import com.mamoki.ieojuda.global.rsdata.RsData;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+// 명세서 "역할별 사후 패키지" - OTP 인증(#76)을 통과한 담당자가 자신의 역할 항목만 확인·완료·신고
+// (로그인 불필요, 열람 세션(accessSessionId)이 곧 인증)
+@Tag(name = "PosthumousPackage", description = "사후 인계 - 역할별 패키지 조회 / 행동 완료 / 문제 신고")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/posthumous-packages")
+public class PosthumousPackageController {
+
+    private final PosthumousPackageService posthumousPackageService;
+
+    @Operation(summary = "패키지 조회", description = "인증된 담당자가 자신의 역할에 필요한 대상·행동·선행 완료 상태만 조회합니다. 다른 역할의 항목과 자격증명 원문은 포함하지 않습니다.")
+    @GetMapping("/{accessSessionId}")
+    public ResponseEntity<RsData<PosthumousPackageResponse>> getPackage(
+            @Parameter(description = "OTP 인증 성공 시 발급된 열람 세션 식별자") @PathVariable String accessSessionId
+    ) {
+        return ResponseEntity.ok(RsData.success(posthumousPackageService.getPackage(accessSessionId)));
+    }
+
+    @Operation(summary = "행동 완료", description = "자신의 역할 항목 하나를 완료 처리합니다. Idempotency-Key 헤더를 보내면 같은 키의 재전송은 중복 요청(409)으로 응답합니다.")
+    @PostMapping("/{accessSessionId}/actions/{actionId}/complete")
+    public ResponseEntity<RsData<PackageActionResponse>> completeAction(
+            @Parameter(description = "열람 세션 식별자") @PathVariable String accessSessionId,
+            @Parameter(description = "완료할 행동(항목) ID") @PathVariable Long actionId,
+            @RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey
+    ) {
+        return ResponseEntity.ok(RsData.success(
+                posthumousPackageService.completeAction(accessSessionId, actionId, idempotencyKey)));
+    }
+
+    @Operation(summary = "문제 신고", description = "자신의 역할 항목 중 하나에서 발생한 문제를 신고합니다.")
+    @PostMapping("/{accessSessionId}/issues")
+    public ResponseEntity<RsData<PackageIssueResponse>> reportIssue(
+            @Parameter(description = "열람 세션 식별자") @PathVariable String accessSessionId,
+            @Valid @RequestBody PackageIssueRequest request
+    ) {
+        return ResponseEntity.ok(RsData.success(posthumousPackageService.reportIssue(accessSessionId, request)));
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/postaccess/dto/PackageActionResponse.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/postaccess/dto/PackageActionResponse.java
@@ -1,0 +1,30 @@
+package com.mamoki.ieojuda.domain.postaccess.dto;
+
+import com.mamoki.ieojuda.domain.plan.dto.PlanSnapshotDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+// 명세서 "역할별 사후 패키지" - 담당자가 수행할 행동 하나. 봉인된 스냅샷의 항목 하나에 대응한다.
+public record PackageActionResponse(
+        @Schema(description = "행동(항목) ID") Long actionId,
+        @Schema(description = "제목") String title,
+        @Schema(description = "행동 내용") String content,
+        @Schema(description = "대상 이름") String targetName,
+        @Schema(description = "위치 유형") String locationType,
+        @Schema(description = "선행 조건") String precondition,
+        @Schema(description = "선행 조건 충족 여부") boolean preconditionMet,
+        @Schema(description = "완료 상태", allowableValues = {"PENDING", "COMPLETED"}) String status
+) {
+    public static PackageActionResponse of(PlanSnapshotDto.ItemSnapshot item, boolean completed) {
+        boolean preconditionMet = item.precondition() == null || item.precondition().isBlank();
+        return new PackageActionResponse(
+                item.itemId(),
+                item.title(),
+                item.content(),
+                item.targetName(),
+                item.locationType(),
+                item.precondition(),
+                preconditionMet,
+                completed ? "COMPLETED" : "PENDING"
+        );
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/postaccess/dto/PackageActionResponse.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/postaccess/dto/PackageActionResponse.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 // 명세서 "역할별 사후 패키지" - 담당자가 수행할 행동 하나. 봉인된 스냅샷의 항목 하나에 대응한다.
 public record PackageActionResponse(
         @Schema(description = "행동(항목) ID") Long actionId,
+        @Schema(description = "수행해야 할 행동 전체 설명", example = "인스타그램 아이디 비밀번호를 통해 SNS 계정을 정리해줘") String action,
         @Schema(description = "제목") String title,
         @Schema(description = "행동 내용") String content,
         @Schema(description = "대상 이름") String targetName,
@@ -18,6 +19,7 @@ public record PackageActionResponse(
         boolean preconditionMet = item.precondition() == null || item.precondition().isBlank();
         return new PackageActionResponse(
                 item.itemId(),
+                item.action(),
                 item.title(),
                 item.content(),
                 item.targetName(),

--- a/src/main/java/com/mamoki/ieojuda/domain/postaccess/dto/PackageIssueRequest.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/postaccess/dto/PackageIssueRequest.java
@@ -1,0 +1,15 @@
+package com.mamoki.ieojuda.domain.postaccess.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record PackageIssueRequest(
+        @Schema(description = "문제가 발생한 행동 ID", example = "12")
+        @NotNull(message = "행동 ID를 입력해 주세요.") Long actionId,
+
+        @Schema(description = "문제 사유", example = "해당 계정에 접근할 수 없습니다.")
+        @NotBlank(message = "문제 사유를 입력해 주세요.")
+        @jakarta.validation.constraints.Size(max = 1000, message = "문제 사유는 1000자 이하여야 합니다.") String reason
+) {
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/postaccess/dto/PackageIssueResponse.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/postaccess/dto/PackageIssueResponse.java
@@ -1,0 +1,18 @@
+package com.mamoki.ieojuda.domain.postaccess.dto;
+
+import com.mamoki.ieojuda.domain.postaccess.entity.PackageIssue;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record PackageIssueResponse(
+        @Schema(description = "신고 ID") Long issueId,
+        @Schema(description = "문제가 발생한 행동 ID") Long actionId,
+        @Schema(description = "처리 상태", allowableValues = {"OPEN", "RESOLVED"}) String status
+) {
+    public static PackageIssueResponse from(PackageIssue issue) {
+        return new PackageIssueResponse(
+                issue.getIssueId(),
+                issue.getItem().getItemId(),
+                issue.getStatus().name()
+        );
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/postaccess/dto/PosthumousAccessResponse.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/postaccess/dto/PosthumousAccessResponse.java
@@ -2,7 +2,6 @@ package com.mamoki.ieojuda.domain.postaccess.dto;
 
 import com.mamoki.ieojuda.domain.postaccess.entity.AccessToken;
 import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
-import com.mamoki.ieojuda.domain.recipient.entity.RoleType;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
@@ -23,18 +22,10 @@ public record PosthumousAccessResponse(
                 recipient.getName(),
                 recipient.getPlan().getUser().getName(),
                 recipient.getRoleType().name(),
-                roleLabel(recipient.getRoleType()),
+                recipient.getRoleType().label(),
                 accessToken.getExpiresAt(),
                 accessToken.getOtpSentAt() != null,
                 contactEmail
         );
-    }
-
-    private static String roleLabel(RoleType roleType) {
-        return switch (roleType) {
-            case FAMILY_MANAGER -> "가족 담당자";
-            case WORK_MANAGER -> "업무 담당자";
-            case RELATIONSHIP_MANAGER -> "관계 정리 담당자";
-        };
     }
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/postaccess/dto/PosthumousPackageResponse.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/postaccess/dto/PosthumousPackageResponse.java
@@ -1,0 +1,17 @@
+package com.mamoki.ieojuda.domain.postaccess.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+// 명세서 "역할별 사후 패키지" - 인증된 담당자가 자신의 역할에 필요한 대상·행동·순서만 확인하는 화면.
+// 다른 역할의 항목과 자격증명(원문)은 어떤 필드에도 포함하지 않는다.
+public record PosthumousPackageResponse(
+        @Schema(description = "역할 한글 명칭", example = "관계 정리 담당자") String roleLabel,
+        @Schema(description = "작성자(계획 소유자) 이름") String authorName,
+        @Schema(description = "전체 행동 수") int totalCount,
+        @Schema(description = "완료된 행동 수") int completedCount,
+        @Schema(description = "안내 문구") String notice,
+        @Schema(description = "행동 목록") List<PackageActionResponse> actions
+) {
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/postaccess/entity/AccessToken.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/postaccess/entity/AccessToken.java
@@ -15,6 +15,10 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AccessToken {
 
+    // OTP 인증 성공 후 열람 세션이 유효한 시간(분) - PosthumousAccessService(#76)와
+    // PosthumousPackageService(#77)가 세션 만료 판단 기준으로 함께 참조한다.
+    public static final int SESSION_TTL_MINUTES = 60;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "token_id")
@@ -71,5 +75,11 @@ public class AccessToken {
     public void verify() {
         this.verifiedAt = LocalDateTime.now();
         this.used = true;
+    }
+
+    // 역할별 사후 패키지 조회(#77)에서 쓰는 세션 유효성 판단 - OTP 인증을 통과했고(verifiedAt 존재)
+    // 세션 유효 시간(60분) 이내인지 확인한다.
+    public boolean isSessionValid(LocalDateTime now) {
+        return verifiedAt != null && verifiedAt.plusMinutes(SESSION_TTL_MINUTES).isAfter(now);
     }
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/postaccess/entity/PackageActionCompletion.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/postaccess/entity/PackageActionCompletion.java
@@ -1,0 +1,44 @@
+package com.mamoki.ieojuda.domain.postaccess.entity;
+
+import com.mamoki.ieojuda.domain.stage.entity.HandoverStage;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+// 명세서 "역할별 사후 패키지" - 행동(항목) 완료 기록. 조회는 봉인된 스냅샷(PlanSnapshotDto)만 읽으므로
+// (issue #42 결정사항, 라이브 Item 테이블 불가) 완료 여부는 스냅샷과 별개인 이 엔티티가 담당한다.
+// itemId는 스냅샷 기준 참조일 뿐 라이브 Item과의 FK가 아니다.
+@Entity
+@Table(name = "package_action_completions",
+        uniqueConstraints = @UniqueConstraint(name = "UQ_package_action_completions_stage_item",
+                columnNames = {"stage_id", "item_id"}))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PackageActionCompletion {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "completion_id")
+    private Long completionId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "stage_id", nullable = false)
+    private HandoverStage handoverStage;
+
+    @Column(name = "item_id", nullable = false)
+    private Long itemId;
+
+    @Column(name = "completed_at")
+    private LocalDateTime completedAt;
+
+    @Builder
+    public PackageActionCompletion(HandoverStage handoverStage, Long itemId) {
+        this.handoverStage = handoverStage;
+        this.itemId = itemId;
+        this.completedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/postaccess/repository/PackageActionCompletionRepository.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/postaccess/repository/PackageActionCompletionRepository.java
@@ -1,0 +1,16 @@
+package com.mamoki.ieojuda.domain.postaccess.repository;
+
+import com.mamoki.ieojuda.domain.postaccess.entity.PackageActionCompletion;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PackageActionCompletionRepository extends JpaRepository<PackageActionCompletion, Long> {
+
+    // 역할별 패키지 조회 - 이 단계에서 이미 완료된 행동 전체 (진행률 계산용)
+    List<PackageActionCompletion> findByHandoverStage_StageId(Long stageId);
+
+    // 행동 완료 처리 - 같은 행동을 다시 완료 요청했는지 확인
+    Optional<PackageActionCompletion> findByHandoverStage_StageIdAndItemId(Long stageId, Long itemId);
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/postaccess/service/PosthumousAccessService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/postaccess/service/PosthumousAccessService.java
@@ -42,7 +42,6 @@ public class PosthumousAccessService {
     private static final int OTP_TTL_MINUTES = 10;
     private static final int OTP_RESEND_COOLDOWN_SECONDS = 60;
     private static final int MAX_OTP_ATTEMPTS = 5;
-    private static final int SESSION_TTL_MINUTES = 60;
     private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
     private final AccessTokenRepository accessTokenRepository;
@@ -116,7 +115,7 @@ public class PosthumousAccessService {
         // 새 컬럼을 두지 않고 같은 원본 토큰을 그대로 열람 세션 식별자로 쓴다 -
         // 이후 조회는 verifiedAt(세션 시작 시각) 기준으로 60분 이내인지만 확인하면 된다.
         accessToken.verify();
-        LocalDateTime sessionExpiresAt = accessToken.getVerifiedAt().plusMinutes(SESSION_TTL_MINUTES);
+        LocalDateTime sessionExpiresAt = accessToken.getVerifiedAt().plusMinutes(AccessToken.SESSION_TTL_MINUTES);
 
         return new OtpVerifyResponse(plainToken, sessionExpiresAt);
     }

--- a/src/main/java/com/mamoki/ieojuda/domain/postaccess/service/PosthumousPackageService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/postaccess/service/PosthumousPackageService.java
@@ -1,0 +1,150 @@
+package com.mamoki.ieojuda.domain.postaccess.service;
+
+import com.mamoki.ieojuda.domain.plan.dto.PlanSnapshotDto;
+import com.mamoki.ieojuda.domain.plan.repository.ItemRepository;
+import com.mamoki.ieojuda.domain.plan.service.PlanSnapshotService;
+import com.mamoki.ieojuda.domain.postaccess.dto.PackageActionResponse;
+import com.mamoki.ieojuda.domain.postaccess.dto.PackageIssueRequest;
+import com.mamoki.ieojuda.domain.postaccess.dto.PackageIssueResponse;
+import com.mamoki.ieojuda.domain.postaccess.dto.PosthumousPackageResponse;
+import com.mamoki.ieojuda.domain.postaccess.entity.AccessToken;
+import com.mamoki.ieojuda.domain.postaccess.entity.PackageActionCompletion;
+import com.mamoki.ieojuda.domain.postaccess.entity.PackageIssue;
+import com.mamoki.ieojuda.domain.postaccess.repository.AccessTokenRepository;
+import com.mamoki.ieojuda.domain.postaccess.repository.PackageActionCompletionRepository;
+import com.mamoki.ieojuda.domain.postaccess.repository.PackageIssueRepository;
+import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
+import com.mamoki.ieojuda.global.email.token.TokenProvider;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import com.mamoki.ieojuda.global.idempotency.service.IdempotencyGuard;
+import com.mamoki.ieojuda.global.ratelimit.PublicLinkAuditor;
+import com.mamoki.ieojuda.global.ratelimit.TokenLookupGuard;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
+// 명세서 "역할별 사후 패키지" - OTP 인증을 통과한 담당자가 자신의 역할에 필요한 대상·행동·순서만
+// 확인한다. 데이터 출처는 반드시 봉인된 스냅샷이며 라이브 Item 테이블을 조회하지 않는다(issue #42).
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PosthumousPackageService {
+
+    private static final String COMPLETE_IDEMPOTENCY_SCOPE = "package-action-complete";
+
+    private final AccessTokenRepository accessTokenRepository;
+    private final PackageActionCompletionRepository packageActionCompletionRepository;
+    private final PackageIssueRepository packageIssueRepository;
+    private final ItemRepository itemRepository;
+    private final PlanSnapshotService planSnapshotService;
+    private final TokenLookupGuard tokenLookupGuard;
+    private final PublicLinkAuditor publicLinkAuditor;
+    private final IdempotencyGuard idempotencyGuard;
+
+    // ① 패키지 조회 - 자기 역할 항목만, 다른 역할·자격증명 원문은 응답에 포함하지 않는다
+    @Transactional
+    public PosthumousPackageResponse getPackage(String accessSessionId) {
+        AccessToken accessToken = findValidSession(accessSessionId);
+        Recipient recipient = accessToken.getHandoverStage().getRecipient();
+        PlanSnapshotDto snapshot = deserializeSnapshot(accessToken);
+
+        List<PlanSnapshotDto.ItemSnapshot> myItems = itemsOf(snapshot, recipient.getAssigneeId());
+        Set<Long> completedItemIds = completedItemIds(accessToken.getHandoverStage().getStageId());
+
+        List<PackageActionResponse> actions = myItems.stream()
+                .map(item -> PackageActionResponse.of(item, completedItemIds.contains(item.itemId())))
+                .toList();
+
+        String authorName = recipient.getPlan().getUser().getName();
+        return new PosthumousPackageResponse(
+                recipient.getRoleType().label(),
+                authorName,
+                myItems.size(),
+                (int) myItems.stream().filter(item -> completedItemIds.contains(item.itemId())).count(),
+                "이 인계는 %s님이 생전에 이어두다를 통해 공식적으로 설정한 거예요.".formatted(authorName),
+                actions
+        );
+    }
+
+    // ② 행동 완료
+    @Transactional
+    public PackageActionResponse completeAction(String accessSessionId, Long actionId, String idempotencyKey) {
+        idempotencyGuard.claim(COMPLETE_IDEMPOTENCY_SCOPE, idempotencyKey);
+
+        AccessToken accessToken = findValidSession(accessSessionId);
+        Recipient recipient = accessToken.getHandoverStage().getRecipient();
+        PlanSnapshotDto.ItemSnapshot item = findOwnedItem(accessToken, recipient, actionId);
+
+        Long stageId = accessToken.getHandoverStage().getStageId();
+        boolean alreadyCompleted = packageActionCompletionRepository
+                .findByHandoverStage_StageIdAndItemId(stageId, actionId).isPresent();
+        if (!alreadyCompleted) {
+            packageActionCompletionRepository.save(PackageActionCompletion.builder()
+                    .handoverStage(accessToken.getHandoverStage())
+                    .itemId(actionId)
+                    .build());
+        }
+
+        return PackageActionResponse.of(item, true);
+    }
+
+    // ③ 문제 신고
+    @Transactional
+    public PackageIssueResponse reportIssue(String accessSessionId, PackageIssueRequest request) {
+        AccessToken accessToken = findValidSession(accessSessionId);
+        Recipient recipient = accessToken.getHandoverStage().getRecipient();
+        findOwnedItem(accessToken, recipient, request.actionId()); // 소유·존재 검증
+
+        PackageIssue issue = packageIssueRepository.save(PackageIssue.builder()
+                .item(itemRepository.getReferenceById(request.actionId())) // FK 연결용 참조일 뿐 내용을 읽지 않는다
+                .recipient(recipient)
+                .description(request.reason())
+                .build());
+
+        return PackageIssueResponse.from(issue);
+    }
+
+    private AccessToken findValidSession(String accessSessionId) {
+        AccessToken accessToken = tokenLookupGuard.resolve(accessSessionId,
+                () -> accessTokenRepository.findByTokenHash(TokenProvider.hashToken(accessSessionId)));
+        if (!accessToken.isSessionValid(LocalDateTime.now())) {
+            publicLinkAuditor.recordStateFailure(ErrorCode.ACCESS_LINK_EXPIRED);
+            throw new CustomException(ErrorCode.ACCESS_LINK_EXPIRED);
+        }
+        return accessToken;
+    }
+
+    // 요청한 actionId가 실제로 이 세션 담당자의 항목인지 매번 검사 - 다른 역할 요청 차단
+    private PlanSnapshotDto.ItemSnapshot findOwnedItem(AccessToken accessToken, Recipient recipient, Long actionId) {
+        PlanSnapshotDto snapshot = deserializeSnapshot(accessToken);
+        return itemsOf(snapshot, recipient.getAssigneeId()).stream()
+                .filter(item -> item.itemId().equals(actionId))
+                .findFirst()
+                .orElseThrow(() -> {
+                    publicLinkAuditor.recordStateFailure(ErrorCode.ROLE_PACKAGE_ACCESS_DENIED);
+                    return new CustomException(ErrorCode.ROLE_PACKAGE_ACCESS_DENIED);
+                });
+    }
+
+    private PlanSnapshotDto deserializeSnapshot(AccessToken accessToken) {
+        String snapshotData = accessToken.getHandoverStage().getReleaseCase().getPlanVersion().getSnapshotData();
+        return planSnapshotService.deserialize(snapshotData);
+    }
+
+    private List<PlanSnapshotDto.ItemSnapshot> itemsOf(PlanSnapshotDto snapshot, Long recipientId) {
+        return snapshot.items().stream()
+                .filter(item -> recipientId.equals(item.recipientId()))
+                .toList();
+    }
+
+    private Set<Long> completedItemIds(Long stageId) {
+        return packageActionCompletionRepository.findByHandoverStage_StageId(stageId).stream()
+                .map(PackageActionCompletion::getItemId)
+                .collect(java.util.stream.Collectors.toSet());
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/recipient/entity/RoleType.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/recipient/entity/RoleType.java
@@ -4,4 +4,15 @@ public enum RoleType {
     FAMILY_MANAGER,       // 가족 담당자
     WORK_MANAGER,         // 업무 담당자
     RELATIONSHIP_MANAGER  // 관계 정리 담당자
+
+    ;
+
+    // 사후 인계 화면(#76,#77)에서 함께 쓰는 한글 표기 - 명세서 「역할별 최소 공개 정책」 표기와 일치
+    public String label() {
+        return switch (this) {
+            case FAMILY_MANAGER -> "가족 담당자";
+            case WORK_MANAGER -> "업무 담당자";
+            case RELATIONSHIP_MANAGER -> "관계 정리 담당자";
+        };
+    }
 }

--- a/src/main/java/com/mamoki/ieojuda/global/config/SecurityConfig.java
+++ b/src/main/java/com/mamoki/ieojuda/global/config/SecurityConfig.java
@@ -43,7 +43,8 @@ public class SecurityConfig {
             "/api/dispute-contacts/*/objections", // 이의 제기 접수
             "/api/recipient-acceptances/**",// 역할 담당자 수락
             "/api/confirmer-acceptances/**", // 지정확인자 수락 / 사망 신고 / 증빙 제출
-            "/api/posthumous-access/**" // 사후 인계 링크 검증 / OTP 발송·확인
+            "/api/posthumous-access/**", // 사후 인계 링크 검증 / OTP 발송·확인
+            "/api/posthumous-packages/**" // 역할별 사후 패키지 조회 / 행동 완료 / 문제 신고 (열람 세션이 곧 인증)
     };
 
     // 운영관리자 전용 - 이메일 발송 감사/재시도/사건 동결/단계 조회·대체담당자 전환
@@ -82,6 +83,9 @@ public class SecurityConfig {
                 new RateLimitRule("posthumous-otp", "/api/posthumous-access/*/otp", "POST", 5, Duration.ofHours(1)),
                 new RateLimitRule("posthumous-verify", "/api/posthumous-access/*/verify", "POST", 10, Duration.ofHours(1)),
                 new RateLimitRule("posthumous-link", "/api/posthumous-access/**", null, 30, Duration.ofHours(1)),
+                new RateLimitRule("posthumous-package-complete", "/api/posthumous-packages/*/actions/*/complete", "POST", 20, Duration.ofHours(1)),
+                new RateLimitRule("posthumous-package-issue", "/api/posthumous-packages/*/issues", "POST", 10, Duration.ofHours(1)),
+                new RateLimitRule("posthumous-package", "/api/posthumous-packages/**", null, 60, Duration.ofHours(1)),
                 new RateLimitRule("confirmer-link", "/api/confirmer-acceptances/**", null, 30, Duration.ofHours(1)),
                 new RateLimitRule("recipient-link", "/api/recipient-acceptances/**", null, 30, Duration.ofHours(1))
         );

--- a/src/test/java/com/mamoki/ieojuda/domain/postaccess/controller/PosthumousPackageHttpIntegrationTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/postaccess/controller/PosthumousPackageHttpIntegrationTest.java
@@ -166,6 +166,7 @@ class PosthumousPackageHttpIntegrationTest {
         assertThat(response.body()).contains("\"roleLabel\":\"관계 정리 담당자\"");
         assertThat(response.body()).contains("\"totalCount\":1");
         assertThat(response.body()).contains("\"actionId\":" + item.getItemId());
+        assertThat(response.body()).contains("\"action\":\"비공개 전환\""); // 이슈/노션이 요구하는 "행동" 필드
         assertThat(response.body()).doesNotContain("근거"); // sourceExcerpt(원문 근거)는 응답에 없어야 함
     }
 

--- a/src/test/java/com/mamoki/ieojuda/domain/postaccess/controller/PosthumousPackageHttpIntegrationTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/postaccess/controller/PosthumousPackageHttpIntegrationTest.java
@@ -1,0 +1,235 @@
+package com.mamoki.ieojuda.domain.postaccess.controller;
+
+import com.mamoki.ieojuda.domain.account.entity.User;
+import com.mamoki.ieojuda.domain.account.repository.UserRepository;
+import com.mamoki.ieojuda.domain.plan.dto.PlanSnapshotDto;
+import com.mamoki.ieojuda.domain.plan.entity.Conversation;
+import com.mamoki.ieojuda.domain.plan.entity.DisclosureScope;
+import com.mamoki.ieojuda.domain.plan.entity.Item;
+import com.mamoki.ieojuda.domain.plan.entity.ItemActionType;
+import com.mamoki.ieojuda.domain.plan.entity.LifeArea;
+import com.mamoki.ieojuda.domain.plan.entity.LifeAreaCategory;
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.plan.entity.PlanVersion;
+import com.mamoki.ieojuda.domain.plan.repository.ConversationRepository;
+import com.mamoki.ieojuda.domain.plan.repository.ItemRepository;
+import com.mamoki.ieojuda.domain.plan.repository.LifeAreaRepository;
+import com.mamoki.ieojuda.domain.plan.repository.PlanRepository;
+import com.mamoki.ieojuda.domain.plan.repository.PlanVersionRepository;
+import com.mamoki.ieojuda.domain.plan.service.PlanSnapshotService;
+import com.mamoki.ieojuda.domain.postaccess.entity.AccessToken;
+import com.mamoki.ieojuda.domain.postaccess.repository.AccessTokenRepository;
+import com.mamoki.ieojuda.domain.postaccess.repository.PackageActionCompletionRepository;
+import com.mamoki.ieojuda.domain.postaccess.repository.PackageIssueRepository;
+import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
+import com.mamoki.ieojuda.domain.recipient.entity.RoleType;
+import com.mamoki.ieojuda.domain.recipient.repository.RecipientRepository;
+import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCase;
+import com.mamoki.ieojuda.domain.releasecase.repository.ReleaseCaseRepository;
+import com.mamoki.ieojuda.domain.stage.entity.HandoverStage;
+import com.mamoki.ieojuda.domain.stage.repository.HandoverStageRepository;
+import com.mamoki.ieojuda.global.email.token.TokenProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+// issue #77 - 실제 컨트롤러/Security 필터 체인/Idempotency-Key DB 유니크 제약까지 포함한 HTTP 레벨 검증.
+// 서비스 단위 테스트(Mockito)는 IdempotencyGuard를 목으로 대체하므로, 실제 중복 요청 차단이 되는지는
+// 이 테스트가 유일하게 검증한다 (issue #76에서 Mockito가 트랜잭션 롤백을 못 잡아냈던 것과 같은 이유).
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class PosthumousPackageHttpIntegrationTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private PlanRepository planRepository;
+    @Autowired
+    private ConversationRepository conversationRepository;
+    @Autowired
+    private LifeAreaRepository lifeAreaRepository;
+    @Autowired
+    private RecipientRepository recipientRepository;
+    @Autowired
+    private ItemRepository itemRepository;
+    @Autowired
+    private PlanVersionRepository planVersionRepository;
+    @Autowired
+    private ReleaseCaseRepository releaseCaseRepository;
+    @Autowired
+    private HandoverStageRepository handoverStageRepository;
+    @Autowired
+    private AccessTokenRepository accessTokenRepository;
+    @Autowired
+    private PackageActionCompletionRepository packageActionCompletionRepository;
+    @Autowired
+    private PackageIssueRepository packageIssueRepository;
+    @Autowired
+    private PlanSnapshotService planSnapshotService;
+
+    private final HttpClient httpClient = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build();
+
+    private User user;
+    private Plan plan;
+    private Recipient recipient;
+    private Item item;
+    private HandoverStage stage;
+    private ReleaseCase releaseCase;
+    private PlanVersion planVersion;
+
+    @BeforeEach
+    void setUp() {
+        user = userRepository.saveAndFlush(User.builder()
+                .email("posthumous-pkg-http-" + UUID.randomUUID() + "@test.com").password("hash").name("김나무").build());
+        plan = planRepository.saveAndFlush(Plan.builder().user(user).build());
+        Conversation conversation = conversationRepository.saveAndFlush(Conversation.builder().plan(plan).build());
+        LifeArea lifeArea = lifeAreaRepository.saveAndFlush(
+                LifeArea.builder().plan(plan).conversation(conversation).category(LifeAreaCategory.RELATIONSHIP_CLEANUP).build());
+        recipient = recipientRepository.saveAndFlush(Recipient.builder()
+                .plan(plan).lifeArea(lifeArea).name("이지수").email("jisoo-pkg-http-" + UUID.randomUUID() + "@test.com")
+                .roleType(RoleType.RELATIONSHIP_MANAGER).isBackup(false)
+                .disclosureScope(DisclosureScope.RELATIONSHIP).maxWaitHours(168).backupFor(null).build());
+        item = itemRepository.saveAndFlush(Item.builder()
+                .lifeArea(lifeArea).targetName("이지수").locationType("인스타그램").action("비공개 전환")
+                .title("SNS 계정 처리").content("비공개로 전환").precondition("")
+                .disclosureScope(DisclosureScope.RELATIONSHIP).sourceExcerpt("근거")
+                .sortOrder(0).actionType(ItemActionType.DELETE).build());
+        item.assignRecipient(recipient);
+        item = itemRepository.saveAndFlush(item);
+
+        PlanSnapshotDto snapshot = planSnapshotService.buildSnapshot(plan);
+        String snapshotData = planSnapshotService.serialize(snapshot);
+        planVersion = planVersionRepository.saveAndFlush(
+                PlanVersion.builder().plan(plan).versionNum(1).snapshotData(snapshotData).build());
+        planVersion.seal(planSnapshotService.hash(snapshotData));
+        planVersion = planVersionRepository.saveAndFlush(planVersion);
+
+        releaseCase = releaseCaseRepository.saveAndFlush(ReleaseCase.builder().plan(plan).planVersion(planVersion).build());
+
+        stage = handoverStageRepository.saveAndFlush(HandoverStage.builder().plan(plan).recipient(recipient).stageOrder(0).build());
+        stage.assignToCase(releaseCase);
+        stage.send();
+        stage = handoverStageRepository.saveAndFlush(stage);
+    }
+
+    @AfterEach
+    void tearDown() {
+        packageIssueRepository.findByRecipient_Plan_PlanId(plan.getPlanId()).forEach(packageIssueRepository::delete);
+        packageActionCompletionRepository.findByHandoverStage_StageId(stage.getStageId()).forEach(packageActionCompletionRepository::delete);
+        accessTokenRepository.findAll().stream()
+                .filter(t -> t.getHandoverStage().getStageId().equals(stage.getStageId()))
+                .forEach(accessTokenRepository::delete);
+        handoverStageRepository.delete(stage);
+        releaseCaseRepository.delete(releaseCase);
+        planVersionRepository.delete(planVersion);
+        itemRepository.delete(item);
+        recipientRepository.delete(recipient);
+        lifeAreaRepository.findByPlan_PlanId(plan.getPlanId()).forEach(lifeAreaRepository::delete);
+        conversationRepository.findByPlan_PlanId(plan.getPlanId()).forEach(conversationRepository::delete);
+        planRepository.delete(plan);
+        userRepository.delete(user);
+    }
+
+    private String issueVerifiedSession() {
+        String plainToken = "pkg-session-" + UUID.randomUUID();
+        AccessToken accessToken = AccessToken.builder()
+                .handoverStage(stage).tokenHash(TokenProvider.hashToken(plainToken))
+                .expiresAt(LocalDateTime.now().plusHours(1)).build();
+        accessToken.verify();
+        accessTokenRepository.saveAndFlush(accessToken);
+        return plainToken;
+    }
+
+    @Test
+    void getPackage_returnsMyItemOnly() throws Exception {
+        String sessionId = issueVerifiedSession();
+
+        HttpResponse<String> response = get("/api/posthumous-packages/" + sessionId);
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.body()).contains("\"roleLabel\":\"관계 정리 담당자\"");
+        assertThat(response.body()).contains("\"totalCount\":1");
+        assertThat(response.body()).contains("\"actionId\":" + item.getItemId());
+        assertThat(response.body()).doesNotContain("근거"); // sourceExcerpt(원문 근거)는 응답에 없어야 함
+    }
+
+    @Test
+    void getPackage_whenSessionNotVerified_returns401() throws Exception {
+        String plainToken = "pkg-unverified-" + UUID.randomUUID();
+        accessTokenRepository.saveAndFlush(AccessToken.builder()
+                .handoverStage(stage).tokenHash(TokenProvider.hashToken(plainToken))
+                .expiresAt(LocalDateTime.now().plusHours(1)).build()); // verify() 호출 안 함
+
+        HttpResponse<String> response = get("/api/posthumous-packages/" + plainToken);
+
+        assertThat(response.statusCode()).isEqualTo(401);
+        assertThat(response.body()).contains("\"code\":\"ACCESS_LINK_EXPIRED\"");
+    }
+
+    @Test
+    void completeAction_withSameIdempotencyKeyTwice_secondCallRejectedAsDuplicate() throws Exception {
+        String sessionId = issueVerifiedSession();
+        String idempotencyKey = UUID.randomUUID().toString();
+        String path = "/api/posthumous-packages/" + sessionId + "/actions/" + item.getItemId() + "/complete";
+
+        HttpResponse<String> first = postWithIdempotencyKey(path, idempotencyKey);
+        assertThat(first.statusCode()).isEqualTo(200);
+        assertThat(first.body()).contains("\"status\":\"COMPLETED\"");
+        assertThat(packageActionCompletionRepository.findByHandoverStage_StageIdAndItemId(stage.getStageId(), item.getItemId()))
+                .isPresent();
+
+        HttpResponse<String> second = postWithIdempotencyKey(path, idempotencyKey);
+        assertThat(second.statusCode()).isEqualTo(409);
+        assertThat(second.body()).contains("\"code\":\"DUPLICATE_REQUEST\"");
+        // 실제로 완료 기록은 하나만 남아야 한다 (중복 저장되지 않음)
+        assertThat(packageActionCompletionRepository.findByHandoverStage_StageId(stage.getStageId())).hasSize(1);
+    }
+
+    @Test
+    void reportIssue_savesAndIsQueryable() throws Exception {
+        String sessionId = issueVerifiedSession();
+
+        HttpResponse<String> response = post("/api/posthumous-packages/" + sessionId + "/issues",
+                "{\"actionId\":" + item.getItemId() + ",\"reason\":\"해당 계정에 접근할 수 없습니다.\"}");
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.body()).contains("\"status\":\"OPEN\"");
+        assertThat(packageIssueRepository.findByRecipient_Plan_PlanId(plan.getPlanId())).hasSize(1);
+    }
+
+    private HttpResponse<String> get(String path) throws Exception {
+        return httpClient.send(HttpRequest.newBuilder(uri(path)).GET().build(), HttpResponse.BodyHandlers.ofString());
+    }
+
+    private HttpResponse<String> post(String path, String jsonBody) throws Exception {
+        return httpClient.send(HttpRequest.newBuilder(uri(path))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(jsonBody)).build(), HttpResponse.BodyHandlers.ofString());
+    }
+
+    private HttpResponse<String> postWithIdempotencyKey(String path, String key) throws Exception {
+        return httpClient.send(HttpRequest.newBuilder(uri(path))
+                .header("Idempotency-Key", key)
+                .POST(HttpRequest.BodyPublishers.noBody()).build(), HttpResponse.BodyHandlers.ofString());
+    }
+
+    private URI uri(String path) {
+        return URI.create("http://127.0.0.1:" + port + path);
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/domain/postaccess/service/PosthumousPackageServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/postaccess/service/PosthumousPackageServiceTest.java
@@ -1,0 +1,237 @@
+package com.mamoki.ieojuda.domain.postaccess.service;
+
+import com.mamoki.ieojuda.domain.account.entity.User;
+import com.mamoki.ieojuda.domain.plan.dto.PlanSnapshotDto;
+import com.mamoki.ieojuda.domain.plan.entity.DisclosureScope;
+import com.mamoki.ieojuda.domain.plan.entity.ItemActionType;
+import com.mamoki.ieojuda.domain.plan.entity.ItemStatus;
+import com.mamoki.ieojuda.domain.plan.entity.LifeArea;
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.plan.entity.PlanVersion;
+import com.mamoki.ieojuda.domain.plan.repository.ItemRepository;
+import com.mamoki.ieojuda.domain.plan.service.PlanSnapshotService;
+import com.mamoki.ieojuda.domain.postaccess.dto.PackageIssueRequest;
+import com.mamoki.ieojuda.domain.postaccess.entity.AccessToken;
+import com.mamoki.ieojuda.domain.postaccess.entity.PackageActionCompletion;
+import com.mamoki.ieojuda.domain.postaccess.entity.PackageIssue;
+import com.mamoki.ieojuda.domain.postaccess.repository.AccessTokenRepository;
+import com.mamoki.ieojuda.domain.postaccess.repository.PackageActionCompletionRepository;
+import com.mamoki.ieojuda.domain.postaccess.repository.PackageIssueRepository;
+import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
+import com.mamoki.ieojuda.domain.recipient.entity.RoleType;
+import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCase;
+import com.mamoki.ieojuda.domain.stage.entity.HandoverStage;
+import com.mamoki.ieojuda.global.email.token.TokenProvider;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import com.mamoki.ieojuda.global.idempotency.service.IdempotencyGuard;
+import com.mamoki.ieojuda.global.ratelimit.PublicLinkAuditor;
+import com.mamoki.ieojuda.global.ratelimit.TokenLookupGuard;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+// issue #77 - 역할별 사후 패키지 조회·완료·문제신고. 다른 역할 항목 접근 차단을 중점 검증한다.
+class PosthumousPackageServiceTest {
+
+    private static final String SESSION_ID = "session-token";
+    private static final Long MY_RECIPIENT_ID = 4L;
+    private static final Long OTHER_RECIPIENT_ID = 5L;
+
+    private AccessTokenRepository accessTokenRepository;
+    private PackageActionCompletionRepository packageActionCompletionRepository;
+    private PackageIssueRepository packageIssueRepository;
+    private ItemRepository itemRepository;
+    private PlanSnapshotService planSnapshotService;
+    private TokenLookupGuard tokenLookupGuard;
+    private PublicLinkAuditor publicLinkAuditor;
+    private IdempotencyGuard idempotencyGuard;
+    private PosthumousPackageService posthumousPackageService;
+
+    private AccessToken accessToken;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        accessTokenRepository = mock(AccessTokenRepository.class);
+        packageActionCompletionRepository = mock(PackageActionCompletionRepository.class);
+        packageIssueRepository = mock(PackageIssueRepository.class);
+        itemRepository = mock(ItemRepository.class);
+        planSnapshotService = mock(PlanSnapshotService.class);
+        tokenLookupGuard = mock(TokenLookupGuard.class);
+        publicLinkAuditor = mock(PublicLinkAuditor.class);
+        idempotencyGuard = mock(IdempotencyGuard.class);
+        posthumousPackageService = new PosthumousPackageService(
+                accessTokenRepository, packageActionCompletionRepository, packageIssueRepository,
+                itemRepository, planSnapshotService, tokenLookupGuard, publicLinkAuditor, idempotencyGuard);
+
+        when(tokenLookupGuard.resolve(anyString(), any())).thenAnswer(invocation -> {
+            Supplier<Optional<?>> lookup = invocation.getArgument(1);
+            return lookup.get().orElseThrow(() -> new CustomException(ErrorCode.TOKEN_INVALID));
+        });
+        when(packageActionCompletionRepository.findByHandoverStage_StageId(any())).thenReturn(List.of());
+
+        User user = mock(User.class);
+        when(user.getName()).thenReturn("김나무");
+        Plan plan = mock(Plan.class);
+        when(plan.getUser()).thenReturn(user);
+        LifeArea lifeArea = mock(LifeArea.class);
+
+        Recipient myRecipient = Recipient.builder()
+                .plan(plan).lifeArea(lifeArea).name("이지수").email("jisoo@test.com")
+                .roleType(RoleType.RELATIONSHIP_MANAGER).isBackup(false)
+                .disclosureScope(DisclosureScope.RELATIONSHIP).maxWaitHours(168).backupFor(null).build();
+        setId(myRecipient, MY_RECIPIENT_ID);
+
+        HandoverStage stage = HandoverStage.builder().plan(plan).recipient(myRecipient).stageOrder(0).build();
+        setId(stage, 10L);
+        stage.send();
+
+        PlanVersion planVersion = mock(PlanVersion.class);
+        when(planVersion.getSnapshotData()).thenReturn("{\"frozen\":true}");
+        ReleaseCase releaseCase = ReleaseCase.builder().plan(plan).planVersion(planVersion).build();
+        stage.assignToCase(releaseCase);
+
+        accessToken = AccessToken.builder()
+                .handoverStage(stage).tokenHash(TokenProvider.hashToken(SESSION_ID))
+                .expiresAt(LocalDateTime.now().plusHours(1)).build();
+        accessToken.verify(); // OTP 인증 통과한 상태로 시작 (verifiedAt now)
+        when(accessTokenRepository.findByTokenHash(TokenProvider.hashToken(SESSION_ID)))
+                .thenReturn(Optional.of(accessToken));
+
+        // 스냅샷: 내 항목 1개(itemId=100) + 다른 담당자 항목 1개(itemId=200)
+        PlanSnapshotDto.ItemSnapshot myItem = new PlanSnapshotDto.ItemSnapshot(
+                100L, MY_RECIPIENT_ID, "이지수", "인스타그램", "비공개 전환", "SNS 계정 처리", "비공개로 전환",
+                "", DisclosureScope.RELATIONSHIP, "지수에게 SNS 정리를 부탁", ItemStatus.APPROVED, 0, ItemActionType.DELETE);
+        PlanSnapshotDto.ItemSnapshot otherItem = new PlanSnapshotDto.ItemSnapshot(
+                200L, OTHER_RECIPIENT_ID, "다른사람", "이메일", "정리", "업무 메일 정리", "내용",
+                "", DisclosureScope.WORK, "근거", ItemStatus.APPROVED, 0, ItemActionType.TRANSFER);
+        PlanSnapshotDto snapshot = new PlanSnapshotDto(1L, 7, List.of(myItem, otherItem), List.of(), List.of());
+        when(planSnapshotService.deserialize("{\"frozen\":true}")).thenReturn(snapshot);
+    }
+
+    private void setId(Object entity, Long id) {
+        try {
+            String fieldName = entity instanceof Recipient ? "assigneeId" : "stageId";
+            var field = entity.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(entity, id);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void getPackage_returnsOnlyMyItems_excludesOtherRolesAndSourceExcerpt() {
+        var response = posthumousPackageService.getPackage(SESSION_ID);
+
+        assertThat(response.totalCount()).isEqualTo(1);
+        assertThat(response.roleLabel()).isEqualTo("관계 정리 담당자");
+        assertThat(response.authorName()).isEqualTo("김나무");
+        assertThat(response.notice()).contains("김나무");
+        assertThat(response.actions()).hasSize(1);
+        assertThat(response.actions().get(0).actionId()).isEqualTo(100L);
+        assertThat(response.actions().get(0).status()).isEqualTo("PENDING");
+    }
+
+    @Test
+    void getPackage_whenSessionExpired_throwsAccessLinkExpired() {
+        AccessToken expiredSession = AccessToken.builder()
+                .handoverStage(accessToken.getHandoverStage())
+                .tokenHash(TokenProvider.hashToken("expired-session"))
+                .expiresAt(LocalDateTime.now().plusHours(1)).build();
+        // verify()를 호출하지 않아 verifiedAt == null -> 세션 자체가 시작되지 않은 상태
+        when(accessTokenRepository.findByTokenHash(TokenProvider.hashToken("expired-session")))
+                .thenReturn(Optional.of(expiredSession));
+
+        assertThatThrownBy(() -> posthumousPackageService.getPackage("expired-session"))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.ACCESS_LINK_EXPIRED));
+    }
+
+    @Test
+    void getPackage_reflectsCompletedCount() {
+        PackageActionCompletion completion = PackageActionCompletion.builder()
+                .handoverStage(accessToken.getHandoverStage()).itemId(100L).build();
+        when(packageActionCompletionRepository.findByHandoverStage_StageId(10L)).thenReturn(List.of(completion));
+
+        var response = posthumousPackageService.getPackage(SESSION_ID);
+
+        assertThat(response.completedCount()).isEqualTo(1);
+        assertThat(response.actions().get(0).status()).isEqualTo("COMPLETED");
+    }
+
+    // issue #77 완료 조건 - "다른 역할의 항목 요청 시 차단"
+    @Test
+    void completeAction_whenActionBelongsToOtherRole_throwsRolePackageAccessDenied() {
+        assertThatThrownBy(() -> posthumousPackageService.completeAction(SESSION_ID, 200L, null))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.ROLE_PACKAGE_ACCESS_DENIED));
+        verify(packageActionCompletionRepository, never()).save(any());
+    }
+
+    @Test
+    void completeAction_whenOwned_savesCompletionAndReturnsCompletedStatus() {
+        when(packageActionCompletionRepository.findByHandoverStage_StageIdAndItemId(10L, 100L))
+                .thenReturn(Optional.empty());
+
+        var response = posthumousPackageService.completeAction(SESSION_ID, 100L, null);
+
+        assertThat(response.status()).isEqualTo("COMPLETED");
+        verify(packageActionCompletionRepository, times(1)).save(any());
+        verify(idempotencyGuard).claim("package-action-complete", null);
+    }
+
+    @Test
+    void completeAction_whenAlreadyCompleted_doesNotDuplicateSave() {
+        PackageActionCompletion existing = PackageActionCompletion.builder()
+                .handoverStage(accessToken.getHandoverStage()).itemId(100L).build();
+        when(packageActionCompletionRepository.findByHandoverStage_StageIdAndItemId(10L, 100L))
+                .thenReturn(Optional.of(existing));
+
+        posthumousPackageService.completeAction(SESSION_ID, 100L, "same-key");
+
+        verify(packageActionCompletionRepository, never()).save(any());
+    }
+
+    @Test
+    void reportIssue_whenActionBelongsToOtherRole_throwsRolePackageAccessDenied() {
+        PackageIssueRequest request = new PackageIssueRequest(200L, "문제 있음");
+
+        assertThatThrownBy(() -> posthumousPackageService.reportIssue(SESSION_ID, request))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.ROLE_PACKAGE_ACCESS_DENIED));
+        verify(packageIssueRepository, never()).save(any());
+    }
+
+    @Test
+    void reportIssue_whenOwned_savesIssue() {
+        when(itemRepository.getReferenceById(100L)).thenReturn(mock(com.mamoki.ieojuda.domain.plan.entity.Item.class));
+        when(packageIssueRepository.save(any())).thenAnswer(invocation -> {
+            PackageIssue issue = invocation.getArgument(0);
+            var field = PackageIssue.class.getDeclaredField("issueId");
+            field.setAccessible(true);
+            field.set(issue, 1L);
+            return issue;
+        });
+
+        var response = posthumousPackageService.reportIssue(SESSION_ID, new PackageIssueRequest(100L, "접근 불가"));
+
+        assertThat(response.issueId()).isEqualTo(1L);
+        assertThat(response.status()).isEqualTo("OPEN");
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/domain/postaccess/service/PosthumousPackageServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/postaccess/service/PosthumousPackageServiceTest.java
@@ -145,6 +145,7 @@ class PosthumousPackageServiceTest {
         assertThat(response.notice()).contains("김나무");
         assertThat(response.actions()).hasSize(1);
         assertThat(response.actions().get(0).actionId()).isEqualTo(100L);
+        assertThat(response.actions().get(0).action()).isEqualTo("비공개 전환");
         assertThat(response.actions().get(0).status()).isEqualTo("PENDING");
     }
 


### PR DESCRIPTION
## 연관 Issue
Closes #77

## 요약
OTP 인증(#76)을 통과한 담당자가 자신의 역할에 필요한 대상·행동·순서만 확인하고, 각 행동을 완료 처리하거나 문제를 신고할 수 있게 구현했습니다.

## 작업 내용
- `PosthumousPackageService` / `PosthumousPackageController` 신설
- `GET /api/posthumous-packages/{accessSessionId}` - 봉인된 `PlanVersion.snapshotData`(스냅샷)에서 이 세션 담당자(recipientId 일치) 항목만 추출해 응답
- `POST /api/posthumous-packages/{id}/actions/{actionId}/complete` - 행동 완료, `Idempotency-Key` 헤더 지원(공통규칙 0-5)
- `POST /api/posthumous-packages/{id}/issues` - 문제 신고, `PackageIssue` 엔티티 생성
- **신규 엔티티 `PackageActionCompletion`(handoverStage+itemId+completedAt)** - 조회는 불변 스냅샷만 읽어야 하고(issue #42) 라이브 Item도 건드릴 수 없어서, 행동별 완료 여부를 저장할 곳이 없었음. 이슈 본문엔 없던 항목이라 작업 전 사용자 확인 받고 추가함
- `AccessToken`에 `SESSION_TTL_MINUTES` 공개 상수 + `isSessionValid()` 추가 (#76의 세션 만료 판단 로직을 #77과 공유, 중복 제거)
- `RoleType`에 `label()` 메서드 추가해 #76/#77에 중복돼 있던 역할 한글 라벨 매핑 통합
- `SecurityConfig`의 `PERMIT_ALL_PATHS` + `rateLimitRules()`에 `/api/posthumous-packages/**` 등록 (공통규칙 0-3)

## 범위
### 포함:
- 이슈 본문의 3개 API + 역할별 최소 공개 필터링 + PackageIssue 생성

### 제외:
- 링크 검증과 OTP 인증 (#76, 이미 머지됨)
- 완료 이후 다음 단계 자동 발송 (#78)

## 완료 조건 체크
- [x] 인증된 담당자가 자기 역할 항목만 조회 가능
- [x] 다른 역할의 항목 요청 시 차단 (`ROLE_PACKAGE_ACCESS_DENIED`, 기존 미사용 에러코드 연결)
- [x] 행동 완료와 문제 신고가 저장되고 조회됨
- [x] 진행률 계산 가능 (`totalCount`/`completedCount`)

## 테스트
- `PosthumousPackageServiceTest` 8건 (다른 역할 접근 차단, 세션 만료 차단, 진행률 계산, 완료·신고 저장 등)
- `PosthumousPackageHttpIntegrationTest` 4건 - 실제 서버로 끝까지 검증. 특히 **Idempotency-Key 중복 요청이 실제 DB 유니크 제약으로 막히는지**(단위 테스트는 IdempotencyGuard를 목으로 대체해서 검증 못 함, #76에서 겪은 것과 같은 이유)까지 실제 HTTP로 확인
- 전체 스위트 161건 통과, 회귀 없음