### PR TITLE
[Fix/#78] 단계 완료 후 다음 발송 단계가 진행되지 않는 문제 수정

### DIFF
--- a/src/main/java/com/mamoki/ieojuda/domain/postaccess/repository/PackageActionCompletionRepository.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/postaccess/repository/PackageActionCompletionRepository.java
@@ -13,4 +13,7 @@ public interface PackageActionCompletionRepository extends JpaRepository<Package
 
     // 행동 완료 처리 - 같은 행동을 다시 완료 요청했는지 확인
     Optional<PackageActionCompletion> findByHandoverStage_StageIdAndItemId(Long stageId, Long itemId);
+
+    // issue #78 - 단계 완료 판정(전체 항목 수 대비 완료된 항목 수)에 사용
+    long countByHandoverStage_StageId(Long stageId);
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/postaccess/service/PosthumousPackageService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/postaccess/service/PosthumousPackageService.java
@@ -14,6 +14,7 @@ import com.mamoki.ieojuda.domain.postaccess.repository.AccessTokenRepository;
 import com.mamoki.ieojuda.domain.postaccess.repository.PackageActionCompletionRepository;
 import com.mamoki.ieojuda.domain.postaccess.repository.PackageIssueRepository;
 import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
+import com.mamoki.ieojuda.domain.stage.service.HandoverStageService;
 import com.mamoki.ieojuda.global.email.token.TokenProvider;
 import com.mamoki.ieojuda.global.exception.CustomException;
 import com.mamoki.ieojuda.global.exception.ErrorCode;
@@ -45,6 +46,7 @@ public class PosthumousPackageService {
     private final TokenLookupGuard tokenLookupGuard;
     private final PublicLinkAuditor publicLinkAuditor;
     private final IdempotencyGuard idempotencyGuard;
+    private final HandoverStageService handoverStageService;
 
     // ① 패키지 조회 - 자기 역할 항목만, 다른 역할·자격증명 원문은 응답에 포함하지 않는다
     @Transactional
@@ -71,14 +73,22 @@ public class PosthumousPackageService {
         );
     }
 
-    // ② 행동 완료
+    // ② 행동 완료 - 이 행동으로 단계의 모든 항목이 끝나면 단계를 완료 처리하고 다음 담당자에게 발송한다(issue #78)
     @Transactional
     public PackageActionResponse completeAction(String accessSessionId, Long actionId, String idempotencyKey) {
         idempotencyGuard.claim(COMPLETE_IDEMPOTENCY_SCOPE, idempotencyKey);
 
         AccessToken accessToken = findValidSession(accessSessionId);
         Recipient recipient = accessToken.getHandoverStage().getRecipient();
-        PlanSnapshotDto.ItemSnapshot item = findOwnedItem(accessToken, recipient, actionId);
+        PlanSnapshotDto snapshot = deserializeSnapshot(accessToken);
+        List<PlanSnapshotDto.ItemSnapshot> myItems = itemsOf(snapshot, recipient.getAssigneeId());
+        PlanSnapshotDto.ItemSnapshot item = myItems.stream()
+                .filter(i -> i.itemId().equals(actionId))
+                .findFirst()
+                .orElseThrow(() -> {
+                    publicLinkAuditor.recordStateFailure(ErrorCode.ROLE_PACKAGE_ACCESS_DENIED);
+                    return new CustomException(ErrorCode.ROLE_PACKAGE_ACCESS_DENIED);
+                });
 
         Long stageId = accessToken.getHandoverStage().getStageId();
         boolean alreadyCompleted = packageActionCompletionRepository
@@ -88,6 +98,9 @@ public class PosthumousPackageService {
                     .handoverStage(accessToken.getHandoverStage())
                     .itemId(actionId)
                     .build());
+            // 방금 저장한 완료가 이 단계의 마지막 항목이었는지는, 동시 요청 경쟁을 피하기 위해
+            // 비관적 잠금 아래에서 다시 세어 판정한다 (totalCount는 봉인된 스냅샷 기준이라 안전하게 미리 계산)
+            handoverStageService.completeStageIfAllActionsDone(stageId, myItems.size());
         }
 
         return PackageActionResponse.of(item, true);

--- a/src/main/java/com/mamoki/ieojuda/domain/releasecase/entity/ReleaseCase.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/releasecase/entity/ReleaseCase.java
@@ -129,4 +129,10 @@ public class ReleaseCase {
     public void startReleasing() {
         this.status = ReleaseCaseStatus.RELEASING;
     }
+
+    // issue #78 - 마지막 발송 단계까지 완료되면 사건 전체를 완료 처리
+    public void complete() {
+        this.status = ReleaseCaseStatus.COMPLETED;
+        this.completedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/stage/repository/HandoverStageRepository.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/stage/repository/HandoverStageRepository.java
@@ -1,12 +1,27 @@
 package com.mamoki.ieojuda.domain.stage.repository;
 
 import com.mamoki.ieojuda.domain.stage.entity.HandoverStage;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface HandoverStageRepository extends JpaRepository<HandoverStage, Long> {
 
     // 계정 삭제 시 이 계획의 인계 단계를 전부 지우기 위한 조회 (email_logs보다 나중, role_assignees/release_cases보다 먼저 지워야 함)
     List<HandoverStage> findByPlan_PlanId(Long planId);
+
+    // issue #78 - 현재 단계가 완료됐을 때 그다음 순서로 발송할 담당자 단계를 찾기 위한 조회
+    Optional<HandoverStage> findFirstByReleaseCase_CaseIdAndStageOrderGreaterThanOrderByStageOrderAsc(
+            Long caseId, Integer stageOrder);
+
+    // issue #78 - 같은 단계의 서로 다른 행동이 동시에 완료 요청되면 "전부 완료 판정 → 단계 완료 →
+    // 다음 단계 발송"이 중복 실행될 수 있다. 비관적 잠금으로 이 단계에 대한 판정·전이를 직렬화한다.
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select s from HandoverStage s where s.stageId = :stageId")
+    Optional<HandoverStage> findByIdForUpdate(@Param("stageId") Long stageId);
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/stage/service/HandoverStageService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/stage/service/HandoverStageService.java
@@ -4,12 +4,14 @@ import com.mamoki.ieojuda.domain.account.entity.AdminPermission;
 import com.mamoki.ieojuda.domain.audit.entity.EmailLog;
 import com.mamoki.ieojuda.domain.audit.entity.EmailType;
 import com.mamoki.ieojuda.domain.audit.repository.EmailLogRepository;
+import com.mamoki.ieojuda.domain.postaccess.repository.PackageActionCompletionRepository;
 import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
 import com.mamoki.ieojuda.domain.recipient.repository.RecipientRepository;
 import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCase;
 import com.mamoki.ieojuda.domain.releasecase.repository.ReleaseCaseRepository;
 import com.mamoki.ieojuda.domain.stage.dto.HandoverStageResponse;
 import com.mamoki.ieojuda.domain.stage.entity.HandoverStage;
+import com.mamoki.ieojuda.domain.stage.entity.HandoverStageStatus;
 import com.mamoki.ieojuda.domain.stage.repository.HandoverStageRepository;
 import com.mamoki.ieojuda.global.config.AppProperties;
 import com.mamoki.ieojuda.global.email.contract.EmailContent;
@@ -43,6 +45,7 @@ public class HandoverStageService {
     private final EmailSender emailSender;
     private final AppProperties appProperties;
     private final PermissionGuard permissionGuard;
+    private final PackageActionCompletionRepository packageActionCompletionRepository;
 
     public HandoverStageResponse getStage(Long userId, Long caseId, Long stageId) {
         permissionGuard.require(userId, AdminPermission.CASE_SUPERVISE);
@@ -97,6 +100,42 @@ public class HandoverStageService {
             HandoverStage firstStage = stages.get(0);
             sendHandoffInvite(firstStage, firstStage.getRecipient());
         }
+    }
+
+    // issue #78 - 역할별 사후 패키지(#77)에서 행동 하나가 완료될 때마다 호출된다. 같은 단계의 여러
+    // 행동이 동시에 완료 요청되어도 "전부 완료 → 단계 완료 → 다음 단계 발송"이 한 번만 일어나도록,
+    // 이 단계 행에 비관적 잠금을 걸고 그 안에서 완료 개수를 다시 센다(호출자가 넘긴 개수는 신뢰하지 않음).
+    @Transactional
+    public void completeStageIfAllActionsDone(Long stageId, int totalActionCount) {
+        HandoverStage stage = handoverStageRepository.findByIdForUpdate(stageId)
+                .orElseThrow(() -> new CustomException(ErrorCode.HANDOVER_STAGE_NOT_FOUND));
+        // SENT 상태에서만 완료로 전이한다 - 이미 완료됐다면(동시 요청) 중복 발송 방지, BLOCKED/BOUNCED/
+        // FALLBACK 등 다른 상태라면 "BLOCKED 단계는 다음 단계를 열지 않는다" 규칙을 여기서도 지킨다.
+        if (stage.getStatus() != HandoverStageStatus.SENT) {
+            return;
+        }
+
+        long completedCount = packageActionCompletionRepository.countByHandoverStage_StageId(stageId);
+        if (completedCount < totalActionCount) {
+            return;
+        }
+
+        stage.complete();
+        dispatchNextOrCompleteCase(stage);
+    }
+
+    // 다음 stageOrder 담당자에게 발송하거나, 마지막 단계였다면 사건 전체를 완료 처리한다.
+    // BLOCKED 단계는 애초에 행동을 완료할 수 없어 이 경로를 타지 않으므로, 다음 단계가 자동으로 열리지 않는다.
+    private void dispatchNextOrCompleteCase(HandoverStage stage) {
+        HandoverStage next = handoverStageRepository
+                .findFirstByReleaseCase_CaseIdAndStageOrderGreaterThanOrderByStageOrderAsc(
+                        stage.getReleaseCase().getCaseId(), stage.getStageOrder())
+                .orElse(null);
+        if (next == null) {
+            stage.getReleaseCase().complete();
+            return;
+        }
+        sendHandoffInvite(next, next.getRecipient());
     }
 
     private void sendHandoffInvite(HandoverStage stage, Recipient recipient) {

--- a/src/test/java/com/mamoki/ieojuda/domain/postaccess/controller/PosthumousPackageHttpIntegrationTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/postaccess/controller/PosthumousPackageHttpIntegrationTest.java
@@ -135,8 +135,10 @@ class PosthumousPackageHttpIntegrationTest {
         accessTokenRepository.findAll().stream()
                 .filter(t -> t.getHandoverStage().getStageId().equals(stage.getStageId()))
                 .forEach(accessTokenRepository::delete);
-        handoverStageRepository.delete(stage);
-        releaseCaseRepository.delete(releaseCase);
+        // issue #78 이후 행동 완료가 단계·사건까지 완료 처리할 수 있어(@Version 증가), 이 테스트가 들고
+        // 있는 인스턴스로 delete(entity)를 호출하면 낙관적 잠금 충돌이 날 수 있다 - ID 기준으로 삭제한다.
+        handoverStageRepository.deleteById(stage.getStageId());
+        releaseCaseRepository.deleteById(releaseCase.getCaseId());
         planVersionRepository.delete(planVersion);
         itemRepository.delete(item);
         recipientRepository.delete(recipient);

--- a/src/test/java/com/mamoki/ieojuda/domain/postaccess/service/PosthumousPackageServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/postaccess/service/PosthumousPackageServiceTest.java
@@ -21,6 +21,7 @@ import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
 import com.mamoki.ieojuda.domain.recipient.entity.RoleType;
 import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCase;
 import com.mamoki.ieojuda.domain.stage.entity.HandoverStage;
+import com.mamoki.ieojuda.domain.stage.service.HandoverStageService;
 import com.mamoki.ieojuda.global.email.token.TokenProvider;
 import com.mamoki.ieojuda.global.exception.CustomException;
 import com.mamoki.ieojuda.global.exception.ErrorCode;
@@ -60,6 +61,7 @@ class PosthumousPackageServiceTest {
     private TokenLookupGuard tokenLookupGuard;
     private PublicLinkAuditor publicLinkAuditor;
     private IdempotencyGuard idempotencyGuard;
+    private HandoverStageService handoverStageService;
     private PosthumousPackageService posthumousPackageService;
 
     private AccessToken accessToken;
@@ -75,9 +77,11 @@ class PosthumousPackageServiceTest {
         tokenLookupGuard = mock(TokenLookupGuard.class);
         publicLinkAuditor = mock(PublicLinkAuditor.class);
         idempotencyGuard = mock(IdempotencyGuard.class);
+        handoverStageService = mock(HandoverStageService.class);
         posthumousPackageService = new PosthumousPackageService(
                 accessTokenRepository, packageActionCompletionRepository, packageIssueRepository,
-                itemRepository, planSnapshotService, tokenLookupGuard, publicLinkAuditor, idempotencyGuard);
+                itemRepository, planSnapshotService, tokenLookupGuard, publicLinkAuditor, idempotencyGuard,
+                handoverStageService);
 
         when(tokenLookupGuard.resolve(anyString(), any())).thenAnswer(invocation -> {
             Supplier<Optional<?>> lookup = invocation.getArgument(1);
@@ -195,6 +199,8 @@ class PosthumousPackageServiceTest {
         assertThat(response.status()).isEqualTo("COMPLETED");
         verify(packageActionCompletionRepository, times(1)).save(any());
         verify(idempotencyGuard).claim("package-action-complete", null);
+        // issue #78 - 내 역할 항목이 1개뿐이라 이 완료로 단계 전체가 끝남 -> 단계 완료 판정 호출로 이어져야 한다
+        verify(handoverStageService).completeStageIfAllActionsDone(10L, 1);
     }
 
     @Test
@@ -205,6 +211,9 @@ class PosthumousPackageServiceTest {
                 .thenReturn(Optional.of(existing));
 
         posthumousPackageService.completeAction(SESSION_ID, 100L, "same-key");
+
+        // 이미 완료된 행동을 재요청했을 때는 단계 완료 판정도 다시 트리거하지 않는다(불필요한 재판정 방지)
+        verify(handoverStageService, never()).completeStageIfAllActionsDone(any(), org.mockito.ArgumentMatchers.anyInt());
 
         verify(packageActionCompletionRepository, never()).save(any());
     }

--- a/src/test/java/com/mamoki/ieojuda/domain/stage/service/HandoverStageServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/stage/service/HandoverStageServiceTest.java
@@ -1,0 +1,148 @@
+package com.mamoki.ieojuda.domain.stage.service;
+
+import com.mamoki.ieojuda.domain.audit.repository.EmailLogRepository;
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.plan.entity.PlanVersion;
+import com.mamoki.ieojuda.domain.postaccess.repository.PackageActionCompletionRepository;
+import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
+import com.mamoki.ieojuda.domain.recipient.repository.RecipientRepository;
+import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCase;
+import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCaseStatus;
+import com.mamoki.ieojuda.domain.releasecase.repository.ReleaseCaseRepository;
+import com.mamoki.ieojuda.domain.stage.entity.HandoverStage;
+import com.mamoki.ieojuda.domain.stage.repository.HandoverStageRepository;
+import com.mamoki.ieojuda.global.config.AppProperties;
+import com.mamoki.ieojuda.global.email.contract.EmailSendResult;
+import com.mamoki.ieojuda.global.email.sender.EmailSender;
+import com.mamoki.ieojuda.global.security.PermissionGuard;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+// issue #78 - HandoverStage.complete()가 정의만 되고 호출되지 않아 발송 체인이 1단계에서 멈추던 문제.
+// "전부 완료 -> 다음 단계 발송 -> 마지막이면 사건 완료", "BLOCKED는 다음 단계를 열지 않는다"를 검증한다.
+class HandoverStageServiceTest {
+
+    private ReleaseCaseRepository releaseCaseRepository;
+    private HandoverStageRepository handoverStageRepository;
+    private RecipientRepository recipientRepository;
+    private EmailLogRepository emailLogRepository;
+    private EmailSender emailSender;
+    private AppProperties appProperties;
+    private PermissionGuard permissionGuard;
+    private PackageActionCompletionRepository packageActionCompletionRepository;
+    private HandoverStageService handoverStageService;
+
+    private ReleaseCase releaseCase;
+    private HandoverStage currentStage;
+
+    @BeforeEach
+    void setUp() {
+        releaseCaseRepository = mock(ReleaseCaseRepository.class);
+        handoverStageRepository = mock(HandoverStageRepository.class);
+        recipientRepository = mock(RecipientRepository.class);
+        emailLogRepository = mock(EmailLogRepository.class);
+        emailSender = mock(EmailSender.class);
+        appProperties = mock(AppProperties.class);
+        permissionGuard = mock(PermissionGuard.class);
+        packageActionCompletionRepository = mock(PackageActionCompletionRepository.class);
+        handoverStageService = new HandoverStageService(
+                releaseCaseRepository, handoverStageRepository, recipientRepository, emailLogRepository,
+                emailSender, appProperties, permissionGuard, packageActionCompletionRepository);
+
+        when(appProperties.getContactEmail()).thenReturn("support@ieoduda.example");
+        when(appProperties.getInviteTokenTtlHours()).thenReturn(72L);
+        when(emailSender.send(anyString(), any())).thenReturn(EmailSendResult.success("msg-1"));
+        when(emailLogRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Plan plan = mock(Plan.class);
+        PlanVersion planVersion = mock(PlanVersion.class);
+        releaseCase = ReleaseCase.builder().plan(plan).planVersion(planVersion).build();
+
+        Recipient recipient = mock(Recipient.class);
+        when(recipient.getEmail()).thenReturn("target@test.com");
+        currentStage = HandoverStage.builder().plan(plan).recipient(recipient).stageOrder(0).build();
+        currentStage.assignToCase(releaseCase);
+        currentStage.send(); // 활성 발송 상태(SENT)에서 시작
+
+        when(handoverStageRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(currentStage));
+    }
+
+    @Test
+    void completeStageIfAllActionsDone_whenNotAllCompleted_doesNothing() {
+        when(packageActionCompletionRepository.countByHandoverStage_StageId(1L)).thenReturn(1L);
+
+        handoverStageService.completeStageIfAllActionsDone(1L, 3);
+
+        assertThat(currentStage.getStatus()).isNotEqualTo(com.mamoki.ieojuda.domain.stage.entity.HandoverStageStatus.COMPLETED);
+        verify(emailSender, never()).send(anyString(), any());
+    }
+
+    @Test
+    void completeStageIfAllActionsDone_whenAllCompletedAndNextExists_completesAndDispatchesNext() {
+        when(packageActionCompletionRepository.countByHandoverStage_StageId(1L)).thenReturn(2L);
+
+        Recipient nextRecipient = mock(Recipient.class);
+        when(nextRecipient.getEmail()).thenReturn("next@test.com");
+        HandoverStage nextStage = HandoverStage.builder().plan(currentStage.getPlan()).recipient(nextRecipient).stageOrder(1).build();
+        nextStage.assignToCase(releaseCase);
+        when(handoverStageRepository.findFirstByReleaseCase_CaseIdAndStageOrderGreaterThanOrderByStageOrderAsc(any(), org.mockito.ArgumentMatchers.eq(0)))
+                .thenReturn(Optional.of(nextStage));
+
+        handoverStageService.completeStageIfAllActionsDone(1L, 2);
+
+        assertThat(currentStage.getStatus()).isEqualTo(com.mamoki.ieojuda.domain.stage.entity.HandoverStageStatus.COMPLETED);
+        assertThat(nextStage.getStatus()).isEqualTo(com.mamoki.ieojuda.domain.stage.entity.HandoverStageStatus.SENT);
+        verify(emailSender).send(org.mockito.ArgumentMatchers.eq("next@test.com"), any());
+        assertThat(releaseCase.getStatus()).isNotEqualTo(ReleaseCaseStatus.COMPLETED);
+    }
+
+    @Test
+    void completeStageIfAllActionsDone_whenLastStage_completesReleaseCase() {
+        when(packageActionCompletionRepository.countByHandoverStage_StageId(1L)).thenReturn(1L);
+        when(handoverStageRepository.findFirstByReleaseCase_CaseIdAndStageOrderGreaterThanOrderByStageOrderAsc(any(), any()))
+                .thenReturn(Optional.empty());
+
+        handoverStageService.completeStageIfAllActionsDone(1L, 1);
+
+        assertThat(currentStage.getStatus()).isEqualTo(com.mamoki.ieojuda.domain.stage.entity.HandoverStageStatus.COMPLETED);
+        assertThat(releaseCase.getStatus()).isEqualTo(ReleaseCaseStatus.COMPLETED);
+        assertThat(releaseCase.getCompletedAt()).isNotNull();
+        verify(emailSender, never()).send(anyString(), any());
+    }
+
+    @Test
+    void completeStageIfAllActionsDone_whenAlreadyCompleted_doesNotDispatchAgain() {
+        currentStage.complete(); // 동시 요청으로 이미 처리된 상황을 재현
+        when(packageActionCompletionRepository.countByHandoverStage_StageId(1L)).thenReturn(1L);
+
+        handoverStageService.completeStageIfAllActionsDone(1L, 1);
+
+        verify(emailSender, never()).send(anyString(), any());
+        verify(handoverStageRepository, never())
+                .findFirstByReleaseCase_CaseIdAndStageOrderGreaterThanOrderByStageOrderAsc(any(), any());
+    }
+
+    // issue #78 완료 조건 - "BLOCKED 상태에서는 다음 단계가 자동 활성화되지 않는다"
+    @Test
+    void completeStageIfAllActionsDone_whenStageBlocked_doesNotOpenNextStage() {
+        currentStage.block();
+        when(packageActionCompletionRepository.countByHandoverStage_StageId(1L)).thenReturn(1L);
+
+        handoverStageService.completeStageIfAllActionsDone(1L, 1);
+
+        assertThat(currentStage.getStatus()).isEqualTo(com.mamoki.ieojuda.domain.stage.entity.HandoverStageStatus.BLOCKED);
+        verify(emailSender, never()).send(anyString(), any());
+        verify(handoverStageRepository, never())
+                .findFirstByReleaseCase_CaseIdAndStageOrderGreaterThanOrderByStageOrderAsc(any(), any());
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/domain/stage/service/StageDispatchHttpIntegrationTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/stage/service/StageDispatchHttpIntegrationTest.java
@@ -1,0 +1,260 @@
+package com.mamoki.ieojuda.domain.stage.service;
+
+import com.mamoki.ieojuda.domain.account.entity.User;
+import com.mamoki.ieojuda.domain.account.repository.UserRepository;
+import com.mamoki.ieojuda.domain.audit.repository.EmailLogRepository;
+import com.mamoki.ieojuda.domain.plan.dto.PlanSnapshotDto;
+import com.mamoki.ieojuda.domain.plan.entity.Conversation;
+import com.mamoki.ieojuda.domain.plan.entity.DisclosureScope;
+import com.mamoki.ieojuda.domain.plan.entity.Item;
+import com.mamoki.ieojuda.domain.plan.entity.ItemActionType;
+import com.mamoki.ieojuda.domain.plan.entity.LifeArea;
+import com.mamoki.ieojuda.domain.plan.entity.LifeAreaCategory;
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.plan.entity.PlanVersion;
+import com.mamoki.ieojuda.domain.plan.repository.ConversationRepository;
+import com.mamoki.ieojuda.domain.plan.repository.ItemRepository;
+import com.mamoki.ieojuda.domain.plan.repository.LifeAreaRepository;
+import com.mamoki.ieojuda.domain.plan.repository.PlanRepository;
+import com.mamoki.ieojuda.domain.plan.repository.PlanVersionRepository;
+import com.mamoki.ieojuda.domain.plan.service.PlanSnapshotService;
+import com.mamoki.ieojuda.domain.postaccess.entity.AccessToken;
+import com.mamoki.ieojuda.domain.postaccess.repository.AccessTokenRepository;
+import com.mamoki.ieojuda.domain.postaccess.repository.PackageActionCompletionRepository;
+import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
+import com.mamoki.ieojuda.domain.recipient.entity.RoleType;
+import com.mamoki.ieojuda.domain.recipient.repository.RecipientRepository;
+import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCase;
+import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCaseStatus;
+import com.mamoki.ieojuda.domain.releasecase.repository.ReleaseCaseRepository;
+import com.mamoki.ieojuda.domain.stage.entity.HandoverStage;
+import com.mamoki.ieojuda.domain.stage.entity.HandoverStageStatus;
+import com.mamoki.ieojuda.domain.stage.repository.HandoverStageRepository;
+import com.mamoki.ieojuda.global.email.contract.EmailContent;
+import com.mamoki.ieojuda.global.email.contract.EmailSendResult;
+import com.mamoki.ieojuda.global.email.sender.EmailSender;
+import com.mamoki.ieojuda.global.email.token.TokenProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+// issue #78 - HandoverStage.complete()가 호출되지 않아 발송 체인이 1단계에서 영구히 멈추던 버그의
+// 실제 수정 검증. 서비스 단위 테스트는 HandoverStageService를 목으로 대체하므로, "1단계 완료 -> 2단계
+// 메일 발송 -> 마지막 단계 완료 -> ReleaseCase.COMPLETED"라는 전체 체인이 실제로 이어지는지는
+// 이 테스트가 유일하게 검증한다.
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class StageDispatchHttpIntegrationTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private PlanRepository planRepository;
+    @Autowired
+    private ConversationRepository conversationRepository;
+    @Autowired
+    private LifeAreaRepository lifeAreaRepository;
+    @Autowired
+    private RecipientRepository recipientRepository;
+    @Autowired
+    private ItemRepository itemRepository;
+    @Autowired
+    private PlanVersionRepository planVersionRepository;
+    @Autowired
+    private ReleaseCaseRepository releaseCaseRepository;
+    @Autowired
+    private HandoverStageRepository handoverStageRepository;
+    @Autowired
+    private AccessTokenRepository accessTokenRepository;
+    @Autowired
+    private PackageActionCompletionRepository packageActionCompletionRepository;
+    @Autowired
+    private EmailLogRepository emailLogRepository;
+    @Autowired
+    private PlanSnapshotService planSnapshotService;
+
+    @MockitoBean
+    private EmailSender emailSender;
+
+    private final HttpClient httpClient = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build();
+
+    private User user;
+    private Plan plan;
+    private Recipient recipient1;
+    private Recipient recipient2;
+    private Item item1;
+    private Item item2;
+    private HandoverStage stage1;
+    private HandoverStage stage2;
+    private ReleaseCase releaseCase;
+    private PlanVersion planVersion;
+
+    @BeforeEach
+    void setUp() {
+        when(emailSender.send(anyString(), any(EmailContent.class))).thenReturn(EmailSendResult.success("msg-dispatch-test"));
+
+        user = userRepository.saveAndFlush(User.builder()
+                .email("stage-dispatch-" + UUID.randomUUID() + "@test.com").password("hash").name("김나무").build());
+        plan = planRepository.saveAndFlush(Plan.builder().user(user).build());
+        Conversation conversation = conversationRepository.saveAndFlush(Conversation.builder().plan(plan).build());
+        LifeArea lifeArea = lifeAreaRepository.saveAndFlush(
+                LifeArea.builder().plan(plan).conversation(conversation).category(LifeAreaCategory.RELATIONSHIP_CLEANUP).build());
+
+        recipient1 = recipientRepository.saveAndFlush(Recipient.builder()
+                .plan(plan).lifeArea(lifeArea).name("담당자1").email("stage1-" + UUID.randomUUID() + "@test.com")
+                .roleType(RoleType.RELATIONSHIP_MANAGER).isBackup(false)
+                .disclosureScope(DisclosureScope.RELATIONSHIP).maxWaitHours(168).backupFor(null).build());
+        recipient2 = recipientRepository.saveAndFlush(Recipient.builder()
+                .plan(plan).lifeArea(lifeArea).name("담당자2").email("stage2-" + UUID.randomUUID() + "@test.com")
+                .roleType(RoleType.WORK_MANAGER).isBackup(false)
+                .disclosureScope(DisclosureScope.WORK).maxWaitHours(168).backupFor(null).build());
+
+        item1 = itemRepository.saveAndFlush(Item.builder()
+                .lifeArea(lifeArea).targetName("대상1").locationType("이메일").action("정리")
+                .title("업무 메일 정리").content("정리").precondition("")
+                .disclosureScope(DisclosureScope.RELATIONSHIP).sourceExcerpt("근거")
+                .sortOrder(0).actionType(ItemActionType.TRANSFER).build());
+        item1.assignRecipient(recipient1);
+        item1 = itemRepository.saveAndFlush(item1);
+
+        item2 = itemRepository.saveAndFlush(Item.builder()
+                .lifeArea(lifeArea).targetName("대상2").locationType("클라우드").action("이전")
+                .title("자료 이전").content("이전").precondition("")
+                .disclosureScope(DisclosureScope.WORK).sourceExcerpt("근거2")
+                .sortOrder(1).actionType(ItemActionType.TRANSFER).build());
+        item2.assignRecipient(recipient2);
+        item2 = itemRepository.saveAndFlush(item2);
+
+        PlanSnapshotDto snapshot = planSnapshotService.buildSnapshot(plan);
+        String snapshotData = planSnapshotService.serialize(snapshot);
+        planVersion = planVersionRepository.saveAndFlush(
+                PlanVersion.builder().plan(plan).versionNum(1).snapshotData(snapshotData).build());
+        planVersion.seal(planSnapshotService.hash(snapshotData));
+        planVersion = planVersionRepository.saveAndFlush(planVersion);
+
+        releaseCase = releaseCaseRepository.saveAndFlush(ReleaseCase.builder().plan(plan).planVersion(planVersion).build());
+
+        stage1 = handoverStageRepository.saveAndFlush(HandoverStage.builder().plan(plan).recipient(recipient1).stageOrder(0).build());
+        stage1.assignToCase(releaseCase);
+        stage1.send(); // 1단계는 이미 발송된 상태로 시작
+        stage1 = handoverStageRepository.saveAndFlush(stage1);
+
+        stage2 = handoverStageRepository.saveAndFlush(HandoverStage.builder().plan(plan).recipient(recipient2).stageOrder(1).build());
+        stage2.assignToCase(releaseCase);
+        stage2 = handoverStageRepository.saveAndFlush(stage2); // 2단계는 PENDING 그대로 (아직 발송 전)
+    }
+
+    @AfterEach
+    void tearDown() {
+        emailLogRepository.findByPlan_PlanIdOrderBySentAtDesc(plan.getPlanId()).forEach(emailLogRepository::delete);
+        packageActionCompletionRepository.findByHandoverStage_StageId(stage1.getStageId()).forEach(packageActionCompletionRepository::delete);
+        packageActionCompletionRepository.findByHandoverStage_StageId(stage2.getStageId()).forEach(packageActionCompletionRepository::delete);
+        accessTokenRepository.findAll().stream()
+                .filter(t -> List.of(stage1.getStageId(), stage2.getStageId()).contains(t.getHandoverStage().getStageId()))
+                .forEach(accessTokenRepository::delete);
+        // HTTP 호출로 실제 서버가 별도 영속성 컨텍스트에서 stage1/2, releaseCase의 @Version을 올려놨으므로,
+        // 이 테스트가 들고 있는(버전이 낡은) 인스턴스로 delete(entity)를 호출하면 낙관적 잠금 충돌이 난다.
+        handoverStageRepository.deleteById(stage1.getStageId());
+        handoverStageRepository.deleteById(stage2.getStageId());
+        releaseCaseRepository.deleteById(releaseCase.getCaseId());
+        planVersionRepository.delete(planVersion);
+        itemRepository.delete(item1);
+        itemRepository.delete(item2);
+        recipientRepository.delete(recipient1);
+        recipientRepository.delete(recipient2);
+        lifeAreaRepository.findByPlan_PlanId(plan.getPlanId()).forEach(lifeAreaRepository::delete);
+        conversationRepository.findByPlan_PlanId(plan.getPlanId()).forEach(conversationRepository::delete);
+        planRepository.delete(plan);
+        userRepository.delete(user);
+    }
+
+    private String issueVerifiedSession(HandoverStage stage) {
+        String plainToken = "dispatch-session-" + UUID.randomUUID();
+        AccessToken accessToken = AccessToken.builder()
+                .handoverStage(stage).tokenHash(TokenProvider.hashToken(plainToken))
+                .expiresAt(LocalDateTime.now().plusHours(1)).build();
+        accessToken.verify();
+        accessTokenRepository.saveAndFlush(accessToken);
+        return plainToken;
+    }
+
+    @Test
+    void completingLastActionOfStage_dispatchesNextStage_andCompletesCaseAfterLastStage() throws Exception {
+        // 1단계 담당자가 자신의 유일한 행동을 완료 -> 2단계가 자동으로 열려야 한다(완료조건 1)
+        String stage1Session = issueVerifiedSession(stage1);
+        HttpResponse<String> completeStage1 = post(
+                "/api/posthumous-packages/" + stage1Session + "/actions/" + item1.getItemId() + "/complete");
+        assertThat(completeStage1.statusCode()).isEqualTo(200);
+
+        HandoverStage reloadedStage1 = handoverStageRepository.findById(stage1.getStageId()).orElseThrow();
+        assertThat(reloadedStage1.getStatus()).isEqualTo(HandoverStageStatus.COMPLETED);
+
+        HandoverStage reloadedStage2 = handoverStageRepository.findById(stage2.getStageId()).orElseThrow();
+        assertThat(reloadedStage2.getStatus()).isEqualTo(HandoverStageStatus.SENT);
+        assertThat(emailLogRepository.findByPlan_PlanIdOrderBySentAtDesc(plan.getPlanId()))
+                .anyMatch(log -> log.getHandoverStage().getStageId().equals(stage2.getStageId()));
+
+        ReleaseCase reloadedCase = releaseCaseRepository.findById(releaseCase.getCaseId()).orElseThrow();
+        assertThat(reloadedCase.getStatus()).isNotEqualTo(ReleaseCaseStatus.COMPLETED); // 아직 2단계가 안 끝남
+
+        // 2단계(마지막 단계) 담당자가 완료 -> 사건 전체가 COMPLETED 되어야 한다(완료조건 2)
+        String stage2Session = issueVerifiedSession(reloadedStage2);
+        HttpResponse<String> completeStage2 = post(
+                "/api/posthumous-packages/" + stage2Session + "/actions/" + item2.getItemId() + "/complete");
+        assertThat(completeStage2.statusCode()).isEqualTo(200);
+
+        ReleaseCase finalCase = releaseCaseRepository.findById(releaseCase.getCaseId()).orElseThrow();
+        assertThat(finalCase.getStatus()).isEqualTo(ReleaseCaseStatus.COMPLETED);
+        assertThat(finalCase.getCompletedAt()).isNotNull();
+    }
+
+    // issue #78 완료 조건 - "BLOCKED 상태에서는 다음 단계가 자동 활성화되지 않는다"
+    @Test
+    void whenStageIsBlocked_completingItsActionDoesNotOpenNextStage() throws Exception {
+        stage1.block();
+        stage1 = handoverStageRepository.saveAndFlush(stage1);
+        String plainToken = "blocked-session-" + UUID.randomUUID();
+        // BLOCKED 이전에 발급됐던 세션이 아직 살아있는 극단적 상황을 가정해 서비스 계층 가드까지 검증
+        AccessToken accessToken = AccessToken.builder()
+                .handoverStage(stage1).tokenHash(TokenProvider.hashToken(plainToken))
+                .expiresAt(LocalDateTime.now().plusHours(1)).build();
+        accessToken.verify();
+        accessTokenRepository.saveAndFlush(accessToken);
+
+        post("/api/posthumous-packages/" + plainToken + "/actions/" + item1.getItemId() + "/complete");
+
+        HandoverStage reloadedStage2 = handoverStageRepository.findById(stage2.getStageId()).orElseThrow();
+        assertThat(reloadedStage2.getStatus()).isEqualTo(HandoverStageStatus.PENDING); // 열리지 않았어야 한다
+        assertThat(emailLogRepository.findByPlan_PlanIdOrderBySentAtDesc(plan.getPlanId()))
+                .noneMatch(log -> log.getHandoverStage().getStageId().equals(stage2.getStageId()));
+    }
+
+    private HttpResponse<String> post(String path) throws Exception {
+        return httpClient.send(HttpRequest.newBuilder(uri(path))
+                .POST(HttpRequest.BodyPublishers.noBody()).build(), HttpResponse.BodyHandlers.ofString());
+    }
+
+    private URI uri(String path) {
+        return URI.create("http://127.0.0.1:" + port + path);
+    }
+}


### PR DESCRIPTION
## 연관 Issue
Closes #78

## 요약
`HandoverStage.complete()`가 정의만 되고 코드베이스 어디에서도 호출되지 않아 발송 체인이 1단계에서 영구히 멈추던 버그를 수정했습니다. 행동 완료(#77) 시 단계의 모든 항목이 끝났는지 확인해 단계를 완료 처리하고, 다음 순서 담당자에게 자동 발송하며, 마지막 단계면 `ReleaseCase`를 완료 처리합니다.

## 작업 내용
- `PosthumousPackageService.completeAction()`에서 행동 저장 직후 `HandoverStageService.completeStageIfAllActionsDone()` 호출
- `HandoverStageService.completeStageIfAllActionsDone(stageId, totalActionCount)` 신설 - 단계를 완료 처리하고 다음 단계로 이어감
- `ReleaseCase.complete()` 신설 - 마지막 단계 완료 시 사건을 `COMPLETED`로 전환
- `HandoverStageRepository`에 다음 단계 조회 + **비관적 잠금(`PESSIMISTIC_WRITE`) 조회** 추가
- **동시 완료 요청 중복 발송 방지**: 같은 단계의 서로 다른 행동이 동시에 완료 요청되면 "전부 완료 판정 → 단계 완료 → 다음 단계 발송"이 중복 실행될 수 있어(호출자가 넘긴 개수를 신뢰하지 않고), 단계 행에 `EvidenceSubmitService`/`ReleaseCaseGuardService`와 동일한 비관적 잠금 패턴을 적용하고 잠금 안에서 완료 개수를 다시 셈
- `BLOCKED`(대체 담당자 없음) 등 `SENT`가 아닌 상태에서는 아예 완료 판정을 건너뛰어 "BLOCKED는 다음 단계를 열지 않는다" 규칙을 강제

## 범위
### 포함:
- 이슈 본문의 4개 작업 항목 전부

### 제외:
- 패키지 조회·행동 완료 API 자체 (#77, 이미 있음 - 호출만 추가)
- 대체 담당자 전환 로직 (이미 `HandoverStageService.fallback()`에 구현됨, 손대지 않음)
- 사후 인계 메일 문구의 "대체 담당자로 지정되었습니다" 하드코딩 오류 수정 - 다음 단계 발송도 기존 `sendHandoffInvite()`를 그대로 재사용해서 이 알려진 버그를 그대로 물려받습니다. md 스펙 문서의 `InviteKind` 구분은 별도 이슈(#79)의 몫이라 이번 PR에서는 다루지 않았습니다.

## 완료 조건 체크
- [x] 1단계 완료 시 2단계 담당자에게 메일이 발송된다
- [x] 마지막 단계까지 완료하면 `ReleaseCase.status`가 `COMPLETED`가 된다
- [x] `BLOCKED` 상태에서는 다음 단계가 자동 활성화되지 않는다
- [x] `HandoverStage.complete()`가 실제로 호출되는 경로가 존재한다

## 테스트
- `HandoverStageServiceTest` 5건 - 미완료/완료+다음발송/마지막단계+사건완료/중복방지/BLOCKED 가드
- `StageDispatchHttpIntegrationTest` 2건 (신규) - 실제 서버로 1단계 완료 → 2단계 메일 발송 → 2단계 완료 → 사건 COMPLETED까지 전체 체인을 끝까지 검증, BLOCKED 단계에서 다음 단계가 안 열리는 것도 실제 HTTP로 확인
- 기존 `PosthumousPackageServiceTest`/`PosthumousPackageHttpIntegrationTest`에 새 의존성 반영 (테스트 cleanup에서 낙관적 잠금 충돌 나던 것도 함께 수정 - #78로 단계/사건 버전이 올라갈 수 있어짐)
- 전체 스위트 168건 통과, 회귀 없음