### PR TITLE
[Fix/#79] 사후 인계 링크가 전부 작동하지 않던 치명적 버그 수정

### DIFF
--- a/src/main/java/com/mamoki/ieojuda/domain/stage/service/HandoverStageService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/stage/service/HandoverStageService.java
@@ -4,6 +4,8 @@ import com.mamoki.ieojuda.domain.account.entity.AdminPermission;
 import com.mamoki.ieojuda.domain.audit.entity.EmailLog;
 import com.mamoki.ieojuda.domain.audit.entity.EmailType;
 import com.mamoki.ieojuda.domain.audit.repository.EmailLogRepository;
+import com.mamoki.ieojuda.domain.postaccess.entity.AccessToken;
+import com.mamoki.ieojuda.domain.postaccess.repository.AccessTokenRepository;
 import com.mamoki.ieojuda.domain.postaccess.repository.PackageActionCompletionRepository;
 import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
 import com.mamoki.ieojuda.domain.recipient.repository.RecipientRepository;
@@ -46,6 +48,7 @@ public class HandoverStageService {
     private final AppProperties appProperties;
     private final PermissionGuard permissionGuard;
     private final PackageActionCompletionRepository packageActionCompletionRepository;
+    private final AccessTokenRepository accessTokenRepository;
 
     public HandoverStageResponse getStage(Long userId, Long caseId, Long stageId) {
         permissionGuard.require(userId, AdminPermission.CASE_SUPERVISE);
@@ -140,11 +143,20 @@ public class HandoverStageService {
     }
 
     // issue #79 - 최초 발송(INITIAL)과 대체 담당자 전환(FALLBACK)은 문구가 달라야 한다.
-    // 링크도 생전 역할 수락 화면이 아니라 사후 인증 화면(/posthumous-access/{token}, issue #76)을 가리킨다.
+    // 링크도 생전 역할 수락 화면이 아니라 사후 인증 화면(/posthumous-access/{token})을 가리킨다.
+    //
+    // 버그 수정: 링크만 /posthumous-access/로 바꾸고 토큰은 여전히 recipient.issueInviteToken()
+    // (생전 역할수락용 role_assignees.invite_token)에 저장하고 있었다. issue #76의 검증 API는
+    // AccessToken 테이블(posthumouse_access_tokens)만 조회하므로, 그 상태로는 발송되는 링크가
+    // 전부 "토큰 없음"으로 실패했다 - AccessToken을 이 단계(stage)에 실제로 발급하도록 고쳤다.
     private void sendHandoffInvite(HandoverStage stage, Recipient recipient, InviteKind kind) {
         String plainToken = TokenProvider.generatePlainToken();
         LocalDateTime expiresAt = LocalDateTime.now().plusHours(appProperties.getInviteTokenTtlHours());
-        recipient.issueInviteToken(TokenProvider.hashToken(plainToken), expiresAt);
+        accessTokenRepository.save(AccessToken.builder()
+                .handoverStage(stage)
+                .tokenHash(TokenProvider.hashToken(plainToken))
+                .expiresAt(expiresAt)
+                .build());
 
         String secureLink = appProperties.getBaseUrl() + "/posthumous-access/" + plainToken;
         EmailContent content = kind == InviteKind.INITIAL

--- a/src/test/java/com/mamoki/ieojuda/domain/stage/service/HandoverStageServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/stage/service/HandoverStageServiceTest.java
@@ -4,6 +4,8 @@ import com.mamoki.ieojuda.domain.account.entity.AdminPermission;
 import com.mamoki.ieojuda.domain.audit.repository.EmailLogRepository;
 import com.mamoki.ieojuda.domain.plan.entity.Plan;
 import com.mamoki.ieojuda.domain.plan.entity.PlanVersion;
+import com.mamoki.ieojuda.domain.postaccess.entity.AccessToken;
+import com.mamoki.ieojuda.domain.postaccess.repository.AccessTokenRepository;
 import com.mamoki.ieojuda.domain.postaccess.repository.PackageActionCompletionRepository;
 import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
 import com.mamoki.ieojuda.domain.recipient.entity.RoleType;
@@ -17,6 +19,7 @@ import com.mamoki.ieojuda.global.config.AppProperties;
 import com.mamoki.ieojuda.global.email.contract.EmailContent;
 import com.mamoki.ieojuda.global.email.contract.EmailSendResult;
 import com.mamoki.ieojuda.global.email.sender.EmailSender;
+import com.mamoki.ieojuda.global.email.token.TokenProvider;
 import com.mamoki.ieojuda.global.security.PermissionGuard;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -24,6 +27,8 @@ import org.mockito.ArgumentCaptor;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -46,6 +51,7 @@ class HandoverStageServiceTest {
     private AppProperties appProperties;
     private PermissionGuard permissionGuard;
     private PackageActionCompletionRepository packageActionCompletionRepository;
+    private AccessTokenRepository accessTokenRepository;
     private HandoverStageService handoverStageService;
 
     private ReleaseCase releaseCase;
@@ -61,9 +67,10 @@ class HandoverStageServiceTest {
         appProperties = mock(AppProperties.class);
         permissionGuard = mock(PermissionGuard.class);
         packageActionCompletionRepository = mock(PackageActionCompletionRepository.class);
+        accessTokenRepository = mock(AccessTokenRepository.class);
         handoverStageService = new HandoverStageService(
                 releaseCaseRepository, handoverStageRepository, recipientRepository, emailLogRepository,
-                emailSender, appProperties, permissionGuard, packageActionCompletionRepository);
+                emailSender, appProperties, permissionGuard, packageActionCompletionRepository, accessTokenRepository);
 
         when(appProperties.getContactEmail()).thenReturn("support@ieoduda.example");
         when(appProperties.getInviteTokenTtlHours()).thenReturn(72L);
@@ -71,6 +78,7 @@ class HandoverStageServiceTest {
         when(emailSender.send(anyString(), any())).thenReturn(EmailSendResult.success("msg-1"));
         when(emailLogRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
         when(handoverStageRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(accessTokenRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
 
         Plan plan = mock(Plan.class);
         PlanVersion planVersion = mock(PlanVersion.class);
@@ -84,6 +92,19 @@ class HandoverStageServiceTest {
         currentStage.send(); // 활성 발송 상태(SENT)에서 시작
 
         when(handoverStageRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(currentStage));
+    }
+
+    // 버그 회귀 방지(#79) - 이메일 링크에 박힌 평문 토큰이, 실제로 AccessToken 테이블에 그 해시로
+    // 저장됐는지까지 끝까지 추적해서 확인한다. 링크 문자열만 바뀌고 발급처는 그대로였던 버그를 이 검증이 잡는다.
+    private void assertLinkTokenWasIssuedAsAccessToken(EmailContent content) {
+        Matcher matcher = Pattern.compile("/posthumous-access/([\\w-]+)").matcher(content.body());
+        assertThat(matcher.find()).as("본문에 /posthumous-access/{token} 링크가 있어야 한다").isTrue();
+        String plainToken = matcher.group(1);
+        String expectedHash = TokenProvider.hashToken(plainToken);
+
+        ArgumentCaptor<AccessToken> tokenCaptor = ArgumentCaptor.forClass(AccessToken.class);
+        verify(accessTokenRepository).save(tokenCaptor.capture());
+        assertThat(tokenCaptor.getValue().getTokenHash()).isEqualTo(expectedHash);
     }
 
     private void setId(Object entity, String fieldName, Long id) {
@@ -132,6 +153,7 @@ class HandoverStageServiceTest {
         assertThat(content.body()).contains("업무 담당자 역할로 전달드릴 내용이 있습니다");
         assertThat(content.body()).contains("https://ieoduda.example/posthumous-access/");
         assertThat(content.body()).doesNotContain("/recipient-acceptances/");
+        assertLinkTokenWasIssuedAsAccessToken(content);
     }
 
     @Test
@@ -190,6 +212,7 @@ class HandoverStageServiceTest {
         assertThat(content.body()).doesNotContain("이전 담당자가 응답하지 않아");
         assertThat(content.body()).contains("가족 담당자 역할로 전달드릴 내용이 있습니다");
         assertThat(content.body()).contains("/posthumous-access/");
+        assertLinkTokenWasIssuedAsAccessToken(content);
     }
 
     // issue #79 완료 조건 - "대체 담당자는 기존 문구를 그대로 받는다" + 링크만 사후 인증 화면으로 교체
@@ -214,5 +237,6 @@ class HandoverStageServiceTest {
         assertThat(content.body()).contains("이전 담당자가 응답하지 않아 대체 담당자로 지정되었습니다. 역할 수락 여부를 확인해 주세요.");
         assertThat(content.body()).contains("/posthumous-access/");
         assertThat(content.body()).doesNotContain("/recipient-acceptances/");
+        assertLinkTokenWasIssuedAsAccessToken(content);
     }
 }

--- a/src/test/java/com/mamoki/ieojuda/domain/stage/service/StageDispatchHttpIntegrationTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/stage/service/StageDispatchHttpIntegrationTest.java
@@ -222,6 +222,18 @@ class StageDispatchHttpIntegrationTest {
         assertThat(stage2EmailCaptor.getValue().body()).contains("/posthumous-access/");
         assertThat(stage2EmailCaptor.getValue().body()).doesNotContain("/recipient-acceptances/");
 
+        // 버그 회귀 방지 - 메일 본문에 박힌 링크를 그대로 뽑아서 #76의 실제 인증 API를 호출해본다.
+        // (이전엔 링크 문자열만 /posthumous-access/로 바뀌고 토큰은 여전히 recipient.inviteToken에
+        // 저장되고 있어서, 이 호출이 전부 TOKEN_INVALID로 실패했었다 - 단위 테스트로는 못 잡던 버그)
+        java.util.regex.Matcher linkMatcher = java.util.regex.Pattern
+                .compile("/posthumous-access/([\\w-]+)").matcher(stage2EmailCaptor.getValue().body());
+        assertThat(linkMatcher.find()).as("메일 본문에 사후 인증 링크가 있어야 한다").isTrue();
+        String dispatchedPlainToken = linkMatcher.group(1);
+
+        HttpResponse<String> linkCheckResponse = get("/api/posthumous-access/" + dispatchedPlainToken);
+        assertThat(linkCheckResponse.statusCode()).isEqualTo(200);
+        assertThat(linkCheckResponse.body()).contains("\"recipientName\":\"담당자2\"");
+
         ReleaseCase reloadedCase = releaseCaseRepository.findById(releaseCase.getCaseId()).orElseThrow();
         assertThat(reloadedCase.getStatus()).isNotEqualTo(ReleaseCaseStatus.COMPLETED); // 아직 2단계가 안 끝남
 
@@ -260,6 +272,11 @@ class StageDispatchHttpIntegrationTest {
     private HttpResponse<String> post(String path) throws Exception {
         return httpClient.send(HttpRequest.newBuilder(uri(path))
                 .POST(HttpRequest.BodyPublishers.noBody()).build(), HttpResponse.BodyHandlers.ofString());
+    }
+
+    private HttpResponse<String> get(String path) throws Exception {
+        return httpClient.send(HttpRequest.newBuilder(uri(path))
+                .GET().build(), HttpResponse.BodyHandlers.ofString());
     }
 
     private URI uri(String path) {


### PR DESCRIPTION
## 🚨 긴급 - M1 전체 기능이 실제로는 끝까지 이어지지 않던 버그

## 연관 Issue
#79 (이미 머지된 PR #100의 후속 수정)

## 요약
`76~82`를 전부 만들고 나서 한 번 더 검증하다가 발견했습니다. `#79`에서 사후 인계 이메일 링크를 `/posthumous-access/{token}`으로 바꿨는데, **토큰을 저장하는 코드는 그대로 `recipient.issueInviteToken()`(생전 역할수락용 `role_assignees.invite_token` 컬럼)을 쓰고 있었습니다.** `#76`이 만든 검증 API(`GET /api/posthumous-access/{token}`)는 `AccessToken` 테이블(`posthumouse_access_tokens`)만 조회하기 때문에, **실제로 발송되는 사후 인계 링크가 전부 "토큰 없음"으로 실패하는 상태**였습니다.

각 이슈(#76~#79)를 따로 테스트할 땐 전부 통과했는데, 이유는 제 테스트들이 `AccessToken`을 직접 DB에 심어두고 검증만 했지, **실제 발송 경로(`HandoverStageService`)를 거쳐서 만들어진 토큰이 맞는지는 한 번도 끝까지 이어서 검증한 적이 없었기 때문**입니다.

## 원인
`HandoverStageService.sendHandoffInvite()` - 링크 문자열만 바꾸고 토큰 발급처를 안 바꿨습니다:
```java
// 수정 전 (버그)
recipient.issueInviteToken(TokenProvider.hashToken(plainToken), expiresAt); // 잘못된 테이블
String secureLink = appProperties.getBaseUrl() + "/posthumous-access/" + plainToken;
```

## 수정
```java
// 수정 후
accessTokenRepository.save(AccessToken.builder()
        .handoverStage(stage)
        .tokenHash(TokenProvider.hashToken(plainToken))
        .expiresAt(expiresAt)
        .build());
```
`HandoverStageService`가 `AccessTokenRepository`를 주입받아, 발송 시점에 실제로 `AccessToken`을 생성하도록 고쳤습니다. 이 메서드를 호출하는 3곳(`createStagesAndDispatchFirst`, `fallback`, `#78`의 다음단계발송) 전부에 적용됩니다.

## 테스트
- `HandoverStageServiceTest` - 이메일 본문에서 링크 토큰을 실제로 추출해, 그 해시로 `AccessTokenRepository.save()`가 호출됐는지 검증하는 회귀 테스트를 3개 발송 경로 전부에 추가
- `StageDispatchHttpIntegrationTest` - **가장 중요한 검증**: 실제 HTTP로 1단계를 완료시켜 2단계 담당자에게 메일이 발송되면, 그 메일 본문에서 링크를 그대로 뽑아 `#76`의 실제 `GET /api/posthumous-access/{token}` API를 호출해보고 200이 오는지까지 끝까지 확인 (이 테스트가 있었으면 처음부터 이 버그를 못 만들었을 겁니다)
- 전체 스위트 181건 통과 (develop 기준 - `#81`은 아직 머지 전이라 이 브랜치엔 포함 안 됨, `#81`은 이 코드 경로를 쓰지 않아 무관)

## 머지
승인 전까지 머지하지 않습니다. 다만 **M1(#76~79)의 핵심 기능이 실제로 동작하지 않는 상태**이니 가급적 빨리 검토 부탁드립니다.