### PR TITLE
[Fix/#82] 이메일 변경 시 담당자·확인자 수락 무효화 및 재검증 누락 수정

### DIFF
--- a/src/main/java/com/mamoki/ieojuda/domain/account/service/UserService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/account/service/UserService.java
@@ -79,6 +79,15 @@ public class UserService {
             throw new CustomException(ErrorCode.DUPLICATE_EMAIL);
         }
 
+        // issue #82 - 명세서 "마이페이지" 예외 처리: 진행 중인 사후 사건이 있으면 삭제와 마찬가지로
+        // 이메일 변경도 차단하고 사건을 동결해 운영 검토 대상으로 넘긴다.
+        if (emailChanged) {
+            Long planId = planRepository.findByUser_UserId(userId).map(Plan::getPlanId).orElse(null);
+            if (planId != null && releaseCaseGuardService.freezeIfActiveCaseExists(planId)) {
+                throw new CustomException(ErrorCode.ACTIVE_RELEASE_CASE_EXISTS);
+            }
+        }
+
         user.updateProfile(request.email(), request.name());
 
         // 위 존재 여부 검사와 실제 반영 사이의 경쟁 조건은 DB 유니크 제약이 최종 방어선이다 -
@@ -95,7 +104,12 @@ public class UserService {
         // 기존 초대 토큰을 전부 무효화하고(#48), 이 계정 자신의 세션도 전부 폐기한다(#56) -
         // 공격자가 이미 로그인해 있던 상태였다면 이메일 변경 직후 그 세션도 끊어내기 위함.
         if (emailChanged) {
-            planRepository.findByUser_UserId(userId).ifPresent(plan -> invalidatePlanInviteTokens(plan.getPlanId()));
+            planRepository.findByUser_UserId(userId).ifPresent(plan -> {
+                invalidatePlanInviteTokens(plan.getPlanId());
+                // issue #82 - 본인 경고 이메일은 로그인 이메일과 별개로 검증되지만, 로그인 계정이
+                // 바뀌었다면 그 주소가 여전히 본인 소유인지 다시 확인이 필요하다고 보고 초기화한다.
+                plan.invalidateSelfWarningEmailVerification();
+            });
             sessionRevocationService.revokeAllSessions(user);
         }
 

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/entity/Plan.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/entity/Plan.java
@@ -77,6 +77,11 @@ public class Plan extends BaseCreatedAtEntity {
         this.selfWarningEmailVerified = true;
     }
 
+    // issue #82 - 로그인 이메일이 바뀌면(계정 탈취 대응과 같은 이유) 본인 경고 이메일도 다시 검증이 필요하다
+    public void invalidateSelfWarningEmailVerification() {
+        this.selfWarningEmailVerified = false;
+    }
+
     // 순서 충돌이 없을 때만 서비스에서 호출 - 실행 순서를 확정
     public void confirmOrder() {
         this.orderConfirmedAt = LocalDateTime.now();

--- a/src/test/java/com/mamoki/ieojuda/domain/account/service/UserServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/account/service/UserServiceTest.java
@@ -139,6 +139,28 @@ class UserServiceTest {
         assertThat(confirmer.getInviteToken()).isNull();
         verify(disputeContact).invalidateInviteToken();
         verify(sessionRevocationService).revokeAllSessions(user);
+        // issue #82 - 로그인 이메일이 바뀌면 본인 경고 이메일도 재검증 대상이 된다
+        verify(plan).invalidateSelfWarningEmailVerification();
+    }
+
+    // issue #82 완료 조건 - "진행 중 사후 사건이 있을 때의 동작이 정의되어 있다" (계정 삭제와 동일하게 차단)
+    @Test
+    void updateProfile_whenEmailChangesAndActiveCaseExists_isBlockedAndDoesNotChangeEmail() {
+        User user = User.builder().email("old@test.com").password("hash").name("A").build();
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(userRepository.existsByEmailAndUserIdNot("new@test.com", 1L)).thenReturn(false);
+
+        Plan plan = mock(Plan.class);
+        when(plan.getPlanId()).thenReturn(10L);
+        when(planRepository.findByUser_UserId(1L)).thenReturn(Optional.of(plan));
+        when(releaseCaseGuardService.freezeIfActiveCaseExists(10L)).thenReturn(true);
+
+        assertThatThrownBy(() -> userService.updateProfile(1L, new UserUpdateRequest("new@test.com", "A")))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.ACTIVE_RELEASE_CASE_EXISTS));
+
+        assertThat(user.getEmail()).isEqualTo("old@test.com"); // 변경되지 않아야 한다
+        verifyNoInteractions(recipientRepository, confirmerRepository, disputeContactRepository, sessionRevocationService);
     }
 
     @Test

--- a/src/test/java/com/mamoki/ieojuda/domain/confirmer/entity/ConfirmerTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/confirmer/entity/ConfirmerTest.java
@@ -1,0 +1,47 @@
+package com.mamoki.ieojuda.domain.confirmer.entity;
+
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.recipient.entity.AcceptanceStatus;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+// issue #82 완료 조건 - "확인자에 대해서도 동일하게 동작한다"
+class ConfirmerTest {
+
+    private Confirmer buildAcceptedConfirmer() {
+        Confirmer confirmer = Confirmer.builder()
+                .plan(mock(Plan.class)).name("유지민").relationship(Relationship.FRIEND).email("jimin@test.com").build();
+        confirmer.issueInviteToken("old-token-hash", LocalDateTime.now().plusHours(72));
+        confirmer.accept(null);
+        return confirmer;
+    }
+
+    @Test
+    void updateContact_whenEmailChanges_resetsAcceptanceAndInvalidatesOldToken() {
+        Confirmer confirmer = buildAcceptedConfirmer();
+
+        boolean emailChanged = confirmer.updateContact("유지민", "new-email@test.com");
+
+        assertThat(emailChanged).isTrue();
+        assertThat(confirmer.getEmail()).isEqualTo("new-email@test.com");
+        assertThat(confirmer.getAcceptanceStatus()).isEqualTo(AcceptanceStatus.PENDING);
+        assertThat(confirmer.getAcceptedAt()).isNull();
+        assertThat(confirmer.getInviteToken()).isNull();
+        assertThat(confirmer.getInviteTokenExpiresAt()).isNull();
+    }
+
+    @Test
+    void updateContact_whenEmailUnchanged_keepsAcceptanceAndToken() {
+        Confirmer confirmer = buildAcceptedConfirmer();
+
+        boolean emailChanged = confirmer.updateContact("이름만변경", "jimin@test.com");
+
+        assertThat(emailChanged).isFalse();
+        assertThat(confirmer.getAcceptanceStatus()).isEqualTo(AcceptanceStatus.ACCEPTED);
+        assertThat(confirmer.getInviteToken()).isEqualTo("old-token-hash");
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/domain/recipient/entity/RecipientTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/recipient/entity/RecipientTest.java
@@ -1,0 +1,52 @@
+package com.mamoki.ieojuda.domain.recipient.entity;
+
+import com.mamoki.ieojuda.domain.plan.entity.DisclosureScope;
+import com.mamoki.ieojuda.domain.plan.entity.LifeArea;
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+// issue #82 완료 조건 - "담당자 이메일을 바꾸면 수락 상태가 초기화된다" / "변경 전에 발급된 링크로는
+// 더 이상 수락할 수 없다"
+class RecipientTest {
+
+    private Recipient buildAcceptedRecipient() {
+        Recipient recipient = Recipient.builder()
+                .plan(mock(Plan.class)).lifeArea(mock(LifeArea.class))
+                .name("이지수").email("jisoo@test.com")
+                .roleType(RoleType.RELATIONSHIP_MANAGER).isBackup(false)
+                .disclosureScope(DisclosureScope.RELATIONSHIP).maxWaitHours(168).backupFor(null).build();
+        recipient.issueInviteToken("old-token-hash", LocalDateTime.now().plusHours(72));
+        recipient.accept(null);
+        return recipient;
+    }
+
+    @Test
+    void updateContact_whenEmailChanges_resetsAcceptanceAndInvalidatesOldToken() {
+        Recipient recipient = buildAcceptedRecipient();
+
+        boolean emailChanged = recipient.updateContact("이지수", "new-email@test.com");
+
+        assertThat(emailChanged).isTrue();
+        assertThat(recipient.getEmail()).isEqualTo("new-email@test.com");
+        assertThat(recipient.getAcceptanceStatus()).isEqualTo(AcceptanceStatus.PENDING);
+        assertThat(recipient.getAcceptedAt()).isNull();
+        assertThat(recipient.getInviteToken()).isNull(); // 변경 전 발급된 링크로는 더 이상 수락 불가
+        assertThat(recipient.getInviteTokenExpiresAt()).isNull();
+    }
+
+    @Test
+    void updateContact_whenEmailUnchanged_keepsAcceptanceAndToken() {
+        Recipient recipient = buildAcceptedRecipient();
+
+        boolean emailChanged = recipient.updateContact("이름만변경", "jisoo@test.com");
+
+        assertThat(emailChanged).isFalse();
+        assertThat(recipient.getAcceptanceStatus()).isEqualTo(AcceptanceStatus.ACCEPTED);
+        assertThat(recipient.getInviteToken()).isEqualTo("old-token-hash");
+    }
+}


### PR DESCRIPTION
## 연관 Issue
Closes #82

## 요약
**작업 전 확인**: 담당자(`Recipient`)·확인자(`Confirmer`) 쪽은 이메일 변경 시 수락 무효화+토큰 삭제+재검증 메일 자동발송이 **이미 구현돼 있었습니다** (`updateContact()` + `RecipientService.updateRecipient()`/`ConfirmerService.updateConfirmer()`). 작성자(`PUT /users/me`) 쪽만 두 가지가 빠져 있어서 그 부분만 구현했습니다.

## 이미 되어 있던 것 (확인만 함, 코드 변경 없음)
- 담당자/확인자 이메일 변경 시 `acceptanceStatus` → `PENDING`, `inviteToken` 무효화, 재검증 메일 자동 발송
- 작성자 이메일 변경 시 계획에 걸린 모든 담당자/확인자/이의제기연락처의 초대 토큰 무효화 + 전체 세션 폐기 (issue #48/#56)

## 이번에 추가한 것 (둘 다 md 스펙의 "작성자(`PUT /users/me`)" 행에만 해당)
- `UserService.updateProfile()` - 이메일 변경 시 **진행 중 사후 사건이 있으면 차단** (`ReleaseCaseGuardService.freezeIfActiveCaseExists()` 재사용, `deleteAccount()`와 동일 패턴)
- `Plan.invalidateSelfWarningEmailVerification()` 신설 - 로그인 이메일이 바뀌면 본인 경고 이메일도 재검증 대상으로 초기화

## 범위
### 포함:
- 작성자 이메일 변경 시 관련 역할 재검증(본인 경고 이메일 검증 초기화 + 진행중 사건 차단)
- 담당자·확인자 이메일 변경 시 기존 수락 무효화 (기존 구현 확인)
- 발급된 초대 링크 무효화 (기존 구현 확인)

### 제외 (이슈 명시):
- 이메일 변경 API 자체 (`PUT /users/me`는 이미 존재)

## 완료 조건 체크
- [x] 담당자 이메일을 바꾸면 수락 상태가 초기화된다 (기존 - 신규 테스트로 커버)
- [x] 변경 전에 발급된 링크로는 더 이상 수락할 수 없다 (기존 - 신규 테스트로 커버)
- [x] 확인자에 대해서도 동일하게 동작한다 (기존 - 신규 테스트로 커버)
- [x] 진행 중 사후 사건이 있을 때의 동작이 정의되어 있다 (신규 - 차단+동결)

## 테스트
- `UserServiceTest`에 2건 추가: 이메일 변경 시 본인경고이메일 검증 초기화 확인 / 진행중 사건 있으면 차단·이메일 미변경 확인
- **`RecipientTest`, `ConfirmerTest` 신규** - `updateContact()`가 실제로 존재했는데도 테스트가 하나도 없었어서, 완료조건 1~3번(수락 초기화, 링크 무효화, 확인자도 동일)을 실제로 검증하는 테스트를 이번에 처음 추가
- 전체 스위트 181건 통과, 회귀 없음

## 머지
승인 전까지 머지하지 않습니다.