### PR TITLE
[Feat/#80] 증빙 30일 초과 미삭제 보안 경보 추가

### DIFF
--- a/src/main/java/com/mamoki/ieojuda/domain/evidence/scheduler/EvidenceDeletionScheduler.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/evidence/scheduler/EvidenceDeletionScheduler.java
@@ -27,6 +27,10 @@ public class EvidenceDeletionScheduler {
     private final EvidenceStorageClient evidenceStorageClient;
     private final AdminActionAuditService adminActionAuditService;
 
+    // issue #80 - 삭제 예정일을 30일 넘게 초과한 건은 반복 삭제 실패를 뜻한다 - 재시도와 별개로
+    // 운영자가 알아챌 수 있도록 보안 경보를 남긴다.
+    private static final int SECURITY_ALERT_GRACE_DAYS = 30;
+
     // 10분마다 - 대기기간이 일 단위인 도메인 특성상 촘촘한 주기가 필요하지 않음
     @Scheduled(fixedRate = 600_000)
     @Transactional
@@ -34,7 +38,17 @@ public class EvidenceDeletionScheduler {
         List<Evidence> dueEvidences = evidenceRepository.findDueForDeletionForUpdateSkipLocked(LocalDateTime.now());
 
         for (Evidence evidence : dueEvidences) {
+            alertIfSeverelyOverdue(evidence);
             deleteOne(evidence);
+        }
+    }
+
+    // 삭제 예정일(deleteScheduledAt) 기준으로 다시 30일이 더 지났는데도 아직 삭제되지 않았다면
+    // (반복 삭제 실패가 누적된 상태) 매 주기 경보를 남긴다.
+    private void alertIfSeverelyOverdue(Evidence evidence) {
+        if (evidence.getDeleteScheduledAt().plusDays(SECURITY_ALERT_GRACE_DAYS).isBefore(LocalDateTime.now())) {
+            log.error("[SECURITY ALERT] 증빙 원본 미삭제 30일 초과. evidenceId={}, deleteScheduledAt={}",
+                    evidence.getEvidenceId(), evidence.getDeleteScheduledAt());
         }
     }
 

--- a/src/test/java/com/mamoki/ieojuda/domain/evidence/entity/EvidenceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/evidence/entity/EvidenceTest.java
@@ -1,0 +1,54 @@
+package com.mamoki.ieojuda.domain.evidence.entity;
+
+import com.mamoki.ieojuda.domain.confirmer.entity.Confirmer;
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCase;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+// issue #80 완료 조건 - "삭제 후에도 무결성 해시와 감사 기록은 유지되는지 확인"
+class EvidenceTest {
+
+    @Test
+    void approve_schedulesDeletionThirtyDaysAfterReview() {
+        Evidence evidence = Evidence.builder()
+                .confirmer(mock(Confirmer.class)).plan(mock(Plan.class)).releaseCase(mock(ReleaseCase.class))
+                .storageKey("evidence/1/proof.pdf").fileName("proof.pdf").mimeType("application/pdf")
+                .integrityHash("hash-abc").build();
+
+        evidence.approve();
+
+        assertThat(evidence.getDeleteScheduledAt()).isEqualTo(evidence.getReviewedAt().plusDays(30));
+    }
+
+    @Test
+    void markDeleted_clearsOnlyDeletedAtAndFailureReason_preservesAuditFields() {
+        Evidence evidence = Evidence.builder()
+                .confirmer(mock(Confirmer.class)).plan(mock(Plan.class)).releaseCase(mock(ReleaseCase.class))
+                .storageKey("evidence/1/proof.pdf").fileName("proof.pdf").mimeType("application/pdf")
+                .integrityHash("hash-abc").build();
+        evidence.approve();
+        evidence.markDeleteFailed("first attempt failed");
+
+        LocalDateTime submittedAtBefore = evidence.getSubmittedAt();
+        LocalDateTime reviewedAtBefore = evidence.getReviewedAt();
+        LocalDateTime deleteScheduledAtBefore = evidence.getDeleteScheduledAt();
+        EvidenceReviewStatus reviewStatusBefore = evidence.getReviewStatus();
+        String integrityHashBefore = evidence.getIntegrityHash();
+
+        evidence.markDeleted();
+
+        // 원본 파일만 지워지는 개념이라 - 영구 감사 기록(명세서 "증빙 보관 및 삭제 정책")은 그대로 남아야 한다
+        assertThat(evidence.getDeletedAt()).isNotNull();
+        assertThat(evidence.getFailureReason()).isNull();
+        assertThat(evidence.getSubmittedAt()).isEqualTo(submittedAtBefore);
+        assertThat(evidence.getReviewedAt()).isEqualTo(reviewedAtBefore);
+        assertThat(evidence.getDeleteScheduledAt()).isEqualTo(deleteScheduledAtBefore);
+        assertThat(evidence.getReviewStatus()).isEqualTo(reviewStatusBefore);
+        assertThat(evidence.getIntegrityHash()).isEqualTo(integrityHashBefore);
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/domain/evidence/scheduler/EvidenceDeletionSchedulerTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/evidence/scheduler/EvidenceDeletionSchedulerTest.java
@@ -1,5 +1,9 @@
 package com.mamoki.ieojuda.domain.evidence.scheduler;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.mamoki.ieojuda.domain.audit.entity.AdminActionType;
 import com.mamoki.ieojuda.domain.audit.service.AdminActionAuditService;
 import com.mamoki.ieojuda.domain.evidence.entity.Evidence;
@@ -9,9 +13,12 @@ import com.mamoki.ieojuda.global.exception.ErrorCode;
 import com.mamoki.ieojuda.global.storage.EvidenceStorageClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -52,6 +59,7 @@ class EvidenceDeletionSchedulerTest {
     void deleteExpiredEvidences_whenStorageDeleteSucceeds_marksDeletedWithoutAuditingSuccess() {
         Evidence evidence = mock(Evidence.class);
         when(evidence.getStorageKey()).thenReturn("evidence/1/uuid.pdf");
+        when(evidence.getDeleteScheduledAt()).thenReturn(LocalDateTime.now().minusDays(1));
         when(evidenceRepository.findDueForDeletionForUpdateSkipLocked(any())).thenReturn(List.of(evidence));
 
         scheduler.deleteExpiredEvidences();
@@ -68,6 +76,7 @@ class EvidenceDeletionSchedulerTest {
         Evidence evidence = mock(Evidence.class);
         when(evidence.getEvidenceId()).thenReturn(5L);
         when(evidence.getStorageKey()).thenReturn("evidence/5/uuid.pdf");
+        when(evidence.getDeleteScheduledAt()).thenReturn(LocalDateTime.now().minusDays(1));
         when(evidenceRepository.findDueForDeletionForUpdateSkipLocked(any())).thenReturn(List.of(evidence));
         doThrow(new CustomException(ErrorCode.EVIDENCE_STORAGE_FAILED))
                 .when(evidenceStorageClient).delete("evidence/5/uuid.pdf");
@@ -84,11 +93,13 @@ class EvidenceDeletionSchedulerTest {
         Evidence failing = mock(Evidence.class);
         when(failing.getEvidenceId()).thenReturn(1L);
         when(failing.getStorageKey()).thenReturn("evidence/1/fail.pdf");
+        when(failing.getDeleteScheduledAt()).thenReturn(LocalDateTime.now().minusDays(1));
         doThrow(new RuntimeException("boom")).when(evidenceStorageClient).delete("evidence/1/fail.pdf");
 
         Evidence succeeding = mock(Evidence.class);
         when(succeeding.getEvidenceId()).thenReturn(2L);
         when(succeeding.getStorageKey()).thenReturn("evidence/2/ok.pdf");
+        when(succeeding.getDeleteScheduledAt()).thenReturn(LocalDateTime.now().minusDays(1));
 
         when(evidenceRepository.findDueForDeletionForUpdateSkipLocked(any()))
                 .thenReturn(List.of(failing, succeeding));
@@ -98,5 +109,48 @@ class EvidenceDeletionSchedulerTest {
         verify(failing).markDeleteFailed(anyString());
         verify(succeeding).markDeleted();
         verify(succeeding, never()).markDeleteFailed(anyString());
+    }
+
+    // issue #80 완료 조건 - "30일 초과 미삭제 건이 경보로 감지된다"
+    @Test
+    void deleteExpiredEvidences_whenScheduledDatePlus30DaysHasPassed_logsSecurityAlert() {
+        Evidence severelyOverdue = mock(Evidence.class);
+        when(severelyOverdue.getEvidenceId()).thenReturn(9L);
+        when(severelyOverdue.getStorageKey()).thenReturn("evidence/9/old.pdf");
+        when(severelyOverdue.getDeleteScheduledAt()).thenReturn(LocalDateTime.now().minusDays(31));
+        when(evidenceRepository.findDueForDeletionForUpdateSkipLocked(any())).thenReturn(List.of(severelyOverdue));
+
+        List<ILoggingEvent> logs = captureLogs(() -> scheduler.deleteExpiredEvidences());
+
+        assertThat(logs).anyMatch(event -> event.getLevel() == Level.ERROR
+                && event.getFormattedMessage().contains("[SECURITY ALERT]")
+                && event.getFormattedMessage().contains("evidenceId=9"));
+    }
+
+    @Test
+    void deleteExpiredEvidences_whenWithinThirtyDayGracePeriod_doesNotLogSecurityAlert() {
+        Evidence recentlyDue = mock(Evidence.class);
+        when(recentlyDue.getEvidenceId()).thenReturn(10L);
+        when(recentlyDue.getStorageKey()).thenReturn("evidence/10/recent.pdf");
+        when(recentlyDue.getDeleteScheduledAt()).thenReturn(LocalDateTime.now().minusDays(10)); // 삭제 예정일은 지났지만 +30일 유예 안
+        when(evidenceRepository.findDueForDeletionForUpdateSkipLocked(any())).thenReturn(List.of(recentlyDue));
+
+        List<ILoggingEvent> logs = captureLogs(() -> scheduler.deleteExpiredEvidences());
+
+        assertThat(logs).noneMatch(event -> event.getFormattedMessage().contains("[SECURITY ALERT]"));
+    }
+
+    private List<ILoggingEvent> captureLogs(Runnable action) {
+        Logger logger = (Logger) LoggerFactory.getLogger(EvidenceDeletionScheduler.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        try {
+            action.run();
+            return List.copyOf(appender.list);
+        } finally {
+            logger.detachAppender(appender);
+            appender.stop();
+        }
     }
 }

--- a/src/test/java/com/mamoki/ieojuda/domain/evidence/service/EvidenceDeletionServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/evidence/service/EvidenceDeletionServiceTest.java
@@ -1,0 +1,76 @@
+package com.mamoki.ieojuda.domain.evidence.service;
+
+import com.mamoki.ieojuda.domain.account.entity.AdminPermission;
+import com.mamoki.ieojuda.domain.account.entity.User;
+import com.mamoki.ieojuda.domain.audit.service.AdminActionAuditService;
+import com.mamoki.ieojuda.domain.confirmer.entity.Confirmer;
+import com.mamoki.ieojuda.domain.evidence.dto.EvidenceDeletionStatusResponse;
+import com.mamoki.ieojuda.domain.evidence.entity.Evidence;
+import com.mamoki.ieojuda.domain.evidence.repository.EvidenceRepository;
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCase;
+import com.mamoki.ieojuda.global.security.PermissionGuard;
+import com.mamoki.ieojuda.global.storage.EvidenceStorageClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+// issue #80 완료 조건 - "삭제 후 GET /api/evidence/{id}/deletion-status에 실제 삭제 시각이 나타난다"
+class EvidenceDeletionServiceTest {
+
+    private EvidenceRepository evidenceRepository;
+    private EvidenceStorageClient evidenceStorageClient;
+    private PermissionGuard permissionGuard;
+    private AdminActionAuditService adminActionAuditService;
+    private EvidenceDeletionService evidenceDeletionService;
+
+    @BeforeEach
+    void setUp() {
+        evidenceRepository = mock(EvidenceRepository.class);
+        evidenceStorageClient = mock(EvidenceStorageClient.class);
+        permissionGuard = mock(PermissionGuard.class);
+        adminActionAuditService = mock(AdminActionAuditService.class);
+        evidenceDeletionService = new EvidenceDeletionService(
+                evidenceRepository, evidenceStorageClient, permissionGuard, adminActionAuditService);
+
+        when(permissionGuard.require(any(), any())).thenReturn(mock(User.class));
+    }
+
+    @Test
+    void getStatus_afterSchedulerMarkedDeleted_exposesActualDeletionTimestamp() {
+        Evidence evidence = Evidence.builder()
+                .confirmer(mock(Confirmer.class)).plan(mock(Plan.class)).releaseCase(mock(ReleaseCase.class))
+                .storageKey("evidence/7/proof.pdf").fileName("proof.pdf").mimeType("application/pdf")
+                .integrityHash("hash-xyz").build();
+        evidence.approve();
+        evidence.markDeleted(); // 스케줄러가 실제로 지운 상황을 재현
+        when(evidenceRepository.findById(7L)).thenReturn(Optional.of(evidence));
+
+        EvidenceDeletionStatusResponse response = evidenceDeletionService.getStatus(1L, 7L);
+
+        assertThat(response.deletedAt()).isNotNull();
+        assertThat(response.integrityHash()).isEqualTo("hash-xyz");
+        assertThat(response.overdue()).isFalse(); // 이미 삭제됐으므로 경보 대상 아님
+    }
+
+    @Test
+    void getStatus_whenScheduledButNotYetDeleted_reportsOverdue() {
+        Evidence evidence = Evidence.builder()
+                .confirmer(mock(Confirmer.class)).plan(mock(Plan.class)).releaseCase(mock(ReleaseCase.class))
+                .storageKey("evidence/8/proof.pdf").fileName("proof.pdf").mimeType("application/pdf")
+                .integrityHash("hash-old").build();
+        evidence.approve(); // deleteScheduledAt = 지금 + 30일... 이므로 아직 미래 - overdue 아님을 함께 확인
+        when(evidenceRepository.findById(8L)).thenReturn(Optional.of(evidence));
+
+        EvidenceDeletionStatusResponse response = evidenceDeletionService.getStatus(1L, 8L);
+
+        assertThat(response.deletedAt()).isNull();
+        assertThat(response.overdue()).isFalse();
+    }
+}


### PR DESCRIPTION
## 연관 Issue
Closes #80

## 요약
**작업 전 확인**: `#80`이 요구하는 `EvidenceDeletionScheduler`(자동 삭제 + FOR UPDATE SKIP LOCKED + 실패 사유 기록)는 이미 팀원의 `#44`(증빙 격리 검사 및 30일 자동 삭제) 작업으로 develop에 병합되어 있었습니다. 완료조건 4개를 하나씩 재확인한 결과 **"30일 초과 미삭제 건을 보안 경보로 감지"만 빠져 있어서 그 부분만 구현했습니다.**

## 이미 되어 있던 것 (확인만 함, 코드 변경 없음)
- 삭제 예정일이 지난 증빙 자동 삭제 (`EvidenceDeletionScheduler`, 10분 주기, `FOR UPDATE SKIP LOCKED`)
- 삭제 실패 시 사유 기록 (`markDeleteFailed`) 및 재시도 대상 유지 (`deletedAt IS NULL` 조건이 곧 재시도 가드)
- `GET /api/evidence/{id}/deletion-status`에 실제 삭제 시각 노출
- 삭제 후에도 `submittedAt`/`reviewer`/`reviewStatus`/`reviewedAt`/`integrityHash` 보존 (`markDeleted()`가 `deletedAt`만 건드림)

## 이번에 추가한 것
- `EvidenceDeletionScheduler.alertIfSeverelyOverdue()` - 삭제 예정일(`deleteScheduledAt`) 기준 **추가로 30일**이 더 지났는데도 삭제 안 된 건을 매 주기 `[SECURITY ALERT]` 로그로 남김 (md 스펙 문서가 제시한 `deleteScheduledAt.plusDays(30)` 조건 그대로)
- 기존에 있던 `EvidenceDeletionStatusResponse.overdue` 필드는 "삭제 예정일 자체를 넘겼는지"만 보는 API 응답용 플래그라, 이번에 추가한 "30일 더 초과"라는 별도의 심각도 높은 경보 조건과는 다릅니다 - 서로 대체 관계가 아니라 별개로 둡니다.

## 범위
### 포함:
- 30일 초과 미삭제 보안 경보

### 제외 (이슈 명시):
- 삭제 상태 조회·재처리 API (이미 구현됨)
- 법적 보존 예외 연장 절차

## 완료 조건 체크
- [x] 삭제 예정일이 지난 증빙 원본이 자동으로 삭제된다 (기존)
- [x] 삭제 실패 시 사유가 기록되고 재처리 대상으로 조회된다 (기존)
- [x] 30일 초과 미삭제 건이 경보로 감지된다 (신규)
- [x] 삭제 후 `GET /api/evidence/{id}/deletion-status`에 실제 삭제 시각이 나타난다 (기존)

## 테스트
- `EvidenceDeletionSchedulerTest`에 Logback `ListAppender`로 실제 로그 출력을 캡처하는 테스트 2건 추가 (30일 초과 시 경보 발생 / 유예기간 내에는 미발생)
- 기존 테스트 3건이 새 메서드 호출(`getDeleteScheduledAt()`) 때문에 깨져서 스텁 추가로 함께 수정
- 전체 스위트 172건 통과, 회귀 없음

## 머지
승인 전까지 머지하지 않습니다.