### PR TITLE
[Fix/#79] 최초 사후 인계 이메일의 대체 담당자 문구 및 링크 오류 수정

### DIFF
--- a/src/main/java/com/mamoki/ieojuda/domain/stage/service/HandoverStageService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/stage/service/HandoverStageService.java
@@ -75,7 +75,7 @@ public class HandoverStageService {
         }
 
         stage.fallbackTo(backup);
-        sendHandoffInvite(stage, backup);
+        sendHandoffInvite(stage, backup, InviteKind.FALLBACK);
 
         return HandoverStageResponse.from(stage);
     }
@@ -98,7 +98,7 @@ public class HandoverStageService {
 
         if (!stages.isEmpty()) {
             HandoverStage firstStage = stages.get(0);
-            sendHandoffInvite(firstStage, firstStage.getRecipient());
+            sendHandoffInvite(firstStage, firstStage.getRecipient(), InviteKind.INITIAL);
         }
     }
 
@@ -135,22 +135,31 @@ public class HandoverStageService {
             stage.getReleaseCase().complete();
             return;
         }
-        sendHandoffInvite(next, next.getRecipient());
+        // 정상적으로 자기 순서가 돌아온 것이지 대체 담당자로 전환된 게 아니므로 INITIAL
+        sendHandoffInvite(next, next.getRecipient(), InviteKind.INITIAL);
     }
 
-    private void sendHandoffInvite(HandoverStage stage, Recipient recipient) {
+    // issue #79 - 최초 발송(INITIAL)과 대체 담당자 전환(FALLBACK)은 문구가 달라야 한다.
+    // 링크도 생전 역할 수락 화면이 아니라 사후 인증 화면(/posthumous-access/{token}, issue #76)을 가리킨다.
+    private void sendHandoffInvite(HandoverStage stage, Recipient recipient, InviteKind kind) {
         String plainToken = TokenProvider.generatePlainToken();
         LocalDateTime expiresAt = LocalDateTime.now().plusHours(appProperties.getInviteTokenTtlHours());
         recipient.issueInviteToken(TokenProvider.hashToken(plainToken), expiresAt);
 
-        String secureLink = appProperties.getBaseUrl() + "/recipient-acceptances/" + plainToken;
-        EmailContent content = EmailBuilder.build(
-                "사후 인계 안내 (대체 담당자)",
-                "이전 담당자가 응답하지 않아 대체 담당자로 지정되었습니다. 역할 수락 여부를 확인해 주세요.",
-                expiresAt.atZone(ZoneId.systemDefault()),
-                secureLink,
-                appProperties.getContactEmail()
-        );
+        String secureLink = appProperties.getBaseUrl() + "/posthumous-access/" + plainToken;
+        EmailContent content = kind == InviteKind.INITIAL
+                ? EmailBuilder.build(
+                        "사후 인계 안내",
+                        recipient.getRoleType().label() + " 역할로 전달드릴 내용이 있습니다. 본인 확인 후 확인해 주세요.",
+                        expiresAt.atZone(ZoneId.systemDefault()),
+                        secureLink,
+                        appProperties.getContactEmail())
+                : EmailBuilder.build(
+                        "사후 인계 안내 (대체 담당자)",
+                        "이전 담당자가 응답하지 않아 대체 담당자로 지정되었습니다. 역할 수락 여부를 확인해 주세요.",
+                        expiresAt.atZone(ZoneId.systemDefault()),
+                        secureLink,
+                        appProperties.getContactEmail());
         EmailSendResult result = emailSender.send(recipient.getEmail(), content);
 
         emailLogRepository.save(EmailLog.builder()

--- a/src/main/java/com/mamoki/ieojuda/domain/stage/service/InviteKind.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/stage/service/InviteKind.java
@@ -1,0 +1,7 @@
+package com.mamoki.ieojuda.domain.stage.service;
+
+// issue #79 - 사후 인계 이메일이 최초 발송인지 대체 담당자 전환인지에 따라 문구가 달라야 한다.
+public enum InviteKind {
+    INITIAL,  // 이 담당자의 순서가 정상적으로 돌아옴 (최초 발송 / 다음 단계로 진행)
+    FALLBACK  // 이전 담당자가 응답하지 않아 대체 담당자로 전환됨
+}

--- a/src/test/java/com/mamoki/ieojuda/domain/stage/service/HandoverStageServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/stage/service/HandoverStageServiceTest.java
@@ -1,10 +1,12 @@
 package com.mamoki.ieojuda.domain.stage.service;
 
+import com.mamoki.ieojuda.domain.account.entity.AdminPermission;
 import com.mamoki.ieojuda.domain.audit.repository.EmailLogRepository;
 import com.mamoki.ieojuda.domain.plan.entity.Plan;
 import com.mamoki.ieojuda.domain.plan.entity.PlanVersion;
 import com.mamoki.ieojuda.domain.postaccess.repository.PackageActionCompletionRepository;
 import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
+import com.mamoki.ieojuda.domain.recipient.entity.RoleType;
 import com.mamoki.ieojuda.domain.recipient.repository.RecipientRepository;
 import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCase;
 import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCaseStatus;
@@ -12,17 +14,21 @@ import com.mamoki.ieojuda.domain.releasecase.repository.ReleaseCaseRepository;
 import com.mamoki.ieojuda.domain.stage.entity.HandoverStage;
 import com.mamoki.ieojuda.domain.stage.repository.HandoverStageRepository;
 import com.mamoki.ieojuda.global.config.AppProperties;
+import com.mamoki.ieojuda.global.email.contract.EmailContent;
 import com.mamoki.ieojuda.global.email.contract.EmailSendResult;
 import com.mamoki.ieojuda.global.email.sender.EmailSender;
 import com.mamoki.ieojuda.global.security.PermissionGuard;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -61,12 +67,15 @@ class HandoverStageServiceTest {
 
         when(appProperties.getContactEmail()).thenReturn("support@ieoduda.example");
         when(appProperties.getInviteTokenTtlHours()).thenReturn(72L);
+        when(appProperties.getBaseUrl()).thenReturn("https://ieoduda.example");
         when(emailSender.send(anyString(), any())).thenReturn(EmailSendResult.success("msg-1"));
         when(emailLogRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(handoverStageRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
 
         Plan plan = mock(Plan.class);
         PlanVersion planVersion = mock(PlanVersion.class);
         releaseCase = ReleaseCase.builder().plan(plan).planVersion(planVersion).build();
+        setId(releaseCase, "caseId", 2L);
 
         Recipient recipient = mock(Recipient.class);
         when(recipient.getEmail()).thenReturn("target@test.com");
@@ -75,6 +84,16 @@ class HandoverStageServiceTest {
         currentStage.send(); // 활성 발송 상태(SENT)에서 시작
 
         when(handoverStageRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(currentStage));
+    }
+
+    private void setId(Object entity, String fieldName, Long id) {
+        try {
+            var field = entity.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(entity, id);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Test
@@ -93,17 +112,26 @@ class HandoverStageServiceTest {
 
         Recipient nextRecipient = mock(Recipient.class);
         when(nextRecipient.getEmail()).thenReturn("next@test.com");
+        when(nextRecipient.getRoleType()).thenReturn(RoleType.WORK_MANAGER);
         HandoverStage nextStage = HandoverStage.builder().plan(currentStage.getPlan()).recipient(nextRecipient).stageOrder(1).build();
         nextStage.assignToCase(releaseCase);
-        when(handoverStageRepository.findFirstByReleaseCase_CaseIdAndStageOrderGreaterThanOrderByStageOrderAsc(any(), org.mockito.ArgumentMatchers.eq(0)))
+        when(handoverStageRepository.findFirstByReleaseCase_CaseIdAndStageOrderGreaterThanOrderByStageOrderAsc(any(), eq(0)))
                 .thenReturn(Optional.of(nextStage));
 
         handoverStageService.completeStageIfAllActionsDone(1L, 2);
 
         assertThat(currentStage.getStatus()).isEqualTo(com.mamoki.ieojuda.domain.stage.entity.HandoverStageStatus.COMPLETED);
         assertThat(nextStage.getStatus()).isEqualTo(com.mamoki.ieojuda.domain.stage.entity.HandoverStageStatus.SENT);
-        verify(emailSender).send(org.mockito.ArgumentMatchers.eq("next@test.com"), any());
         assertThat(releaseCase.getStatus()).isNotEqualTo(ReleaseCaseStatus.COMPLETED);
+
+        // issue #79 - 다음 단계로 자기 순서가 온 것뿐이니 대체 담당자 문구가 아니라 최초 발송 문구를 받아야 한다
+        ArgumentCaptor<EmailContent> captor = ArgumentCaptor.forClass(EmailContent.class);
+        verify(emailSender).send(eq("next@test.com"), captor.capture());
+        EmailContent content = captor.getValue();
+        assertThat(content.body()).doesNotContain("대체 담당자로 지정되었습니다");
+        assertThat(content.body()).contains("업무 담당자 역할로 전달드릴 내용이 있습니다");
+        assertThat(content.body()).contains("https://ieoduda.example/posthumous-access/");
+        assertThat(content.body()).doesNotContain("/recipient-acceptances/");
     }
 
     @Test
@@ -144,5 +172,47 @@ class HandoverStageServiceTest {
         verify(emailSender, never()).send(anyString(), any());
         verify(handoverStageRepository, never())
                 .findFirstByReleaseCase_CaseIdAndStageOrderGreaterThanOrderByStageOrderAsc(any(), any());
+    }
+
+    // issue #79 완료 조건 - "1단계 담당자가 대체 담당자 문구를 받지 않는다" + 사후 인증 화면 링크로 연결
+    @Test
+    void createStagesAndDispatchFirst_sendsInitialWordingNotFallbackWording() {
+        Recipient firstRecipient = mock(Recipient.class);
+        when(firstRecipient.getEmail()).thenReturn("first@test.com");
+        when(firstRecipient.getRoleType()).thenReturn(RoleType.FAMILY_MANAGER);
+
+        handoverStageService.createStagesAndDispatchFirst(releaseCase, List.of(firstRecipient));
+
+        ArgumentCaptor<EmailContent> captor = ArgumentCaptor.forClass(EmailContent.class);
+        verify(emailSender).send(eq("first@test.com"), captor.capture());
+        EmailContent content = captor.getValue();
+        assertThat(content.subject()).doesNotContain("대체 담당자");
+        assertThat(content.body()).doesNotContain("이전 담당자가 응답하지 않아");
+        assertThat(content.body()).contains("가족 담당자 역할로 전달드릴 내용이 있습니다");
+        assertThat(content.body()).contains("/posthumous-access/");
+    }
+
+    // issue #79 완료 조건 - "대체 담당자는 기존 문구를 그대로 받는다" + 링크만 사후 인증 화면으로 교체
+    @Test
+    void fallback_sendsFallbackWordingUnchangedButWithPosthumousAccessLink() {
+        Long userId = 1L, caseId = 2L, stageId = 3L;
+        when(permissionGuard.require(userId, AdminPermission.CASE_SUPERVISE)).thenReturn(null);
+        when(releaseCaseRepository.findById(caseId)).thenReturn(Optional.of(releaseCase));
+        currentStage.assignToCase(releaseCase);
+        when(handoverStageRepository.findById(stageId)).thenReturn(Optional.of(currentStage));
+
+        Recipient backup = mock(Recipient.class);
+        when(backup.getEmail()).thenReturn("backup@test.com");
+        when(recipientRepository.findByBackupFor_AssigneeId(any())).thenReturn(Optional.of(backup));
+
+        handoverStageService.fallback(userId, caseId, stageId);
+
+        ArgumentCaptor<EmailContent> captor = ArgumentCaptor.forClass(EmailContent.class);
+        verify(emailSender).send(eq("backup@test.com"), captor.capture());
+        EmailContent content = captor.getValue();
+        assertThat(content.subject()).contains("대체 담당자");
+        assertThat(content.body()).contains("이전 담당자가 응답하지 않아 대체 담당자로 지정되었습니다. 역할 수락 여부를 확인해 주세요.");
+        assertThat(content.body()).contains("/posthumous-access/");
+        assertThat(content.body()).doesNotContain("/recipient-acceptances/");
     }
 }

--- a/src/test/java/com/mamoki/ieojuda/domain/stage/service/StageDispatchHttpIntegrationTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/stage/service/StageDispatchHttpIntegrationTest.java
@@ -54,6 +54,7 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 // issue #78 - HandoverStage.complete()가 호출되지 않아 발송 체인이 1단계에서 영구히 멈추던 버그의
@@ -213,6 +214,13 @@ class StageDispatchHttpIntegrationTest {
         assertThat(reloadedStage2.getStatus()).isEqualTo(HandoverStageStatus.SENT);
         assertThat(emailLogRepository.findByPlan_PlanIdOrderBySentAtDesc(plan.getPlanId()))
                 .anyMatch(log -> log.getHandoverStage().getStageId().equals(stage2.getStageId()));
+
+        // issue #79 - 2단계는 정상적으로 자기 순서가 온 것이지 대체 담당자 전환이 아니므로 최초 발송 문구를 받아야 한다
+        org.mockito.ArgumentCaptor<EmailContent> stage2EmailCaptor = org.mockito.ArgumentCaptor.forClass(EmailContent.class);
+        verify(emailSender).send(org.mockito.ArgumentMatchers.eq(recipient2.getEmail()), stage2EmailCaptor.capture());
+        assertThat(stage2EmailCaptor.getValue().body()).doesNotContain("대체 담당자로 지정되었습니다");
+        assertThat(stage2EmailCaptor.getValue().body()).contains("/posthumous-access/");
+        assertThat(stage2EmailCaptor.getValue().body()).doesNotContain("/recipient-acceptances/");
 
         ReleaseCase reloadedCase = releaseCaseRepository.findById(releaseCase.getCaseId()).orElseThrow();
         assertThat(reloadedCase.getStatus()).isNotEqualTo(ReleaseCaseStatus.COMPLETED); // 아직 2단계가 안 끝남


### PR DESCRIPTION
## 연관 Issue
Closes #79

## 요약
`HandoverStageService.sendHandoffInvite()`가 최초 발송과 대체 담당자 전환에 같은(대체 담당자용) 문구를 썼고, 링크도 생전용 역할 수락 화면(`/recipient-acceptances/{token}`)을 가리키던 버그를 수정했습니다.

## 작업 내용
- `InviteKind` enum(`INITIAL`/`FALLBACK`) 신설
- `sendHandoffInvite(stage, recipient, kind)`로 시그니처 변경 - 최초/대체 문구 분기
- 최초 발송 문구: "{역할명} 역할로 전달드릴 내용이 있습니다. 본인 확인 후 확인해 주세요." (md 스펙 예시는 `recipient.getRoleType()` 원시 enum을 그대로 썼는데, 실제 이메일 품질을 위해 #77에서 만든 `RoleType.label()`(한글 표기)을 대신 사용했습니다)
- 대체 전환 문구: 기존 내용 그대로 유지 (완료조건 "대체 담당자는 기존 문구를 그대로 받는다")
- `secureLink`를 `/posthumous-access/{plainToken}`으로 교체 (#76에서 만든 인증 화면)
- **호출부 3곳** 전부 갱신: `createStagesAndDispatchFirst()`→`INITIAL`, `fallback()`→`FALLBACK`, 그리고 #78에서 새로 추가된 `dispatchNextOrCompleteCase()`(단계 완료 후 다음 담당자 발송)→`INITIAL`. 세 번째는 이슈 작성 시점(#78 이전)엔 없던 호출부라 이슈 본문엔 언급이 없지만, 시그니처를 바꾸는 이상 반드시 함께 고쳐야 해서 포함했습니다.

## 범위
### 포함:
- 최초 발송과 대체 담당자 전환의 메일 문구 분리
- 사후 인계 링크를 `/posthumous-access/{token}`으로 교체

### 제외:
- 링크가 가리킬 인증 API 구현 (#76, 이미 완료)

## 완료 조건 체크
- [x] 1단계 담당자가 대체 담당자 문구를 받지 않는다
- [x] 대체 담당자는 기존 문구를 그대로 받는다
- [x] 두 메일 모두 사후 인계 인증 화면으로 연결된다
- [x] 이메일 본문에 대상 목록·자료 위치·업무 세부사항이 포함되지 않는다 (기존 `EmailBuilder` 템플릿이 애초에 그런 데이터를 받지 않아 구조적으로 보장됨)

## 테스트
- `HandoverStageServiceTest`에 3건 추가: `createStagesAndDispatchFirst`/`fallback`/다음단계발송 각각의 이메일 본문·링크 검증 (기존 대체 담당자 관련 테스트가 하나도 없어서 이번에 처음 커버)
- `StageDispatchHttpIntegrationTest`에 실제 HTTP 흐름에서 2단계로 넘어갈 때의 이메일 본문·링크 검증 추가
- 전체 스위트 170건 통과, 회귀 없음

## 머지
말씀하신 대로 이번 PR은 **승인 전까지 머지하지 않습니다.**