### PR TITLE
[Refactor/#51] 이메일·S3 아웃박스 도입 및 외부 연동 재시도/회로차단 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ repositories {
 dependencies {
 	implementation platform('software.amazon.awssdk:bom:2.46.7')
 	implementation 'software.amazon.awssdk:s3'
+	implementation 'io.github.resilience4j:resilience4j-spring-boot4:2.4.0'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/src/main/java/com/mamoki/ieojuda/domain/account/service/UserService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/account/service/UserService.java
@@ -144,7 +144,7 @@ public class UserService {
     private void deletePlanData(Plan plan) {
         Long planId = plan.getPlanId();
 
-        emailLogRepository.deleteAll(emailLogRepository.findByPlan_PlanIdOrderBySentAtDesc(planId));
+        emailLogRepository.deleteAll(emailLogRepository.findByPlan_PlanIdOrderByRequestedAtDesc(planId));
         deleteEvidenceWithStorage(planId);
         objectionRepository.deleteAll(objectionRepository.findByPlan_PlanId(planId));
         handoffCheckResponseRepository.deleteAll(handoffCheckResponseRepository.findByHandoffCheck_Plan_PlanId(planId));

--- a/src/main/java/com/mamoki/ieojuda/domain/audit/dto/EmailDeliveryResponse.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/audit/dto/EmailDeliveryResponse.java
@@ -10,24 +10,30 @@ public record EmailDeliveryResponse(
         @Schema(description = "로그 ID") Long logId,
         @Schema(description = "수신자 이메일 (마스킹됨)") String recipientEmail,
         @Schema(description = "이메일 종류") String emailType,
+        @Schema(description = "발송 상태 (REQUESTED/SENT/FAILED)") String status,
         @Schema(description = "재시도 횟수") Integer retryCount,
         @Schema(description = "메시지 식별자") String messageId,
-        @Schema(description = "발송 시각") LocalDateTime sentAt,
+        @Schema(description = "요청(등록) 시각") LocalDateTime requestedAt,
+        @Schema(description = "발송 시각 (없으면 null)") LocalDateTime sentAt,
         @Schema(description = "열람 시각 (없으면 null)") LocalDateTime openedAt,
         @Schema(description = "반송 시각 (없으면 null)") LocalDateTime bouncedAt,
-        @Schema(description = "취소 시각 (없으면 null)") LocalDateTime canceledAt
+        @Schema(description = "취소 시각 (없으면 null)") LocalDateTime canceledAt,
+        @Schema(description = "마지막 실패 사유 (없으면 null)") String failureReason
 ) {
     public static EmailDeliveryResponse from(EmailLog log) {
         return new EmailDeliveryResponse(
                 log.getLogId(),
                 mask(log.getRecipientEmail()),
                 log.getEmailType() == null ? null : log.getEmailType().name(),
+                log.getStatus() == null ? null : log.getStatus().name(),
                 log.getRetryCount(),
                 log.getMessageId(),
+                log.getRequestedAt(),
                 log.getSentAt(),
                 log.getOpenedAt(),
                 log.getBouncedAt(),
-                log.getCanceledAt()
+                log.getCanceledAt(),
+                log.getFailureReason()
         );
     }
 

--- a/src/main/java/com/mamoki/ieojuda/domain/audit/entity/AdminActionType.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/audit/entity/AdminActionType.java
@@ -6,5 +6,6 @@ public enum AdminActionType {
     CASE_ASSIGN_PARTNER,  // 사건에 파트너사 배정
     EVIDENCE_DECISION,    // 증빙 승인/반려/추가자료요청
     EVIDENCE_DELETE,      // 증빙 원본 삭제(수동 재처리 또는 자동 스케줄러)
-    EMAIL_OUTBOX_DISPATCH_FAILED // issue #51 - 이메일 아웃박스 최대 재시도 초과(DEAD 전이)
+    EMAIL_OUTBOX_DISPATCH_FAILED, // issue #51 - 이메일 아웃박스 최대 재시도 초과(DEAD 전이)
+    EVIDENCE_ORPHAN_CLEANUP // issue #51 - 트랜잭션 롤백 후 S3 고아 객체 정리 실패
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/audit/entity/AdminActionType.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/audit/entity/AdminActionType.java
@@ -5,5 +5,6 @@ public enum AdminActionType {
     CASE_FREEZE,          // 사건 동결
     CASE_ASSIGN_PARTNER,  // 사건에 파트너사 배정
     EVIDENCE_DECISION,    // 증빙 승인/반려/추가자료요청
-    EVIDENCE_DELETE       // 증빙 원본 삭제(수동 재처리 또는 자동 스케줄러)
+    EVIDENCE_DELETE,      // 증빙 원본 삭제(수동 재처리 또는 자동 스케줄러)
+    EMAIL_OUTBOX_DISPATCH_FAILED // issue #51 - 이메일 아웃박스 최대 재시도 초과(DEAD 전이)
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/audit/entity/EmailDeliveryStatus.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/audit/entity/EmailDeliveryStatus.java
@@ -1,0 +1,9 @@
+package com.mamoki.ieojuda.domain.audit.entity;
+
+// issue #51 - SMTP 발송을 아웃박스로 분리하면서 도입. DELIVERED/BOUNCED/OPENED는
+// 공급자 웹훅 없이는 신뢰할 수 없어 이번 스코프에서 제외하고 기존 bouncedAt/openedAt 컬럼을 그대로 둔다.
+public enum EmailDeliveryStatus {
+    REQUESTED, // 아웃박스에 등록됨 - 아직 실제 SMTP 시도 전
+    SENT,      // JavaMailSender가 예외 없이 반환함 (확인된 성공만 이 상태)
+    FAILED     // 이번 시도 실패 (재시도 대상이면 워커가 다음 주기에 다시 REQUESTED로 시도)
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/audit/entity/EmailLog.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/audit/entity/EmailLog.java
@@ -36,12 +36,21 @@ public class EmailLog {
     @Column(name = "recipient_email", length = 255)
     private String recipientEmail;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 20)
+    private EmailDeliveryStatus status;
+
     @Column(name = "message_id", length = 255)
     private String messageId;
 
     @Column(name = "retry_count")
     private Integer retryCount;
 
+    // 이 로그가 생성된(=아웃박스에 등록된) 시각. sentAt과 달리 항상 채워진다.
+    @Column(name = "requested_at", nullable = false)
+    private LocalDateTime requestedAt;
+
+    // 실제로 SMTP 발송이 성공한 시각. markSent() 호출 전까지는 null.
     @Column(name = "sent_at")
     private LocalDateTime sentAt;
 
@@ -54,16 +63,32 @@ public class EmailLog {
     @Column(name = "canceled_at")
     private LocalDateTime canceledAt;
 
+    @Column(name = "failure_reason", length = 1000)
+    private String failureReason;
+
     @Builder
-    public EmailLog(Plan plan, HandoverStage handoverStage, EmailType emailType,
-                    String recipientEmail, String messageId) {
+    public EmailLog(Plan plan, HandoverStage handoverStage, EmailType emailType, String recipientEmail) {
         this.plan = plan;
         this.handoverStage = handoverStage;
         this.emailType = emailType;
         this.recipientEmail = recipientEmail;
-        this.messageId = messageId;
         this.retryCount = 0;
+        this.status = EmailDeliveryStatus.REQUESTED;
+        this.requestedAt = LocalDateTime.now();
+    }
+
+    // 워커가 실제 SMTP 발송에 성공했을 때만 호출 - 이 메서드가 유일한 SENT/sentAt 기록 경로다.
+    public void markSent(String messageId) {
+        this.status = EmailDeliveryStatus.SENT;
+        this.messageId = messageId;
         this.sentAt = LocalDateTime.now();
+        this.failureReason = null;
+    }
+
+    // 워커의 이번 시도가 실패했을 때 호출 (재시도 대상 여부와 무관하게 매 실패마다 기록)
+    public void markFailed(String reason) {
+        this.status = EmailDeliveryStatus.FAILED;
+        this.failureReason = reason;
     }
 
     public void markOpened() {
@@ -78,11 +103,12 @@ public class EmailLog {
         this.canceledAt = LocalDateTime.now();
     }
 
-    // "이메일 발송 감사" 화면 "재시도 정책 실행하기" - 반송/실패 건 재발송 시 호출
-    public void markRetried(String newMessageId) {
+    // "이메일 발송 감사" 화면 "재시도 정책 실행하기" - 관리자가 재시도를 요청한 시점에 호출.
+    // 실제 재발송 성공 여부는 이후 워커가 markSent/markFailed로 비동기 기록한다.
+    public void recordRetryRequested() {
         this.retryCount = this.retryCount + 1;
-        this.messageId = newMessageId;
-        this.sentAt = LocalDateTime.now();
+        this.status = EmailDeliveryStatus.REQUESTED;
         this.bouncedAt = null;
+        this.failureReason = null;
     }
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/audit/repository/EmailLogRepository.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/audit/repository/EmailLogRepository.java
@@ -8,5 +8,6 @@ import java.util.List;
 public interface EmailLogRepository extends JpaRepository<EmailLog, Long> {
 
     // "이메일 발송 감사" 화면 - 사건에 속한 발송 이력 전체 조회 (plan 기준. 사건-plan은 1:1이라 plan_id로 충분)
-    List<EmailLog> findByPlan_PlanIdOrderBySentAtDesc(Long planId);
+    // issue #51 - sentAt은 미발송 건이면 null이라 정렬 기준으로 requestedAt(항상 채워짐) 사용
+    List<EmailLog> findByPlan_PlanIdOrderByRequestedAtDesc(Long planId);
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/audit/service/EmailAuditService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/audit/service/EmailAuditService.java
@@ -14,8 +14,7 @@ import com.mamoki.ieojuda.domain.releasecase.repository.ReleaseCaseRepository;
 import com.mamoki.ieojuda.domain.stage.entity.HandoverStage;
 import com.mamoki.ieojuda.global.config.AppProperties;
 import com.mamoki.ieojuda.global.email.contract.EmailContent;
-import com.mamoki.ieojuda.global.email.contract.EmailSendResult;
-import com.mamoki.ieojuda.global.email.sender.EmailSender;
+import com.mamoki.ieojuda.global.email.outbox.EmailOutboxService;
 import com.mamoki.ieojuda.global.email.template.EmailBuilder;
 import com.mamoki.ieojuda.global.email.token.TokenProvider;
 import com.mamoki.ieojuda.global.exception.CustomException;
@@ -40,7 +39,7 @@ public class EmailAuditService {
     private final ReleaseCaseRepository releaseCaseRepository;
     private final EmailLogRepository emailLogRepository;
     private final ExternalPartnerRepository externalPartnerRepository;
-    private final EmailSender emailSender;
+    private final EmailOutboxService emailOutboxService;
     private final AppProperties appProperties;
     private final PermissionGuard permissionGuard;
     private final ReauthGuard reauthGuard;
@@ -49,7 +48,7 @@ public class EmailAuditService {
     public List<EmailDeliveryResponse> getDeliveries(Long userId, Long caseId) {
         permissionGuard.require(userId, AdminPermission.CASE_SUPERVISE);
         ReleaseCase releaseCase = findCase(caseId);
-        return emailLogRepository.findByPlan_PlanIdOrderBySentAtDesc(releaseCase.getPlan().getPlanId()).stream()
+        return emailLogRepository.findByPlan_PlanIdOrderByRequestedAtDesc(releaseCase.getPlan().getPlanId()).stream()
                 .map(EmailDeliveryResponse::from)
                 .toList();
     }
@@ -83,13 +82,8 @@ public class EmailAuditService {
                 secureLink,
                 appProperties.getContactEmail()
         );
-        EmailSendResult result = emailSender.send(recipient.getEmail(), content);
+        emailOutboxService.enqueueRetry(log, content);
 
-        if (result.success()) {
-            log.markRetried(result.messageId());
-        } else {
-            log.markBounced();
-        }
         return EmailDeliveryResponse.from(log);
     }
 

--- a/src/main/java/com/mamoki/ieojuda/domain/confirmer/service/ConfirmerService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/confirmer/service/ConfirmerService.java
@@ -12,11 +12,11 @@ import com.mamoki.ieojuda.domain.confirmer.entity.Confirmer;
 import com.mamoki.ieojuda.domain.confirmer.repository.ConfirmerRepository;
 import com.mamoki.ieojuda.domain.plan.entity.Plan;
 import com.mamoki.ieojuda.domain.plan.service.PlanOwnershipReader;
+import com.mamoki.ieojuda.domain.audit.entity.EmailType;
 import com.mamoki.ieojuda.domain.recipient.entity.AcceptanceStatus;
 import com.mamoki.ieojuda.global.config.AppProperties;
 import com.mamoki.ieojuda.global.email.contract.EmailContent;
-import com.mamoki.ieojuda.global.email.contract.EmailSendResult;
-import com.mamoki.ieojuda.global.email.sender.EmailSender;
+import com.mamoki.ieojuda.global.email.outbox.EmailOutboxService;
 import com.mamoki.ieojuda.global.email.template.EmailBuilder;
 import com.mamoki.ieojuda.global.email.token.TokenProvider;
 import com.mamoki.ieojuda.global.exception.CustomException;
@@ -40,7 +40,7 @@ public class ConfirmerService {
 
     private final PlanOwnershipReader planOwnershipReader;
     private final ConfirmerRepository confirmerRepository;
-    private final EmailSender emailSender;
+    private final EmailOutboxService emailOutboxService;
     private final AppProperties appProperties;
 
     @Transactional
@@ -70,8 +70,9 @@ public class ConfirmerService {
         }
     }
 
-    // 확인자 저장 + 초대 토큰 발급 + 수락 이메일 발송
-    // 이메일 발송 실패는 예외로 던지지 않는다 - 확인자 저장은 유지하고 건별 결과만 응답에 담는다
+    // 확인자 저장 + 초대 토큰 발급 + 수락 이메일 발송 큐 등록
+    // 실제 발송은 EmailOutboxScheduler가 비동기로 처리하므로, 여기서는 큐 등록 자체의 성공만 응답에 담는다
+    // (실제 발송 결과는 "이메일 발송 감사" 화면에서 확인)
     private ConfirmerRegisterResponse registerOne(Plan plan, ConfirmerRegisterRequest request) {
         Confirmer confirmer = confirmerRepository.save(Confirmer.builder()
                 .plan(plan)
@@ -79,23 +80,19 @@ public class ConfirmerService {
                 .email(request.email())
                 .build());
 
-        EmailSendResult sendResult = issueInviteAndSend(confirmer);
+        issueInviteAndSend(confirmer);
 
-        return ConfirmerRegisterResponse.of(
-                confirmer,
-                sendResult.success(),
-                sendResult.bounceType() == null ? null : sendResult.bounceType().name()
-        );
+        return ConfirmerRegisterResponse.of(confirmer, true, null);
     }
 
-    private EmailSendResult issueInviteAndSend(Confirmer confirmer) {
+    private void issueInviteAndSend(Confirmer confirmer) {
         String plainToken = TokenProvider.generatePlainToken();
         LocalDateTime expiresAt = LocalDateTime.now().plusHours(appProperties.getInviteTokenTtlHours());
         confirmer.issueInviteToken(TokenProvider.hashToken(plainToken), expiresAt);
-        return sendAcceptanceEmail(confirmer, plainToken, expiresAt);
+        sendAcceptanceEmail(confirmer, plainToken, expiresAt);
     }
 
-    private EmailSendResult sendAcceptanceEmail(Confirmer confirmer, String plainToken, LocalDateTime expiresAt) {
+    private void sendAcceptanceEmail(Confirmer confirmer, String plainToken, LocalDateTime expiresAt) {
         String secureLink = appProperties.getBaseUrl() + "/confirmer-acceptances/" + plainToken;
         EmailContent content = EmailBuilder.build(
                 "지정 확인자",
@@ -104,7 +101,7 @@ public class ConfirmerService {
                 secureLink,
                 appProperties.getContactEmail()
         );
-        return emailSender.send(confirmer.getEmail(), content);
+        emailOutboxService.enqueue(confirmer.getPlan(), null, EmailType.CONFIRMER_ACCEPTANCE_INVITE, confirmer.getEmail(), content);
     }
 
     // "역할 점검" 화면 상세 - 이름 클릭 시 해당 확인자 정보
@@ -128,13 +125,9 @@ public class ConfirmerService {
         }
 
         confirmer.resetAcceptance();
-        EmailSendResult sendResult = issueInviteAndSend(confirmer);
+        issueInviteAndSend(confirmer);
 
-        return ConfirmerResendResponse.of(
-                confirmer,
-                sendResult.success(),
-                sendResult.bounceType() == null ? null : sendResult.bounceType().name()
-        );
+        return ConfirmerResendResponse.of(confirmer, true, null);
     }
 
     // "확인자 수정하기" - 이름/이메일 수정. 이메일이 바뀌면 재검증이 필요하므로 수락 이메일을 다시 보낸다
@@ -144,16 +137,11 @@ public class ConfirmerService {
         Confirmer confirmer = findOwnedConfirmer(planId, confirmId);
 
         boolean emailChanged = confirmer.updateContact(request.name(), request.email());
+        if (emailChanged) {
+            issueInviteAndSend(confirmer);
+        }
 
-        EmailSendResult sendResult = emailChanged
-                ? issueInviteAndSend(confirmer)
-                : null;
-
-        return ConfirmerUpdateResponse.of(
-                confirmer,
-                sendResult != null && sendResult.success(),
-                sendResult == null || sendResult.bounceType() == null ? null : sendResult.bounceType().name()
-        );
+        return ConfirmerUpdateResponse.of(confirmer, emailChanged, null);
     }
 
     private Confirmer findOwnedConfirmer(Long planId, Long confirmId) {

--- a/src/main/java/com/mamoki/ieojuda/domain/confirmer/service/DisputeContactService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/confirmer/service/DisputeContactService.java
@@ -2,14 +2,14 @@ package com.mamoki.ieojuda.domain.confirmer.service;
 
 import com.mamoki.ieojuda.domain.confirmer.dto.DisputeContactRegisterRequest;
 import com.mamoki.ieojuda.domain.confirmer.dto.DisputeContactResponse;
+import com.mamoki.ieojuda.domain.audit.entity.EmailType;
 import com.mamoki.ieojuda.domain.confirmer.entity.DisputeContact;
 import com.mamoki.ieojuda.domain.confirmer.repository.DisputeContactRepository;
 import com.mamoki.ieojuda.domain.plan.entity.Plan;
 import com.mamoki.ieojuda.domain.plan.service.PlanOwnershipReader;
 import com.mamoki.ieojuda.global.config.AppProperties;
 import com.mamoki.ieojuda.global.email.contract.EmailContent;
-import com.mamoki.ieojuda.global.email.contract.EmailSendResult;
-import com.mamoki.ieojuda.global.email.sender.EmailSender;
+import com.mamoki.ieojuda.global.email.outbox.EmailOutboxService;
 import com.mamoki.ieojuda.global.email.template.EmailBuilder;
 import com.mamoki.ieojuda.global.email.token.TokenProvider;
 import com.mamoki.ieojuda.global.email.token.TokenValidator;
@@ -33,7 +33,7 @@ public class DisputeContactService {
 
     private final PlanOwnershipReader planOwnershipReader;
     private final DisputeContactRepository disputeContactRepository;
-    private final EmailSender emailSender;
+    private final EmailOutboxService emailOutboxService;
     private final AppProperties appProperties;
     private final TokenLookupGuard tokenLookupGuard;
     private final PublicLinkAuditor publicLinkAuditor;
@@ -70,6 +70,8 @@ public class DisputeContactService {
         return DisputeContactResponse.of(contact, emailSent);
     }
 
+    // 발송은 EmailOutboxScheduler가 비동기로 처리하므로, 여기서는 큐 등록 자체만 하고 항상 true를 반환한다
+    // (실제 발송 결과는 "이메일 발송 감사" 화면에서 확인)
     private boolean issueTokenAndSendVerificationEmail(DisputeContact contact) {
         String plainToken = TokenProvider.generatePlainToken();
         LocalDateTime expiresAt = LocalDateTime.now().plusHours(appProperties.getInviteTokenTtlHours());
@@ -83,7 +85,8 @@ public class DisputeContactService {
                 secureLink,
                 appProperties.getContactEmail()
         );
-        return emailSender.send(contact.getEmail(), content).success();
+        emailOutboxService.enqueue(contact.getPlan(), null, EmailType.DISPUTE_CONTACT_VERIFICATION, contact.getEmail(), content);
+        return true;
     }
 
     private DisputeContact findContact(Long planId, Long contactId) {

--- a/src/main/java/com/mamoki/ieojuda/domain/evidence/entity/EvidenceOrphanCleanup.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/evidence/entity/EvidenceOrphanCleanup.java
@@ -1,0 +1,56 @@
+package com.mamoki.ieojuda.domain.evidence.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+// issue #51 - DB 트랜잭션 롤백 시 S3 보정 삭제(EvidenceSubmitService.registerCompensatingDelete)
+// 자체가 실패하는 경우를 위한 내구성 있는 재처리 큐. Evidence의 deleted_at 재시도 가드 패턴과 동일하게,
+// deletedAt이 null인 행만 EvidenceOrphanCleanupScheduler가 계속 재시도한다.
+@Entity
+@Table(name = "evidence_orphan_cleanups")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EvidenceOrphanCleanup {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "cleanup_id")
+    private Long cleanupId;
+
+    @Column(name = "storage_key", length = 500, nullable = false)
+    private String storageKey;
+
+    // 정리가 필요해진 사유 (예: 보정 삭제 자체가 던진 예외의 클래스명)
+    @Column(name = "reason", length = 255)
+    private String reason;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @Column(name = "failure_reason", length = 1000)
+    private String failureReason;
+
+    @Builder
+    public EvidenceOrphanCleanup(String storageKey, String reason) {
+        this.storageKey = storageKey;
+        this.reason = reason;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public void markDeleted() {
+        this.deletedAt = LocalDateTime.now();
+        this.failureReason = null;
+    }
+
+    public void markDeleteFailed(String failureReason) {
+        this.failureReason = failureReason;
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/evidence/repository/EvidenceOrphanCleanupRepository.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/evidence/repository/EvidenceOrphanCleanupRepository.java
@@ -1,0 +1,19 @@
+package com.mamoki.ieojuda.domain.evidence.repository;
+
+import com.mamoki.ieojuda.domain.evidence.entity.EvidenceOrphanCleanup;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface EvidenceOrphanCleanupRepository extends JpaRepository<EvidenceOrphanCleanup, Long> {
+
+    // EvidenceOrphanCleanupScheduler - EvidenceRepository.findDueForDeletionForUpdateSkipLocked와
+    // 동일한 이유로 FOR UPDATE SKIP LOCKED + LIMIT 사용 (다중 인스턴스 중복 처리 방지).
+    @Query(value = "SELECT * FROM evidence_orphan_cleanups " +
+            "WHERE deleted_at IS NULL " +
+            "ORDER BY created_at " +
+            "LIMIT 100 " +
+            "FOR UPDATE SKIP LOCKED", nativeQuery = true)
+    List<EvidenceOrphanCleanup> findPendingForUpdateSkipLocked();
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/evidence/scheduler/EvidenceOrphanCleanupScheduler.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/evidence/scheduler/EvidenceOrphanCleanupScheduler.java
@@ -1,0 +1,59 @@
+package com.mamoki.ieojuda.domain.evidence.scheduler;
+
+import com.mamoki.ieojuda.domain.audit.entity.AdminActionType;
+import com.mamoki.ieojuda.domain.audit.service.AdminActionAuditService;
+import com.mamoki.ieojuda.domain.evidence.entity.EvidenceOrphanCleanup;
+import com.mamoki.ieojuda.domain.evidence.repository.EvidenceOrphanCleanupRepository;
+import com.mamoki.ieojuda.global.storage.EvidenceStorageClient;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+// issue #51 - DB 트랜잭션 롤백 시 EvidenceSubmitService의 즉시 보정 삭제가 실패해 기록된 S3 고아
+// 객체를 재처리한다. EvidenceDeletionScheduler와 동일한 재시도 가드(deleted_at IS NULL) +
+// FOR UPDATE SKIP LOCKED 다중 인스턴스 안전성 + 행 단위 예외 격리 패턴을 그대로 따른다.
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EvidenceOrphanCleanupScheduler {
+
+    private final EvidenceOrphanCleanupRepository evidenceOrphanCleanupRepository;
+    private final EvidenceStorageClient evidenceStorageClient;
+    private final AdminActionAuditService adminActionAuditService;
+
+    // 10분마다 - EvidenceDeletionScheduler와 같은 주기
+    @Scheduled(fixedRate = 600_000)
+    @Transactional
+    public void cleanupOrphans() {
+        List<EvidenceOrphanCleanup> pending = evidenceOrphanCleanupRepository.findPendingForUpdateSkipLocked();
+
+        for (EvidenceOrphanCleanup cleanup : pending) {
+            cleanupOne(cleanup);
+        }
+    }
+
+    private void cleanupOne(EvidenceOrphanCleanup cleanup) {
+        try {
+            evidenceStorageClient.delete(cleanup.getStorageKey());
+            cleanup.markDeleted();
+        } catch (Exception e) {
+            String reason = truncate(e.getMessage());
+            cleanup.markDeleteFailed(reason);
+            log.error("[Evidence Orphan Cleanup Retry Failed] cleanupId={}, storageKey={}, cause={}",
+                    cleanup.getCleanupId(), cleanup.getStorageKey(), e.getMessage(), e);
+            adminActionAuditService.recordSystem(
+                    AdminActionType.EVIDENCE_ORPHAN_CLEANUP, cleanup.getCleanupId(), false, reason);
+        }
+    }
+
+    private String truncate(String message) {
+        if (message == null) {
+            return null;
+        }
+        return message.length() > 1000 ? message.substring(0, 1000) : message;
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/evidence/service/EvidenceOrphanCleanupService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/evidence/service/EvidenceOrphanCleanupService.java
@@ -1,0 +1,26 @@
+package com.mamoki.ieojuda.domain.evidence.service;
+
+import com.mamoki.ieojuda.domain.evidence.entity.EvidenceOrphanCleanup;
+import com.mamoki.ieojuda.domain.evidence.repository.EvidenceOrphanCleanupRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+// issue #51 - EvidenceSubmitService.registerCompensatingDelete의 즉시 삭제 시도가 실패했을 때 호출된다.
+// 호출부(TransactionSynchronization.afterCompletion)는 원본 트랜잭션이 이미 끝난 뒤 실행되므로
+// AdminActionAuditService.record와 같은 이유로 REQUIRES_NEW로 새 트랜잭션에 커밋한다.
+@Service
+@RequiredArgsConstructor
+public class EvidenceOrphanCleanupService {
+
+    private final EvidenceOrphanCleanupRepository evidenceOrphanCleanupRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void recordOrphan(String storageKey, String reason) {
+        evidenceOrphanCleanupRepository.save(EvidenceOrphanCleanup.builder()
+                .storageKey(storageKey)
+                .reason(reason)
+                .build());
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/evidence/service/EvidenceSubmitService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/evidence/service/EvidenceSubmitService.java
@@ -56,6 +56,7 @@ public class EvidenceSubmitService {
     private final PublicLinkAuditor publicLinkAuditor;
     private final IdempotencyGuard idempotencyGuard;
     private final MalwareScanner malwareScanner;
+    private final EvidenceOrphanCleanupService evidenceOrphanCleanupService;
 
     @Transactional
     public EvidenceSubmitResponse submit(String plainToken, MultipartFile file, String idempotencyKey) {
@@ -191,6 +192,7 @@ public class EvidenceSubmitService {
                     evidenceStorageClient.delete(storageKey);
                 } catch (Exception e) {
                     log.error("[Evidence Orphan Cleanup Failed] storageKey={}, cause={}", storageKey, e.getMessage(), e);
+                    evidenceOrphanCleanupService.recordOrphan(storageKey, e.getClass().getSimpleName());
                 }
             }
         });

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/service/PlanService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/service/PlanService.java
@@ -1,5 +1,6 @@
 package com.mamoki.ieojuda.domain.plan.service;
 
+import com.mamoki.ieojuda.domain.audit.entity.EmailType;
 import com.mamoki.ieojuda.domain.confirmer.repository.DisputeContactRepository;
 import com.mamoki.ieojuda.domain.plan.dto.PlanResponse;
 import com.mamoki.ieojuda.domain.plan.dto.ReleasePolicyRequest;
@@ -11,8 +12,7 @@ import com.mamoki.ieojuda.domain.plan.entity.Plan;
 import com.mamoki.ieojuda.domain.plan.repository.PlanRepository;
 import com.mamoki.ieojuda.global.config.AppProperties;
 import com.mamoki.ieojuda.global.email.contract.EmailContent;
-import com.mamoki.ieojuda.global.email.contract.EmailSendResult;
-import com.mamoki.ieojuda.global.email.sender.EmailSender;
+import com.mamoki.ieojuda.global.email.outbox.EmailOutboxService;
 import com.mamoki.ieojuda.global.email.template.EmailBuilder;
 import com.mamoki.ieojuda.global.email.token.TokenProvider;
 import com.mamoki.ieojuda.global.email.token.TokenValidator;
@@ -40,7 +40,7 @@ public class PlanService {
     private final PlanRepository planRepository;
     private final PlanOwnershipReader planOwnershipReader;
     private final DisputeContactRepository disputeContactRepository;
-    private final EmailSender emailSender;
+    private final EmailOutboxService emailOutboxService;
     private final AppProperties appProperties;
 
     public PlanResponse getPlan(Long userId, Long planId) {
@@ -99,9 +99,10 @@ public class PlanService {
                 secureLink,
                 appProperties.getContactEmail()
         );
-        EmailSendResult sendResult = emailSender.send(request.email(), content);
+        // 발송은 EmailOutboxScheduler가 비동기로 처리한다 (실제 발송 결과는 "이메일 발송 감사" 화면에서 확인)
+        emailOutboxService.enqueue(plan, null, EmailType.WAITING_PERIOD_WARNING, request.email(), content);
 
-        return SelfWarningEmailResponse.of(plan, sendResult.success());
+        return SelfWarningEmailResponse.of(plan, true);
     }
 
     // 본인 경고 이메일 검증 링크 클릭 - 로그인 불필요(토큰 자체가 증명), planId도 토큰으로 역추적

--- a/src/main/java/com/mamoki/ieojuda/domain/recipient/service/RecipientService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/recipient/service/RecipientService.java
@@ -5,6 +5,7 @@ import com.mamoki.ieojuda.domain.plan.entity.DisclosureScope;
 import com.mamoki.ieojuda.domain.plan.entity.Item;
 import com.mamoki.ieojuda.domain.plan.entity.ItemStatus;
 import com.mamoki.ieojuda.domain.plan.entity.LifeArea;
+import com.mamoki.ieojuda.domain.audit.entity.EmailType;
 import com.mamoki.ieojuda.domain.plan.entity.Plan;
 import com.mamoki.ieojuda.domain.plan.repository.ItemRepository;
 import com.mamoki.ieojuda.domain.plan.service.PlanOwnershipReader;
@@ -24,8 +25,7 @@ import com.mamoki.ieojuda.domain.recipient.entity.RoleType;
 import com.mamoki.ieojuda.domain.recipient.repository.RecipientRepository;
 import com.mamoki.ieojuda.global.config.AppProperties;
 import com.mamoki.ieojuda.global.email.contract.EmailContent;
-import com.mamoki.ieojuda.global.email.contract.EmailSendResult;
-import com.mamoki.ieojuda.global.email.sender.EmailSender;
+import com.mamoki.ieojuda.global.email.outbox.EmailOutboxService;
 import com.mamoki.ieojuda.global.email.template.EmailBuilder;
 import com.mamoki.ieojuda.global.email.token.TokenProvider;
 import com.mamoki.ieojuda.global.exception.CustomException;
@@ -53,7 +53,7 @@ public class RecipientService {
     private final ItemRepository itemRepository;
     private final RecipientRepository recipientRepository;
     private final PlanOwnershipReader planOwnershipReader;
-    private final EmailSender emailSender;
+    private final EmailOutboxService emailOutboxService;
     private final AppProperties appProperties;
 
     @Transactional
@@ -123,19 +123,13 @@ public class RecipientService {
 
         item.assignRecipient(recipient);
 
-        EmailSendResult sendResult = issueInviteAndSend(recipient, toRoleName(disclosureScope));
+        issueInviteAndSend(recipient, toRoleName(disclosureScope));
 
         BackupRegisterResponse backupResponse = request.backup() == null
                 ? null
                 : registerBackup(plan, lifeArea, disclosureScope, recipient, request.backup());
 
-        return RecipientRegisterResponse.of(
-                recipient,
-                item.getItemId(),
-                sendResult.success(),
-                sendResult.bounceType() == null ? null : sendResult.bounceType().name(),
-                backupResponse
-        );
+        return RecipientRegisterResponse.of(recipient, item.getItemId(), true, null, backupResponse);
     }
 
     // 대체 담당자 저장 + 초대 토큰 발급 + 수락 이메일 발송
@@ -154,24 +148,20 @@ public class RecipientService {
                 .backupFor(primary)
                 .build());
 
-        EmailSendResult sendResult = issueInviteAndSend(backup, toRoleName(disclosureScope) + " (대체 담당자)");
+        issueInviteAndSend(backup, toRoleName(disclosureScope) + " (대체 담당자)");
 
-        return BackupRegisterResponse.of(
-                backup,
-                sendResult.success(),
-                sendResult.bounceType() == null ? null : sendResult.bounceType().name()
-        );
+        return BackupRegisterResponse.of(backup, true, null);
     }
 
-    private EmailSendResult issueInviteAndSend(Recipient recipient, String roleName) {
+    private void issueInviteAndSend(Recipient recipient, String roleName) {
         String plainToken = TokenProvider.generatePlainToken();
         LocalDateTime expiresAt = LocalDateTime.now().plusHours(appProperties.getInviteTokenTtlHours());
         recipient.issueInviteToken(TokenProvider.hashToken(plainToken), expiresAt);
-        return sendAcceptanceEmail(recipient, roleName, plainToken, expiresAt);
+        sendAcceptanceEmail(recipient, roleName, plainToken, expiresAt);
     }
 
-    private EmailSendResult sendAcceptanceEmail(Recipient recipient, String roleName,
-                                                 String plainToken, LocalDateTime expiresAt) {
+    private void sendAcceptanceEmail(Recipient recipient, String roleName,
+                                      String plainToken, LocalDateTime expiresAt) {
         String secureLink = appProperties.getBaseUrl() + "/recipient-acceptances/" + plainToken;
         EmailContent content = EmailBuilder.build(
                 roleName,
@@ -180,7 +170,7 @@ public class RecipientService {
                 secureLink,
                 appProperties.getContactEmail()
         );
-        return emailSender.send(recipient.getEmail(), content);
+        emailOutboxService.enqueue(recipient.getPlan(), null, EmailType.ROLE_ACCEPTANCE_INVITE, recipient.getEmail(), content);
     }
 
     private RoleType toRoleType(DisclosureScope disclosureScope) {
@@ -234,13 +224,9 @@ public class RecipientService {
         }
 
         recipient.resetAcceptance();
-        EmailSendResult sendResult = issueInviteAndSend(recipient, toRoleName(recipient.getDisclosureScope()));
+        issueInviteAndSend(recipient, toRoleName(recipient.getDisclosureScope()));
 
-        return RecipientAcceptanceEmailResponse.of(
-                recipient,
-                sendResult.success(),
-                sendResult.bounceType() == null ? null : sendResult.bounceType().name()
-        );
+        return RecipientAcceptanceEmailResponse.of(recipient, true, null);
     }
 
     // "담당자 수정하기" - 이름/이메일 수정. 이메일이 바뀌면 재검증이 필요하므로 수락 이메일을 다시 보낸다
@@ -250,16 +236,11 @@ public class RecipientService {
         Recipient recipient = findOwnedRecipient(planId, assigneeId);
 
         boolean emailChanged = recipient.updateContact(request.name(), request.email());
+        if (emailChanged) {
+            issueInviteAndSend(recipient, toRoleName(recipient.getDisclosureScope()));
+        }
 
-        EmailSendResult sendResult = emailChanged
-                ? issueInviteAndSend(recipient, toRoleName(recipient.getDisclosureScope()))
-                : null;
-
-        return RecipientUpdateResponse.of(
-                recipient,
-                sendResult != null && sendResult.success(),
-                sendResult == null || sendResult.bounceType() == null ? null : sendResult.bounceType().name()
-        );
+        return RecipientUpdateResponse.of(recipient, emailChanged, null);
     }
 
     private Recipient findOwnedRecipient(Long planId, Long assigneeId) {

--- a/src/main/java/com/mamoki/ieojuda/domain/stage/service/HandoverStageService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/stage/service/HandoverStageService.java
@@ -1,9 +1,7 @@
 package com.mamoki.ieojuda.domain.stage.service;
 
 import com.mamoki.ieojuda.domain.account.entity.AdminPermission;
-import com.mamoki.ieojuda.domain.audit.entity.EmailLog;
 import com.mamoki.ieojuda.domain.audit.entity.EmailType;
-import com.mamoki.ieojuda.domain.audit.repository.EmailLogRepository;
 import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
 import com.mamoki.ieojuda.domain.recipient.repository.RecipientRepository;
 import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCase;
@@ -13,8 +11,7 @@ import com.mamoki.ieojuda.domain.stage.entity.HandoverStage;
 import com.mamoki.ieojuda.domain.stage.repository.HandoverStageRepository;
 import com.mamoki.ieojuda.global.config.AppProperties;
 import com.mamoki.ieojuda.global.email.contract.EmailContent;
-import com.mamoki.ieojuda.global.email.contract.EmailSendResult;
-import com.mamoki.ieojuda.global.email.sender.EmailSender;
+import com.mamoki.ieojuda.global.email.outbox.EmailOutboxService;
 import com.mamoki.ieojuda.global.email.template.EmailBuilder;
 import com.mamoki.ieojuda.global.email.token.TokenProvider;
 import com.mamoki.ieojuda.global.exception.CustomException;
@@ -39,8 +36,7 @@ public class HandoverStageService {
     private final ReleaseCaseRepository releaseCaseRepository;
     private final HandoverStageRepository handoverStageRepository;
     private final RecipientRepository recipientRepository;
-    private final EmailLogRepository emailLogRepository;
-    private final EmailSender emailSender;
+    private final EmailOutboxService emailOutboxService;
     private final AppProperties appProperties;
     private final PermissionGuard permissionGuard;
 
@@ -112,16 +108,9 @@ public class HandoverStageService {
                 secureLink,
                 appProperties.getContactEmail()
         );
-        EmailSendResult result = emailSender.send(recipient.getEmail(), content);
-
-        emailLogRepository.save(EmailLog.builder()
-                .plan(stage.getPlan())
-                .handoverStage(stage)
-                .emailType(EmailType.POSTHUMOUS_HANDOFF_LINK)
-                .recipientEmail(recipient.getEmail())
-                .messageId(result.messageId())
-                .build());
-        stage.send();
+        // 실제 SMTP 발송은 EmailOutboxScheduler가 담당한다. stage.send()/EmailLog 기록도
+        // 발송이 실제로 성공했을 때만 워커가 수행하므로, 여기서는 무조건 SENT로 기록되는 일이 없다.
+        emailOutboxService.enqueue(stage.getPlan(), stage, EmailType.POSTHUMOUS_HANDOFF_LINK, recipient.getEmail(), content);
     }
 
     private HandoverStage findStage(ReleaseCase releaseCase, Long stageId) {

--- a/src/main/java/com/mamoki/ieojuda/global/config/AppProperties.java
+++ b/src/main/java/com/mamoki/ieojuda/global/config/AppProperties.java
@@ -18,4 +18,8 @@ public class AppProperties {
 
     @Value("${app.invite-token-ttl-hours}")
     private long inviteTokenTtlHours;
+
+    // issue #51 - 이메일 아웃박스 워커가 이 횟수만큼 실패하면 DEAD로 전이하고 재시도를 멈춘다.
+    @Value("${app.email.outbox.max-attempts}")
+    private int emailOutboxMaxAttempts;
 }

--- a/src/main/java/com/mamoki/ieojuda/global/email/outbox/EmailOutbox.java
+++ b/src/main/java/com/mamoki/ieojuda/global/email/outbox/EmailOutbox.java
@@ -1,0 +1,90 @@
+package com.mamoki.ieojuda.global.email.outbox;
+
+import com.mamoki.ieojuda.domain.audit.entity.EmailLog;
+import com.mamoki.ieojuda.domain.stage.entity.HandoverStage;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+// issue #51 - SMTP 호출을 DB 트랜잭션 밖으로 빼기 위한 아웃박스 작업 단위.
+// 호출자 트랜잭션은 이 행을 EmailLog와 함께 커밋하기만 하고, 실제 발송은 EmailOutboxScheduler가 담당한다.
+// 하나의 EmailLog가 여러 EmailOutbox 행을 가질 수 있다(최초 발송 + 관리자 재시도마다 새 행).
+@Entity
+@Table(name = "email_outbox")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EmailOutbox {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "outbox_id")
+    private Long outboxId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "log_id", nullable = false)
+    private EmailLog emailLog;
+
+    // 성공 시에만 stage.send()를 호출하기 위한 참조. 확인자/이의제기 연락처 발송 등은 단계가 없어 null.
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "stage_id", nullable = true)
+    private HandoverStage handoverStage;
+
+    @Column(name = "recipient_email", length = 255)
+    private String recipientEmail;
+
+    @Column(name = "subject", length = 255)
+    private String subject;
+
+    // 호출자 트랜잭션에서 EmailBuilder로 미리 렌더링한 본문. 워커는 비즈니스 로직을 다시 돌리지 않는다.
+    @Lob
+    @Column(name = "body")
+    private String body;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 20)
+    private EmailOutboxStatus status;
+
+    @Column(name = "attempt_count")
+    private Integer attemptCount;
+
+    @Column(name = "last_error", length = 1000)
+    private String lastError;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public EmailOutbox(EmailLog emailLog, HandoverStage handoverStage, String recipientEmail,
+                        String subject, String body) {
+        this.emailLog = emailLog;
+        this.handoverStage = handoverStage;
+        this.recipientEmail = recipientEmail;
+        this.subject = subject;
+        this.body = body;
+        this.status = EmailOutboxStatus.PENDING;
+        this.attemptCount = 0;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public void markSent() {
+        this.status = EmailOutboxStatus.SENT;
+        this.lastError = null;
+    }
+
+    // 재시도 가능한 실패 - PENDING을 유지해 다음 워커 주기에 다시 시도한다.
+    public void recordFailedAttempt(String reason) {
+        this.attemptCount = this.attemptCount + 1;
+        this.lastError = reason;
+    }
+
+    // 더 이상 재시도하지 않는다 (최대 횟수 초과 또는 영구 반송) - DEAD로 전이해 다음 주기부터 조회되지 않게 한다.
+    public void giveUp(String reason) {
+        this.attemptCount = this.attemptCount + 1;
+        this.lastError = reason;
+        this.status = EmailOutboxStatus.DEAD;
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/global/email/outbox/EmailOutboxRepository.java
+++ b/src/main/java/com/mamoki/ieojuda/global/email/outbox/EmailOutboxRepository.java
@@ -1,0 +1,19 @@
+package com.mamoki.ieojuda.global.email.outbox;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface EmailOutboxRepository extends JpaRepository<EmailOutbox, Long> {
+
+    // EmailOutboxScheduler - 발송 대기 중인 행을 가져온다. EvidenceRepository의
+    // findDueForDeletionForUpdateSkipLocked와 동일한 이유로 FOR UPDATE SKIP LOCKED + LIMIT 사용
+    // (다중 인스턴스 중복 처리 방지, 한 배치가 잡는 잠금 개수 제한).
+    @Query(value = "SELECT * FROM email_outbox " +
+            "WHERE status = 'PENDING' " +
+            "ORDER BY created_at " +
+            "LIMIT 100 " +
+            "FOR UPDATE SKIP LOCKED", nativeQuery = true)
+    List<EmailOutbox> findPendingForUpdateSkipLocked();
+}

--- a/src/main/java/com/mamoki/ieojuda/global/email/outbox/EmailOutboxScheduler.java
+++ b/src/main/java/com/mamoki/ieojuda/global/email/outbox/EmailOutboxScheduler.java
@@ -1,0 +1,76 @@
+package com.mamoki.ieojuda.global.email.outbox;
+
+import com.mamoki.ieojuda.domain.audit.entity.AdminActionType;
+import com.mamoki.ieojuda.domain.audit.entity.EmailLog;
+import com.mamoki.ieojuda.domain.audit.service.AdminActionAuditService;
+import com.mamoki.ieojuda.domain.stage.entity.HandoverStage;
+import com.mamoki.ieojuda.global.config.AppProperties;
+import com.mamoki.ieojuda.global.email.contract.EmailContent;
+import com.mamoki.ieojuda.global.email.contract.EmailSendResult;
+import com.mamoki.ieojuda.global.email.sender.EmailSender;
+import com.mamoki.ieojuda.global.email.sender.RetryPolicy;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+// issue #51 - 아웃박스에 쌓인 이메일을 실제로 발송하는 워커.
+// EvidenceDeletionScheduler와 동일한 이유로 FOR UPDATE SKIP LOCKED를 써서 다중 인스턴스가 같은 행을
+// 중복 처리하지 않게 하고(정확히 한 번 처리), 한 건의 실패가 다른 건의 성공을 롤백시키지 않도록
+// 행 단위로 예외를 격리한다. status='PENDING' 조건 자체가 재시도 가드다.
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EmailOutboxScheduler {
+
+    private final EmailOutboxRepository emailOutboxRepository;
+    private final EmailSender emailSender;
+    private final AppProperties appProperties;
+    private final AdminActionAuditService adminActionAuditService;
+
+    // 10분마다 - EvidenceDeletionScheduler/ReleaseCaseScheduler와 같은 주기
+    @Scheduled(fixedRate = 600_000)
+    @Transactional
+    public void dispatchPending() {
+        List<EmailOutbox> pending = emailOutboxRepository.findPendingForUpdateSkipLocked();
+
+        for (EmailOutbox outbox : pending) {
+            dispatchOne(outbox);
+        }
+    }
+
+    private void dispatchOne(EmailOutbox outbox) {
+        EmailContent content = new EmailContent(outbox.getSubject(), outbox.getBody());
+        EmailSendResult result = emailSender.send(outbox.getRecipientEmail(), content);
+        EmailLog emailLog = outbox.getEmailLog();
+
+        if (result.success()) {
+            emailLog.markSent(result.messageId());
+            outbox.markSent();
+            HandoverStage stage = outbox.getHandoverStage();
+            if (stage != null) {
+                stage.send();
+            }
+            return;
+        }
+
+        String reason = describeFailure(result);
+        emailLog.markFailed(reason);
+        if (RetryPolicy.canRetry(result.bounceType(), outbox.getAttemptCount(), appProperties.getEmailOutboxMaxAttempts())) {
+            outbox.recordFailedAttempt(reason);
+        } else {
+            outbox.giveUp(reason);
+            log.error("[Email Outbox Dispatch Failed] outboxId={}, recipient={}, cause={}",
+                    outbox.getOutboxId(), outbox.getRecipientEmail(), reason);
+            adminActionAuditService.recordSystem(
+                    AdminActionType.EMAIL_OUTBOX_DISPATCH_FAILED, outbox.getOutboxId(), false, reason);
+        }
+    }
+
+    private String describeFailure(EmailSendResult result) {
+        return result.bounceType() + ":" + result.emailFaill();
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/global/email/outbox/EmailOutboxService.java
+++ b/src/main/java/com/mamoki/ieojuda/global/email/outbox/EmailOutboxService.java
@@ -1,0 +1,55 @@
+package com.mamoki.ieojuda.global.email.outbox;
+
+import com.mamoki.ieojuda.domain.audit.entity.EmailLog;
+import com.mamoki.ieojuda.domain.audit.entity.EmailType;
+import com.mamoki.ieojuda.domain.audit.repository.EmailLogRepository;
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.stage.entity.HandoverStage;
+import com.mamoki.ieojuda.global.email.contract.EmailContent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+// issue #51 - SMTP 발송을 DB 트랜잭션 밖으로 분리하는 트랜잭셔널 아웃박스의 유일한 쓰기 지점.
+// 여기는 순수 DB 저장만 하고 네트워크 호출은 하지 않는다 - 호출부의 기존 @Transactional 경계에
+// 그대로 참여해서, 비즈니스 데이터와 발송 요청이 같은 트랜잭션에 원자적으로 커밋되게 한다
+// (IdempotencyGuard와 같은 이유로 독립 트랜잭션을 쓰지 않는다). 실제 발송은 EmailOutboxScheduler가 담당.
+@Component
+@RequiredArgsConstructor
+public class EmailOutboxService {
+
+    private final EmailLogRepository emailLogRepository;
+    private final EmailOutboxRepository emailOutboxRepository;
+
+    // 신규 발송 요청 - 새 EmailLog(REQUESTED)와 EmailOutbox 행을 같은 트랜잭션에 커밋한다.
+    public void enqueue(Plan plan, HandoverStage handoverStage, EmailType emailType,
+                         String recipientEmail, EmailContent content) {
+        EmailLog log = emailLogRepository.save(EmailLog.builder()
+                .plan(plan)
+                .handoverStage(handoverStage)
+                .emailType(emailType)
+                .recipientEmail(recipientEmail)
+                .build());
+
+        emailOutboxRepository.save(EmailOutbox.builder()
+                .emailLog(log)
+                .handoverStage(handoverStage)
+                .recipientEmail(recipientEmail)
+                .subject(content.subject())
+                .body(content.body())
+                .build());
+    }
+
+    // "이메일 발송 감사" 화면 "재시도 정책 실행하기" - 기존 EmailLog(이력 보존)를 REQUESTED로 되돌리고
+    // 새 EmailOutbox 행만 추가한다.
+    public void enqueueRetry(EmailLog existingLog, EmailContent content) {
+        existingLog.recordRetryRequested();
+
+        emailOutboxRepository.save(EmailOutbox.builder()
+                .emailLog(existingLog)
+                .handoverStage(existingLog.getHandoverStage())
+                .recipientEmail(existingLog.getRecipientEmail())
+                .subject(content.subject())
+                .body(content.body())
+                .build());
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/global/email/outbox/EmailOutboxStatus.java
+++ b/src/main/java/com/mamoki/ieojuda/global/email/outbox/EmailOutboxStatus.java
@@ -1,0 +1,7 @@
+package com.mamoki.ieojuda.global.email.outbox;
+
+public enum EmailOutboxStatus {
+    PENDING, // 다음 워커 주기에 처리 대상 (재시도 가드 - 이 상태인 행만 조회된다)
+    SENT,    // 발송 성공, 종결
+    DEAD     // 최대 시도 횟수 초과, 종결(관리자 개입 필요)
+}

--- a/src/main/java/com/mamoki/ieojuda/global/email/sender/FailureAnalyzer.java
+++ b/src/main/java/com/mamoki/ieojuda/global/email/sender/FailureAnalyzer.java
@@ -2,6 +2,7 @@ package com.mamoki.ieojuda.global.email.sender;
 
 import com.mamoki.ieojuda.global.email.contract.BounceType;
 import com.mamoki.ieojuda.global.email.contract.EmailFaill;
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 import jakarta.mail.SendFailedException;
 import jakarta.mail.internet.AddressException;
 import org.springframework.mail.MailAuthenticationException;
@@ -19,6 +20,11 @@ public class FailureAnalyzer {
         // 주소 형식 오류 (전송 시도 이전, MimeMessageHelper.setTo() 등에서 발생)
         if (exception instanceof AddressException) {
             return new Result(BounceType.PERMANENT, EmailFaill.INVALID_ADDRESS_FORMAT);
+        }
+
+        // issue #51 - 회로 차단기가 OPEN 상태라 이번 시도 자체가 거부됨 (연속 실패가 누적된 상황)
+        if (exception instanceof CallNotPermittedException) {
+            return new Result(BounceType.TEMPORARY, EmailFaill.CONNECTION_TIMEOUT);
         }
 
         // 메일 서버 인증 실패

--- a/src/main/java/com/mamoki/ieojuda/global/email/sender/GmailSender.java
+++ b/src/main/java/com/mamoki/ieojuda/global/email/sender/GmailSender.java
@@ -2,21 +2,34 @@ package com.mamoki.ieojuda.global.email.sender;
 
 import com.mamoki.ieojuda.global.email.contract.EmailContent;
 import com.mamoki.ieojuda.global.email.contract.EmailSendResult;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.github.resilience4j.retry.Retry;
+import io.github.resilience4j.retry.RetryRegistry;
 import jakarta.mail.internet.MimeMessage;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Component;
 
 import java.util.UUID;
+import java.util.function.Supplier;
 
+// issue #51 - EmailOutboxScheduler의 한 시도 안에서 발생하는 일시적 SMTP 장애를 짧게 흡수한다
+// (긴 호흡의 재전송은 EmailOutbox.attemptCount가 스케줄러 주기 단위로 담당 - 서로 다른 레이어라 이중 재시도가 아니다).
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class GmailSender implements EmailSender {
 
     private final JavaMailSender javaMailSender;
+    private final Retry retry;
+    private final CircuitBreaker circuitBreaker;
+
+    public GmailSender(JavaMailSender javaMailSender, RetryRegistry retryRegistry, CircuitBreakerRegistry circuitBreakerRegistry) {
+        this.javaMailSender = javaMailSender;
+        this.retry = retryRegistry.retry("emailSend");
+        this.circuitBreaker = circuitBreakerRegistry.circuitBreaker("emailSend");
+    }
 
     @Override
     public EmailSendResult send(String toEmail, EmailContent content) {
@@ -28,7 +41,11 @@ public class GmailSender implements EmailSender {
             helper.setSubject(content.subject());
             helper.setText(content.body(), false);
 
-            javaMailSender.send(message);
+            Supplier<Void> sendOnce = Retry.decorateSupplier(retry, () -> {
+                javaMailSender.send(message);
+                return null;
+            });
+            CircuitBreaker.decorateSupplier(circuitBreaker, sendOnce).get();
 
             //이 메일 한 통의 고유 식별자 (어떤 발송 건인지)
             String messageId = message.getMessageID() != null // 이메일 발송 이력 추적을 위해 (phase8 고려)

--- a/src/main/java/com/mamoki/ieojuda/global/storage/S3EvidenceStorageClient.java
+++ b/src/main/java/com/mamoki/ieojuda/global/storage/S3EvidenceStorageClient.java
@@ -5,7 +5,11 @@ import com.mamoki.ieojuda.global.exception.ErrorCode;
 import com.mamoki.ieojuda.global.storage.config.S3Properties;
 import com.mamoki.ieojuda.global.storage.contract.EvidenceUpload;
 import com.mamoki.ieojuda.global.storage.contract.StoredEvidence;
-import lombok.RequiredArgsConstructor;
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.github.resilience4j.retry.Retry;
+import io.github.resilience4j.retry.RetryRegistry;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import software.amazon.awssdk.core.exception.SdkException;
@@ -19,13 +23,35 @@ import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.ServerSideEncryption;
 
+import java.util.function.Supplier;
+
+// issue #51 - store/load/delete 각각 짧은 재시도+회로차단을 별도로 둔다. store는 사용자 대면 업로드
+// 경로라 더 빨리 실패해야 하고, delete/load는 백그라운드 스케줄러가 다음 주기에 다시 시도해주므로
+// 상대적으로 여유를 둘 수 있다 - application.properties의 s3Put/s3Get/s3Delete 인스턴스 설정 참고.
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class S3EvidenceStorageClient implements EvidenceStorageClient {
 
     private final S3Client s3Client;
     private final S3Properties s3Properties;
+    private final Retry putRetry;
+    private final CircuitBreaker putCircuitBreaker;
+    private final Retry getRetry;
+    private final CircuitBreaker getCircuitBreaker;
+    private final Retry deleteRetry;
+    private final CircuitBreaker deleteCircuitBreaker;
+
+    public S3EvidenceStorageClient(S3Client s3Client, S3Properties s3Properties,
+                                    RetryRegistry retryRegistry, CircuitBreakerRegistry circuitBreakerRegistry) {
+        this.s3Client = s3Client;
+        this.s3Properties = s3Properties;
+        this.putRetry = retryRegistry.retry("s3Put");
+        this.putCircuitBreaker = circuitBreakerRegistry.circuitBreaker("s3Put");
+        this.getRetry = retryRegistry.retry("s3Get");
+        this.getCircuitBreaker = circuitBreakerRegistry.circuitBreaker("s3Get");
+        this.deleteRetry = retryRegistry.retry("s3Delete");
+        this.deleteCircuitBreaker = circuitBreakerRegistry.circuitBreaker("s3Delete");
+    }
 
     @Override
     public StoredEvidence store(Long caseId, EvidenceUpload upload) {
@@ -34,18 +60,23 @@ public class S3EvidenceStorageClient implements EvidenceStorageClient {
         try {
             // Supplier로 감싼 스트림을 넘긴다 - 전송 실패로 SDK가 재시도할 때마다
             // ContentStreamProvider가 새 스트림을 열어준다(멀티파트 임시 파일에서 다시 읽음).
-            s3Client.putObject(
-                    PutObjectRequest.builder()
-                            .bucket(s3Properties.getBucket())
-                            .key(storageKey)
-                            .contentType(upload.mimeType())
-                            .serverSideEncryption(ServerSideEncryption.AES256)
-                            .build(),
-                    RequestBody.fromContentProvider(
-                            ContentStreamProvider.fromInputStreamSupplier(upload.content()),
-                            upload.contentLength(),
-                            upload.mimeType()));
-        } catch (SdkException e) {
+            PutObjectRequest request = PutObjectRequest.builder()
+                    .bucket(s3Properties.getBucket())
+                    .key(storageKey)
+                    .contentType(upload.mimeType())
+                    .serverSideEncryption(ServerSideEncryption.AES256)
+                    .build();
+            RequestBody requestBody = RequestBody.fromContentProvider(
+                    ContentStreamProvider.fromInputStreamSupplier(upload.content()),
+                    upload.contentLength(),
+                    upload.mimeType());
+
+            Supplier<Void> putOnce = Retry.decorateSupplier(putRetry, () -> {
+                s3Client.putObject(request, requestBody);
+                return null;
+            });
+            CircuitBreaker.decorateSupplier(putCircuitBreaker, putOnce).get();
+        } catch (SdkException | CallNotPermittedException e) {
             log.error("[Evidence Store Failed] caseId={}, cause={}", caseId, e.getMessage(), e);
             throw new CustomException(ErrorCode.EVIDENCE_STORAGE_FAILED);
         }
@@ -56,15 +87,16 @@ public class S3EvidenceStorageClient implements EvidenceStorageClient {
     @Override
     public byte[] load(String storageKey) {
         try {
-            return s3Client.getObject(
+            Supplier<byte[]> loadOnce = Retry.decorateSupplier(getRetry, () -> s3Client.getObject(
                     GetObjectRequest.builder()
                             .bucket(s3Properties.getBucket())
                             .key(storageKey)
                             .build(),
-                    ResponseTransformer.toBytes()).asByteArray();
+                    ResponseTransformer.toBytes()).asByteArray());
+            return CircuitBreaker.decorateSupplier(getCircuitBreaker, loadOnce).get();
         } catch (NoSuchKeyException e) { //S3에 해당 storageKey에 해당하는 파일이 없을 경우
             throw new CustomException(ErrorCode.EVIDENCE_NOT_FOUND);
-        } catch (SdkException e) { // 네트워크 단계나 S3 연동 문제
+        } catch (SdkException | CallNotPermittedException e) { // 네트워크 단계나 S3 연동 문제
             log.error("[Evidence Load Failed] storageKey={}, cause={}", storageKey, e.getMessage(), e);
             throw new CustomException(ErrorCode.EVIDENCE_STORAGE_FAILED);
         }
@@ -73,12 +105,16 @@ public class S3EvidenceStorageClient implements EvidenceStorageClient {
     @Override
     public void delete(String storageKey) {
         try {
-            s3Client.deleteObject(
-                    DeleteObjectRequest.builder()
-                            .bucket(s3Properties.getBucket())
-                            .key(storageKey)
-                            .build());
-        } catch (SdkException e) {
+            Supplier<Void> deleteOnce = Retry.decorateSupplier(deleteRetry, () -> {
+                s3Client.deleteObject(
+                        DeleteObjectRequest.builder()
+                                .bucket(s3Properties.getBucket())
+                                .key(storageKey)
+                                .build());
+                return null;
+            });
+            CircuitBreaker.decorateSupplier(deleteCircuitBreaker, deleteOnce).get();
+        } catch (SdkException | CallNotPermittedException e) {
             log.error("[Evidence Delete Failed] storageKey={}, cause={}", storageKey, e.getMessage(), e);
             throw new CustomException(ErrorCode.EVIDENCE_STORAGE_FAILED);
         }

--- a/src/main/java/com/mamoki/ieojuda/global/storage/config/S3Config.java
+++ b/src/main/java/com/mamoki/ieojuda/global/storage/config/S3Config.java
@@ -4,8 +4,12 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.retries.StandardRetryStrategy;
 import software.amazon.awssdk.services.s3.S3Client;
+
+import java.time.Duration;
 
 @Configuration
 public class S3Config {
@@ -17,6 +21,13 @@ public class S3Config {
                 // EC2 배포 시 이 한 줄만 DefaultCredentialsProvider.create()로 교체하면 IAM Role을 쓴다
                 .credentialsProvider(StaticCredentialsProvider.create(
                         AwsBasicCredentials.create(s3Properties.getAccessKey(), s3Properties.getSecretKey())))
+                // issue #51 - SDK 기본값은 사실상 무제한 대기라 응답 없는 S3 호출에 스레드가 묶일 수 있음.
+                // 재시도 자체는 Resilience4j(S3EvidenceStorageClient)가 담당하므로 SDK 자체 재시도는 끈다.
+                .overrideConfiguration(ClientOverrideConfiguration.builder()
+                        .apiCallAttemptTimeout(Duration.ofSeconds(5))
+                        .apiCallTimeout(Duration.ofSeconds(15))
+                        .retryStrategy(StandardRetryStrategy.builder().maxAttempts(1).build())
+                        .build())
                 .build();
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -25,6 +25,21 @@ spring.mail.username=${MAIL_USERNAME}
 spring.mail.password=${MAIL_PASSWORD}
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
+# SMTP 타임아웃 (issue #51) - 기본값은 무제한 대기라 응답 없는 서버에 스레드가 계속 묶일 수 있음
+spring.mail.properties.mail.smtp.connectiontimeout=5000
+spring.mail.properties.mail.smtp.timeout=5000
+spring.mail.properties.mail.smtp.writetimeout=5000
+
+# Resilience4j - 이메일 발송 (issue #51). 짧은 재시도로 순간적인 블립만 흡수하고,
+# 그래도 계속 실패하면 EmailOutbox.attemptCount가 다음 스케줄러 주기에 다시 시도한다.
+resilience4j.retry.instances.emailSend.max-attempts=3
+resilience4j.retry.instances.emailSend.wait-duration=1s
+resilience4j.retry.instances.emailSend.enable-exponential-backoff=true
+resilience4j.retry.instances.emailSend.exponential-backoff-multiplier=2
+resilience4j.circuitbreaker.instances.emailSend.sliding-window-size=10
+resilience4j.circuitbreaker.instances.emailSend.failure-rate-threshold=50
+resilience4j.circuitbreaker.instances.emailSend.wait-duration-in-open-state=30s
+resilience4j.circuitbreaker.instances.emailSend.permitted-number-of-calls-in-half-open-state=3
 
 # 공식 증빙 자료 제출 - 파일당 25MB, 요청 전체 30MB
 spring.servlet.multipart.max-file-size=25MB

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -41,6 +41,24 @@ resilience4j.circuitbreaker.instances.emailSend.failure-rate-threshold=50
 resilience4j.circuitbreaker.instances.emailSend.wait-duration-in-open-state=30s
 resilience4j.circuitbreaker.instances.emailSend.permitted-number-of-calls-in-half-open-state=3
 
+# Resilience4j - S3 (issue #51). s3Put은 사용자 대면 업로드 경로라 짧게, s3Get/s3Delete는
+# 백그라운드 스케줄러가 다음 주기에 다시 시도해주므로 상대적으로 여유를 둔다.
+resilience4j.retry.instances.s3Put.max-attempts=3
+resilience4j.retry.instances.s3Put.wait-duration=500ms
+resilience4j.retry.instances.s3Get.max-attempts=3
+resilience4j.retry.instances.s3Get.wait-duration=500ms
+resilience4j.retry.instances.s3Delete.max-attempts=3
+resilience4j.retry.instances.s3Delete.wait-duration=500ms
+resilience4j.circuitbreaker.instances.s3Put.sliding-window-size=10
+resilience4j.circuitbreaker.instances.s3Put.failure-rate-threshold=50
+resilience4j.circuitbreaker.instances.s3Put.wait-duration-in-open-state=30s
+resilience4j.circuitbreaker.instances.s3Get.sliding-window-size=10
+resilience4j.circuitbreaker.instances.s3Get.failure-rate-threshold=50
+resilience4j.circuitbreaker.instances.s3Get.wait-duration-in-open-state=30s
+resilience4j.circuitbreaker.instances.s3Delete.sliding-window-size=10
+resilience4j.circuitbreaker.instances.s3Delete.failure-rate-threshold=50
+resilience4j.circuitbreaker.instances.s3Delete.wait-duration-in-open-state=30s
+
 # 공식 증빙 자료 제출 - 파일당 25MB, 요청 전체 30MB
 spring.servlet.multipart.max-file-size=25MB
 spring.servlet.multipart.max-request-size=30MB

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -51,3 +51,5 @@ app.base-url=${APP_BASE_URL}
 app.contact-email=${APP_CONTACT_EMAIL}
 # 초대 링크 토큰 시간
 app.invite-token-ttl-hours=72
+# 이메일 아웃박스 워커 최대 재시도 횟수 (issue #51)
+app.email.outbox.max-attempts=5

--- a/src/test/java/com/mamoki/ieojuda/domain/audit/entity/EmailLogTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/audit/entity/EmailLogTest.java
@@ -1,0 +1,69 @@
+package com.mamoki.ieojuda.domain.audit.entity;
+
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+// issue #51 - EmailLog가 "SENT"로 기록되는 경로는 markSent() 하나뿐이어야 한다는 것이 이번 리팩터의 핵심.
+class EmailLogTest {
+
+    @Test
+    void construct_startsAsRequestedWithoutSentAt() {
+        EmailLog log = EmailLog.builder()
+                .plan(mock(Plan.class))
+                .handoverStage(null)
+                .emailType(EmailType.POSTHUMOUS_HANDOFF_LINK)
+                .recipientEmail("test@example.com")
+                .build();
+
+        assertThat(log.getStatus()).isEqualTo(EmailDeliveryStatus.REQUESTED);
+        assertThat(log.getSentAt()).isNull();
+        assertThat(log.getRequestedAt()).isNotNull();
+        assertThat(log.getRetryCount()).isZero();
+    }
+
+    @Test
+    void markSent_setsSentStatusAndSentAtAndMessageId() {
+        EmailLog log = newRequestedLog();
+
+        log.markSent("message-id-1");
+
+        assertThat(log.getStatus()).isEqualTo(EmailDeliveryStatus.SENT);
+        assertThat(log.getMessageId()).isEqualTo("message-id-1");
+        assertThat(log.getSentAt()).isNotNull();
+    }
+
+    @Test
+    void markFailed_setsFailedStatusAndReason_neverTouchesSentAt() {
+        EmailLog log = newRequestedLog();
+
+        log.markFailed("TEMPORARY:CONNECTION_TIMEOUT");
+
+        assertThat(log.getStatus()).isEqualTo(EmailDeliveryStatus.FAILED);
+        assertThat(log.getFailureReason()).isEqualTo("TEMPORARY:CONNECTION_TIMEOUT");
+        assertThat(log.getSentAt()).isNull();
+    }
+
+    @Test
+    void recordRetryRequested_incrementsRetryCountAndResetsToRequested() {
+        EmailLog log = newRequestedLog();
+        log.markFailed("TEMPORARY:CONNECTION_TIMEOUT");
+
+        log.recordRetryRequested();
+
+        assertThat(log.getRetryCount()).isEqualTo(1);
+        assertThat(log.getStatus()).isEqualTo(EmailDeliveryStatus.REQUESTED);
+        assertThat(log.getFailureReason()).isNull();
+    }
+
+    private EmailLog newRequestedLog() {
+        return EmailLog.builder()
+                .plan(mock(Plan.class))
+                .handoverStage(null)
+                .emailType(EmailType.POSTHUMOUS_HANDOFF_LINK)
+                .recipientEmail("test@example.com")
+                .build();
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/domain/confirmer/service/DisputeContactServiceBolaTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/confirmer/service/DisputeContactServiceBolaTest.java
@@ -5,7 +5,7 @@ import com.mamoki.ieojuda.domain.confirmer.repository.DisputeContactRepository;
 import com.mamoki.ieojuda.domain.plan.repository.PlanRepository;
 import com.mamoki.ieojuda.domain.plan.service.PlanOwnershipReader;
 import com.mamoki.ieojuda.global.config.AppProperties;
-import com.mamoki.ieojuda.global.email.sender.EmailSender;
+import com.mamoki.ieojuda.global.email.outbox.EmailOutboxService;
 import com.mamoki.ieojuda.global.exception.CustomException;
 import com.mamoki.ieojuda.global.exception.ErrorCode;
 import com.mamoki.ieojuda.global.ratelimit.PublicLinkAuditor;
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 // 사용자 B가 사용자 A의 planId에 이의 제기 연락처를 등록/수정하려 하면 PLAN_NOT_FOUND로 막혀야 한다.
-// 통과시키면 공격자가 스스로를 피해자 계획의 이의 제기 연락처로 등록해 발송 거부권을 얻으므로, disputeContactRepository/emailSender에
+// 통과시키면 공격자가 스스로를 피해자 계획의 이의 제기 연락처로 등록해 발송 거부권을 얻으므로, disputeContactRepository/emailOutboxService에
 // 전혀 손대지 않는지가 특히 중요하다.
 class DisputeContactServiceBolaTest {
 
@@ -32,18 +32,18 @@ class DisputeContactServiceBolaTest {
 
     private PlanRepository planRepository;
     private DisputeContactRepository disputeContactRepository;
-    private EmailSender emailSender;
+    private EmailOutboxService emailOutboxService;
     private DisputeContactService disputeContactService;
 
     @BeforeEach
     void setUp() {
         planRepository = mock(PlanRepository.class);
         disputeContactRepository = mock(DisputeContactRepository.class);
-        emailSender = mock(EmailSender.class);
+        emailOutboxService = mock(EmailOutboxService.class);
         disputeContactService = new DisputeContactService(
                 new PlanOwnershipReader(planRepository),
                 disputeContactRepository,
-                emailSender,
+                emailOutboxService,
                 mock(AppProperties.class),
                 mock(TokenLookupGuard.class),
                 mock(PublicLinkAuditor.class)
@@ -59,7 +59,7 @@ class DisputeContactServiceBolaTest {
                 .isInstanceOfSatisfying(CustomException.class,
                         exception -> assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.PLAN_NOT_FOUND));
         verifyNoInteractions(disputeContactRepository);
-        verifyNoInteractions(emailSender);
+        verifyNoInteractions(emailOutboxService);
     }
 
     @Test
@@ -70,6 +70,6 @@ class DisputeContactServiceBolaTest {
                 .isInstanceOfSatisfying(CustomException.class,
                         exception -> assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.PLAN_NOT_FOUND));
         verifyNoInteractions(disputeContactRepository);
-        verifyNoInteractions(emailSender);
+        verifyNoInteractions(emailOutboxService);
     }
 }

--- a/src/test/java/com/mamoki/ieojuda/domain/evidence/scheduler/EvidenceOrphanCleanupSchedulerTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/evidence/scheduler/EvidenceOrphanCleanupSchedulerTest.java
@@ -1,0 +1,118 @@
+package com.mamoki.ieojuda.domain.evidence.scheduler;
+
+import com.mamoki.ieojuda.domain.audit.entity.AdminActionType;
+import com.mamoki.ieojuda.domain.audit.service.AdminActionAuditService;
+import com.mamoki.ieojuda.domain.evidence.entity.EvidenceOrphanCleanup;
+import com.mamoki.ieojuda.domain.evidence.repository.EvidenceOrphanCleanupRepository;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import com.mamoki.ieojuda.global.storage.EvidenceStorageClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+// issue #51 - S3 보정 삭제 실패로 기록된 고아 객체를 재처리하는 워커. EvidenceDeletionSchedulerTest와
+// 동일하게, 한 건의 실패가 다른 건의 성공을 막지 않아야 한다(배치 트랜잭션 하나로 묶여 있기 때문).
+class EvidenceOrphanCleanupSchedulerTest {
+
+    private EvidenceOrphanCleanupRepository evidenceOrphanCleanupRepository;
+    private EvidenceStorageClient evidenceStorageClient;
+    private AdminActionAuditService adminActionAuditService;
+    private EvidenceOrphanCleanupScheduler scheduler;
+
+    @BeforeEach
+    void setUp() {
+        evidenceOrphanCleanupRepository = mock(EvidenceOrphanCleanupRepository.class);
+        evidenceStorageClient = mock(EvidenceStorageClient.class);
+        adminActionAuditService = mock(AdminActionAuditService.class);
+        scheduler = new EvidenceOrphanCleanupScheduler(evidenceOrphanCleanupRepository, evidenceStorageClient, adminActionAuditService);
+    }
+
+    @Test
+    void cleanupOrphans_whenNoneAreDue_doesNothing() {
+        when(evidenceOrphanCleanupRepository.findPendingForUpdateSkipLocked()).thenReturn(List.of());
+
+        scheduler.cleanupOrphans();
+
+        verifyNoInteractions(evidenceStorageClient, adminActionAuditService);
+    }
+
+    @Test
+    void cleanupOrphans_whenStorageDeleteSucceeds_marksDeletedWithoutAuditingSuccess() {
+        EvidenceOrphanCleanup cleanup = mock(EvidenceOrphanCleanup.class);
+        when(cleanup.getStorageKey()).thenReturn("evidence/1/uuid.pdf");
+        when(evidenceOrphanCleanupRepository.findPendingForUpdateSkipLocked()).thenReturn(List.of(cleanup));
+
+        scheduler.cleanupOrphans();
+
+        verify(evidenceStorageClient).delete("evidence/1/uuid.pdf");
+        verify(cleanup).markDeleted();
+        verify(cleanup, never()).markDeleteFailed(anyString());
+        verifyNoInteractions(adminActionAuditService);
+    }
+
+    @Test
+    void cleanupOrphans_whenStorageDeleteFails_marksFailedAndAudits() {
+        EvidenceOrphanCleanup cleanup = mock(EvidenceOrphanCleanup.class);
+        when(cleanup.getCleanupId()).thenReturn(5L);
+        when(cleanup.getStorageKey()).thenReturn("evidence/5/uuid.pdf");
+        when(evidenceOrphanCleanupRepository.findPendingForUpdateSkipLocked()).thenReturn(List.of(cleanup));
+        doThrow(new CustomException(ErrorCode.EVIDENCE_STORAGE_FAILED))
+                .when(evidenceStorageClient).delete("evidence/5/uuid.pdf");
+
+        scheduler.cleanupOrphans();
+
+        verify(cleanup, never()).markDeleted();
+        verify(cleanup).markDeleteFailed(anyString());
+        verify(adminActionAuditService)
+                .recordSystem(eq(AdminActionType.EVIDENCE_ORPHAN_CLEANUP), eq(5L), eq(false), anyString());
+    }
+
+    @Test
+    void cleanupOrphans_whenOneOfSeveralFails_theOthersStillGetDeleted() {
+        EvidenceOrphanCleanup failing = mock(EvidenceOrphanCleanup.class);
+        when(failing.getCleanupId()).thenReturn(1L);
+        when(failing.getStorageKey()).thenReturn("evidence/1/fail.pdf");
+        doThrow(new RuntimeException("boom")).when(evidenceStorageClient).delete("evidence/1/fail.pdf");
+
+        EvidenceOrphanCleanup succeeding = mock(EvidenceOrphanCleanup.class);
+        when(succeeding.getCleanupId()).thenReturn(2L);
+        when(succeeding.getStorageKey()).thenReturn("evidence/2/ok.pdf");
+
+        when(evidenceOrphanCleanupRepository.findPendingForUpdateSkipLocked())
+                .thenReturn(List.of(failing, succeeding));
+
+        scheduler.cleanupOrphans();
+
+        verify(failing).markDeleteFailed(anyString());
+        verify(succeeding).markDeleted();
+        verify(succeeding, never()).markDeleteFailed(anyString());
+    }
+
+    // 재처리 멱등성: 첫 주기에 성공한 행은 deleted_at이 채워져 status='PENDING' 조건에서 제외되므로
+    // 두 번째 실행에서 다시 조회되지 않는다 - evidenceStorageClient.delete가 두 번 호출되지 않는다.
+    @Test
+    void cleanupOrphans_calledTwice_whenRowAlreadyDeleted_doesNotDeleteAgain() {
+        EvidenceOrphanCleanup cleanup = mock(EvidenceOrphanCleanup.class);
+        when(cleanup.getStorageKey()).thenReturn("evidence/1/uuid.pdf");
+        when(evidenceOrphanCleanupRepository.findPendingForUpdateSkipLocked())
+                .thenReturn(List.of(cleanup))
+                .thenReturn(List.of());
+
+        scheduler.cleanupOrphans();
+        scheduler.cleanupOrphans();
+
+        verify(evidenceStorageClient, org.mockito.Mockito.times(1)).delete(any());
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/domain/evidence/service/EvidenceOrphanCleanupServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/evidence/service/EvidenceOrphanCleanupServiceTest.java
@@ -1,0 +1,38 @@
+package com.mamoki.ieojuda.domain.evidence.service;
+
+import com.mamoki.ieojuda.domain.evidence.entity.EvidenceOrphanCleanup;
+import com.mamoki.ieojuda.domain.evidence.repository.EvidenceOrphanCleanupRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+// issue #51 - registerCompensatingDelete의 즉시 삭제가 실패했을 때 재처리 대상으로 기록하는 지점.
+class EvidenceOrphanCleanupServiceTest {
+
+    private EvidenceOrphanCleanupRepository evidenceOrphanCleanupRepository;
+    private EvidenceOrphanCleanupService service;
+
+    @BeforeEach
+    void setUp() {
+        evidenceOrphanCleanupRepository = mock(EvidenceOrphanCleanupRepository.class);
+        service = new EvidenceOrphanCleanupService(evidenceOrphanCleanupRepository);
+    }
+
+    @Test
+    void recordOrphan_savesStorageKeyAndReason() {
+        service.recordOrphan("evidence/1/uuid.pdf", "RuntimeException");
+
+        ArgumentCaptor<EvidenceOrphanCleanup> captor = ArgumentCaptor.forClass(EvidenceOrphanCleanup.class);
+        verify(evidenceOrphanCleanupRepository).save(captor.capture());
+        EvidenceOrphanCleanup saved = captor.getValue();
+
+        assertThat(saved.getStorageKey()).isEqualTo("evidence/1/uuid.pdf");
+        assertThat(saved.getReason()).isEqualTo("RuntimeException");
+        assertThat(saved.getDeletedAt()).isNull();
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/domain/evidence/service/EvidenceSubmitServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/evidence/service/EvidenceSubmitServiceTest.java
@@ -17,9 +17,12 @@ import com.mamoki.ieojuda.global.scan.MalwareScanner;
 import com.mamoki.ieojuda.global.scan.ScanResult;
 import com.mamoki.ieojuda.global.storage.EvidenceStorageClient;
 import com.mamoki.ieojuda.global.storage.contract.StoredEvidence;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+import org.springframework.transaction.support.TransactionSynchronizationUtils;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
@@ -30,6 +33,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -47,6 +51,7 @@ class EvidenceSubmitServiceTest {
     private PublicLinkAuditor publicLinkAuditor;
     private IdempotencyGuard idempotencyGuard;
     private MalwareScanner malwareScanner;
+    private EvidenceOrphanCleanupService evidenceOrphanCleanupService;
     private EvidenceSubmitService evidenceSubmitService;
 
     private Confirmer confirmer;
@@ -63,9 +68,10 @@ class EvidenceSubmitServiceTest {
         publicLinkAuditor = mock(PublicLinkAuditor.class);
         idempotencyGuard = mock(IdempotencyGuard.class);
         malwareScanner = mock(MalwareScanner.class);
+        evidenceOrphanCleanupService = mock(EvidenceOrphanCleanupService.class);
         evidenceSubmitService = new EvidenceSubmitService(
                 confirmerRepository, releaseCaseRepository, evidenceRepository, evidenceStorageClient,
-                tokenLookupGuard, publicLinkAuditor, idempotencyGuard, malwareScanner);
+                tokenLookupGuard, publicLinkAuditor, idempotencyGuard, malwareScanner, evidenceOrphanCleanupService);
 
         // TokenLookupGuard는 실제 구현처럼 supplier를 그대로 실행해 confirmerRepository 목 설정이
         // 기존과 동일하게 동작하도록 위임한다.
@@ -89,6 +95,14 @@ class EvidenceSubmitServiceTest {
 
         when(evidenceRepository.countByReleaseCase_CaseId(10L)).thenReturn(0L);
         when(evidenceRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    }
+
+    @AfterEach
+    void tearDown() {
+        // registerCompensatingDelete 관련 테스트가 스레드로컬 동기화 상태를 남기지 않도록 정리
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.clearSynchronization();
+        }
     }
 
     @Test
@@ -154,5 +168,30 @@ class EvidenceSubmitServiceTest {
         evidenceSubmitService.submit("token", file, null);
 
         verify(releaseCase, never()).startEvidenceReview();
+    }
+
+    // issue #51 - DB 트랜잭션이 롤백된 뒤 보정 삭제(afterCompletion) 자체가 실패하면, 이전에는 로그만
+    // 남기고 예외를 삼켰다. 이제는 EvidenceOrphanCleanupService에 재처리 대상으로 기록해야 한다.
+    @Test
+    void submit_whenTransactionRollsBackAndCompensatingDeleteFails_recordsOrphanForRetry() {
+        byte[] pdfBytes = "%PDF-1.4\n%%EOF".getBytes(StandardCharsets.US_ASCII);
+        MockMultipartFile file = new MockMultipartFile("file", "proof.pdf", "application/pdf", pdfBytes);
+        when(malwareScanner.scan(any())).thenReturn(ScanResult.passed());
+        when(evidenceStorageClient.store(eq(10L), any()))
+                .thenReturn(new StoredEvidence("evidence/10/uuid.pdf", pdfBytes.length));
+        // 보정 삭제 자체가 실패하는 상황을 재현
+        doThrow(new RuntimeException("S3 unreachable")).when(evidenceStorageClient).delete("evidence/10/uuid.pdf");
+
+        TransactionSynchronizationManager.initSynchronization();
+        try {
+            evidenceSubmitService.submit("token", file, null);
+            // 실제 Spring 트랜잭션이 롤백된 뒤 afterCompletion을 호출하는 것과 동일하게 재현
+            TransactionSynchronizationUtils.triggerAfterCompletion(
+                    org.springframework.transaction.support.TransactionSynchronization.STATUS_ROLLED_BACK);
+        } finally {
+            TransactionSynchronizationManager.clearSynchronization();
+        }
+
+        verify(evidenceOrphanCleanupService).recordOrphan(eq("evidence/10/uuid.pdf"), eq("RuntimeException"));
     }
 }

--- a/src/test/java/com/mamoki/ieojuda/domain/plan/service/PlanServiceBolaTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/plan/service/PlanServiceBolaTest.java
@@ -7,7 +7,7 @@ import com.mamoki.ieojuda.domain.plan.entity.Plan;
 import com.mamoki.ieojuda.domain.plan.entity.PlanStatus;
 import com.mamoki.ieojuda.domain.plan.repository.PlanRepository;
 import com.mamoki.ieojuda.global.config.AppProperties;
-import com.mamoki.ieojuda.global.email.sender.EmailSender;
+import com.mamoki.ieojuda.global.email.outbox.EmailOutboxService;
 import com.mamoki.ieojuda.global.exception.CustomException;
 import com.mamoki.ieojuda.global.exception.ErrorCode;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,19 +31,19 @@ class PlanServiceBolaTest {
 
     private PlanRepository planRepository;
     private DisputeContactRepository disputeContactRepository;
-    private EmailSender emailSender;
+    private EmailOutboxService emailOutboxService;
     private PlanService planService;
 
     @BeforeEach
     void setUp() {
         planRepository = mock(PlanRepository.class);
         disputeContactRepository = mock(DisputeContactRepository.class);
-        emailSender = mock(EmailSender.class);
+        emailOutboxService = mock(EmailOutboxService.class);
         planService = new PlanService(
                 planRepository,
                 new PlanOwnershipReader(planRepository),
                 disputeContactRepository,
-                emailSender,
+                emailOutboxService,
                 mock(AppProperties.class)
         );
         // 사용자 A의 계획만 존재한다 - 사용자 B(공격자)로 조회하면 항상 빈 Optional
@@ -86,7 +86,7 @@ class PlanServiceBolaTest {
                 ATTACKER_ID, PLAN_ID, new SelfWarningEmailRequest("attacker@example.com")))
                 .isInstanceOfSatisfying(CustomException.class,
                         exception -> assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.PLAN_NOT_FOUND));
-        verifyNoInteractions(emailSender);
+        verifyNoInteractions(emailOutboxService);
     }
 
     @Test

--- a/src/test/java/com/mamoki/ieojuda/domain/plan/service/PlanServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/plan/service/PlanServiceTest.java
@@ -5,7 +5,7 @@ import com.mamoki.ieojuda.domain.plan.dto.ReleasePolicyRequest;
 import com.mamoki.ieojuda.domain.plan.entity.Plan;
 import com.mamoki.ieojuda.domain.plan.repository.PlanRepository;
 import com.mamoki.ieojuda.global.config.AppProperties;
-import com.mamoki.ieojuda.global.email.sender.EmailSender;
+import com.mamoki.ieojuda.global.email.outbox.EmailOutboxService;
 import com.mamoki.ieojuda.global.exception.CustomException;
 import com.mamoki.ieojuda.global.exception.ErrorCode;
 import jakarta.validation.Validation;
@@ -45,7 +45,7 @@ class PlanServiceTest {
                 planRepository,
                 new PlanOwnershipReader(planRepository),
                 mock(DisputeContactRepository.class),
-                mock(EmailSender.class),
+                mock(EmailOutboxService.class),
                 mock(AppProperties.class)
         );
         validator = Validation.buildDefaultValidatorFactory().getValidator();

--- a/src/test/java/com/mamoki/ieojuda/domain/stage/service/HandoverStageServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/stage/service/HandoverStageServiceTest.java
@@ -1,0 +1,84 @@
+package com.mamoki.ieojuda.domain.stage.service;
+
+import com.mamoki.ieojuda.domain.audit.entity.EmailType;
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
+import com.mamoki.ieojuda.domain.recipient.repository.RecipientRepository;
+import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCase;
+import com.mamoki.ieojuda.domain.releasecase.repository.ReleaseCaseRepository;
+import com.mamoki.ieojuda.domain.stage.entity.HandoverStage;
+import com.mamoki.ieojuda.domain.stage.entity.HandoverStageStatus;
+import com.mamoki.ieojuda.domain.stage.repository.HandoverStageRepository;
+import com.mamoki.ieojuda.global.config.AppProperties;
+import com.mamoki.ieojuda.global.email.contract.EmailContent;
+import com.mamoki.ieojuda.global.email.outbox.EmailOutboxService;
+import com.mamoki.ieojuda.global.security.PermissionGuard;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+// issue #51 - 핵심 버그 회귀 테스트: sendHandoffInvite는 더는 SMTP 결과와 무관하게 stage.send()나
+// "발송됨" 기록을 하지 않는다. 실제 발송(및 성공 시 stage.send())은 EmailOutboxScheduler만 담당한다.
+class HandoverStageServiceTest {
+
+    private ReleaseCaseRepository releaseCaseRepository;
+    private HandoverStageRepository handoverStageRepository;
+    private RecipientRepository recipientRepository;
+    private EmailOutboxService emailOutboxService;
+    private AppProperties appProperties;
+    private PermissionGuard permissionGuard;
+    private HandoverStageService service;
+
+    @BeforeEach
+    void setUp() {
+        releaseCaseRepository = mock(ReleaseCaseRepository.class);
+        handoverStageRepository = mock(HandoverStageRepository.class);
+        recipientRepository = mock(RecipientRepository.class);
+        emailOutboxService = mock(EmailOutboxService.class);
+        appProperties = mock(AppProperties.class);
+        permissionGuard = mock(PermissionGuard.class);
+        service = new HandoverStageService(releaseCaseRepository, handoverStageRepository,
+                recipientRepository, emailOutboxService, appProperties, permissionGuard);
+
+        when(appProperties.getInviteTokenTtlHours()).thenReturn(72L);
+        when(appProperties.getBaseUrl()).thenReturn("https://example.com");
+        when(appProperties.getContactEmail()).thenReturn("contact@example.com");
+        when(handoverStageRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    }
+
+    @Test
+    void createStagesAndDispatchFirst_enqueuesEmail_andNeverMarksStageSentSynchronously() {
+        ReleaseCase releaseCase = mock(ReleaseCase.class);
+        Plan plan = mock(Plan.class);
+        when(releaseCase.getPlan()).thenReturn(plan);
+        Recipient recipient = mock(Recipient.class);
+        when(recipient.getEmail()).thenReturn("recipient@example.com");
+
+        service.createStagesAndDispatchFirst(releaseCase, List.of(recipient));
+
+        verify(recipient).issueInviteToken(anyString(), any());
+        verify(emailOutboxService).enqueue(
+                eq(plan), any(HandoverStage.class), eq(EmailType.POSTHUMOUS_HANDOFF_LINK),
+                eq("recipient@example.com"), any(EmailContent.class));
+        // 이 서비스는 발송 결과를 알 수 없으므로, 이 메서드가 끝난 뒤에도 단계는 여전히 PENDING이어야 한다
+        // (과거 버그: SMTP 성공 여부와 무관하게 여기서 바로 SENT/sentAt을 기록했음).
+        HandoverStage createdStage = captureCreatedStage();
+        assertThat(createdStage.getStatus()).isEqualTo(HandoverStageStatus.PENDING);
+        assertThat(createdStage.getSentAt()).isNull();
+    }
+
+    private HandoverStage captureCreatedStage() {
+        var captor = org.mockito.ArgumentCaptor.forClass(HandoverStage.class);
+        verify(emailOutboxService).enqueue(any(), captor.capture(), any(), anyString(), any());
+        return captor.getValue();
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/global/email/outbox/EmailOutboxSchedulerTest.java
+++ b/src/test/java/com/mamoki/ieojuda/global/email/outbox/EmailOutboxSchedulerTest.java
@@ -1,0 +1,186 @@
+package com.mamoki.ieojuda.global.email.outbox;
+
+import com.mamoki.ieojuda.domain.audit.entity.AdminActionType;
+import com.mamoki.ieojuda.domain.audit.entity.EmailLog;
+import com.mamoki.ieojuda.domain.audit.service.AdminActionAuditService;
+import com.mamoki.ieojuda.domain.stage.entity.HandoverStage;
+import com.mamoki.ieojuda.global.config.AppProperties;
+import com.mamoki.ieojuda.global.email.contract.BounceType;
+import com.mamoki.ieojuda.global.email.contract.EmailFaill;
+import com.mamoki.ieojuda.global.email.contract.EmailSendResult;
+import com.mamoki.ieojuda.global.email.sender.EmailSender;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+// issue #51 - "SMTP 발송 실패가 성공으로 기록되지 않는다"와 "중복 워커 실행에도 한 번만 처리된다"를
+// 직접 검증한다. EvidenceDeletionSchedulerTest와 동일한 구조(행 단위 격리, 배치 부분 실패).
+class EmailOutboxSchedulerTest {
+
+    private EmailOutboxRepository emailOutboxRepository;
+    private EmailSender emailSender;
+    private AppProperties appProperties;
+    private AdminActionAuditService adminActionAuditService;
+    private EmailOutboxScheduler scheduler;
+
+    @BeforeEach
+    void setUp() {
+        emailOutboxRepository = mock(EmailOutboxRepository.class);
+        emailSender = mock(EmailSender.class);
+        appProperties = mock(AppProperties.class);
+        adminActionAuditService = mock(AdminActionAuditService.class);
+        when(appProperties.getEmailOutboxMaxAttempts()).thenReturn(3);
+        scheduler = new EmailOutboxScheduler(emailOutboxRepository, emailSender, appProperties, adminActionAuditService);
+    }
+
+    @Test
+    void dispatchPending_whenNoneAreDue_doesNothing() {
+        when(emailOutboxRepository.findPendingForUpdateSkipLocked()).thenReturn(List.of());
+
+        scheduler.dispatchPending();
+
+        verifyNoInteractions(emailSender, adminActionAuditService);
+    }
+
+    @Test
+    void dispatchPending_whenSendSucceeds_marksLogAndOutboxSentAndDispatchesStage() {
+        EmailLog log = mock(EmailLog.class);
+        HandoverStage stage = mock(HandoverStage.class);
+        EmailOutbox outbox = outboxOf(log, stage);
+        when(emailOutboxRepository.findPendingForUpdateSkipLocked()).thenReturn(List.of(outbox));
+        when(emailSender.send(eq("a@b.com"), any())).thenReturn(EmailSendResult.success("msg-1"));
+
+        scheduler.dispatchPending();
+
+        verify(log).markSent("msg-1");
+        verify(outbox).markSent();
+        verify(stage).send();
+        verifyNoInteractions(adminActionAuditService);
+    }
+
+    @Test
+    void dispatchPending_whenSendSucceeds_withoutStage_doesNotTouchStage() {
+        EmailLog log = mock(EmailLog.class);
+        EmailOutbox outbox = outboxOf(log, null);
+        when(emailOutboxRepository.findPendingForUpdateSkipLocked()).thenReturn(List.of(outbox));
+        when(emailSender.send(eq("a@b.com"), any())).thenReturn(EmailSendResult.success("msg-1"));
+
+        scheduler.dispatchPending();
+
+        verify(log).markSent("msg-1");
+        verify(outbox).markSent();
+    }
+
+    @Test
+    void dispatchPending_whenSendFailsTemporarilyUnderMaxAttempts_recordsFailedAttemptAndStaysPending() {
+        EmailLog log = mock(EmailLog.class);
+        EmailOutbox outbox = outboxOf(log, null);
+        when(outbox.getAttemptCount()).thenReturn(0);
+        when(emailOutboxRepository.findPendingForUpdateSkipLocked()).thenReturn(List.of(outbox));
+        when(emailSender.send(eq("a@b.com"), any()))
+                .thenReturn(EmailSendResult.failure(BounceType.TEMPORARY, EmailFaill.CONNECTION_TIMEOUT));
+
+        scheduler.dispatchPending();
+
+        verify(log).markFailed(anyString());
+        verify(outbox).recordFailedAttempt(anyString());
+        verify(outbox, never()).giveUp(anyString());
+        verifyNoInteractions(adminActionAuditService);
+    }
+
+    @Test
+    void dispatchPending_whenSendFailsAtMaxAttempts_givesUpAndAudits() {
+        EmailLog log = mock(EmailLog.class);
+        EmailOutbox outbox = outboxOf(log, null);
+        when(outbox.getOutboxId()).thenReturn(7L);
+        when(outbox.getAttemptCount()).thenReturn(3); // 이미 maxAttempts(3)만큼 시도함
+        when(emailOutboxRepository.findPendingForUpdateSkipLocked()).thenReturn(List.of(outbox));
+        when(emailSender.send(eq("a@b.com"), any()))
+                .thenReturn(EmailSendResult.failure(BounceType.TEMPORARY, EmailFaill.CONNECTION_TIMEOUT));
+
+        scheduler.dispatchPending();
+
+        verify(log).markFailed(anyString());
+        verify(outbox).giveUp(anyString());
+        verify(outbox, never()).recordFailedAttempt(anyString());
+        verify(adminActionAuditService)
+                .recordSystem(eq(AdminActionType.EMAIL_OUTBOX_DISPATCH_FAILED), eq(7L), eq(false), anyString());
+    }
+
+    @Test
+    void dispatchPending_whenBounceIsPermanent_givesUpImmediatelyRegardlessOfAttemptCount() {
+        EmailLog log = mock(EmailLog.class);
+        EmailOutbox outbox = outboxOf(log, null);
+        when(outbox.getOutboxId()).thenReturn(9L);
+        when(outbox.getAttemptCount()).thenReturn(0); // 첫 시도인데도
+        when(emailOutboxRepository.findPendingForUpdateSkipLocked()).thenReturn(List.of(outbox));
+        when(emailSender.send(eq("a@b.com"), any()))
+                .thenReturn(EmailSendResult.failure(BounceType.PERMANENT, EmailFaill.INVALID_ADDRESS_FORMAT));
+
+        scheduler.dispatchPending();
+
+        verify(outbox).giveUp(anyString());
+        verify(outbox, never()).recordFailedAttempt(anyString());
+    }
+
+    @Test
+    void dispatchPending_whenOneOfSeveralFails_theOthersStillGetSent() {
+        EmailLog failingLog = mock(EmailLog.class);
+        EmailOutbox failing = outboxOf(failingLog, null);
+        when(failing.getRecipientEmail()).thenReturn("fail@b.com");
+        when(failing.getAttemptCount()).thenReturn(0);
+
+        EmailLog succeedingLog = mock(EmailLog.class);
+        EmailOutbox succeeding = outboxOf(succeedingLog, null);
+        when(succeeding.getRecipientEmail()).thenReturn("ok@b.com");
+
+        when(emailOutboxRepository.findPendingForUpdateSkipLocked()).thenReturn(List.of(failing, succeeding));
+        when(emailSender.send(eq("fail@b.com"), any()))
+                .thenReturn(EmailSendResult.failure(BounceType.TEMPORARY, EmailFaill.CONNECTION_TIMEOUT));
+        when(emailSender.send(eq("ok@b.com"), any())).thenReturn(EmailSendResult.success("msg-2"));
+
+        scheduler.dispatchPending();
+
+        verify(failing).recordFailedAttempt(anyString());
+        verify(succeeding).markSent();
+        verify(succeedingLog).markSent("msg-2");
+    }
+
+    // 재처리 멱등성: 이미 SENT로 전이된 행은 두 번째 스케줄러 실행에서 더는 조회되지 않으므로
+    // (findPendingForUpdateSkipLocked의 status='PENDING' 조건), 같은 행에 대해 emailSender.send가
+    // 두 번 호출되는 일은 없다.
+    @Test
+    void dispatchPending_calledTwiceWithSameRowOnlyOnFirstRun_sendsExactlyOnce() {
+        EmailLog log = mock(EmailLog.class);
+        EmailOutbox outbox = outboxOf(log, null);
+        when(emailOutboxRepository.findPendingForUpdateSkipLocked())
+                .thenReturn(List.of(outbox))
+                .thenReturn(List.of()); // 두 번째 주기에는 SENT로 전이되어 더는 조회되지 않음
+        when(emailSender.send(eq("a@b.com"), any())).thenReturn(EmailSendResult.success("msg-1"));
+
+        scheduler.dispatchPending();
+        scheduler.dispatchPending();
+
+        verify(emailSender, org.mockito.Mockito.times(1)).send(eq("a@b.com"), any());
+    }
+
+    private EmailOutbox outboxOf(EmailLog log, HandoverStage stage) {
+        EmailOutbox outbox = mock(EmailOutbox.class);
+        when(outbox.getEmailLog()).thenReturn(log);
+        when(outbox.getHandoverStage()).thenReturn(stage);
+        when(outbox.getRecipientEmail()).thenReturn("a@b.com");
+        when(outbox.getSubject()).thenReturn("subject");
+        when(outbox.getBody()).thenReturn("body");
+        return outbox;
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/global/email/outbox/EmailOutboxServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/global/email/outbox/EmailOutboxServiceTest.java
@@ -1,0 +1,82 @@
+package com.mamoki.ieojuda.global.email.outbox;
+
+import com.mamoki.ieojuda.domain.audit.entity.EmailLog;
+import com.mamoki.ieojuda.domain.audit.entity.EmailType;
+import com.mamoki.ieojuda.domain.audit.repository.EmailLogRepository;
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.stage.entity.HandoverStage;
+import com.mamoki.ieojuda.global.email.contract.EmailContent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+// issue #51 - 트랜잭셔널 아웃박스의 유일한 쓰기 지점. 여기서 EmailLog/EmailOutbox 연결이 잘못되면
+// 워커가 엉뚱한 로그를 갱신하거나, 감사 화면에 발송 이력이 아예 안 남는 문제로 이어진다.
+class EmailOutboxServiceTest {
+
+    private EmailLogRepository emailLogRepository;
+    private EmailOutboxRepository emailOutboxRepository;
+    private EmailOutboxService emailOutboxService;
+
+    @BeforeEach
+    void setUp() {
+        emailLogRepository = mock(EmailLogRepository.class);
+        emailOutboxRepository = mock(EmailOutboxRepository.class);
+        emailOutboxService = new EmailOutboxService(emailLogRepository, emailOutboxRepository);
+
+        when(emailLogRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(emailOutboxRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    }
+
+    @Test
+    void enqueue_savesRequestedEmailLogAndLinkedOutboxRowInSameCall() {
+        Plan plan = mock(Plan.class);
+        HandoverStage stage = mock(HandoverStage.class);
+        EmailContent content = new EmailContent("제목", "본문");
+
+        emailOutboxService.enqueue(plan, stage, EmailType.POSTHUMOUS_HANDOFF_LINK, "a@b.com", content);
+
+        ArgumentCaptor<EmailLog> logCaptor = ArgumentCaptor.forClass(EmailLog.class);
+        verify(emailLogRepository).save(logCaptor.capture());
+        EmailLog savedLog = logCaptor.getValue();
+
+        ArgumentCaptor<EmailOutbox> outboxCaptor = ArgumentCaptor.forClass(EmailOutbox.class);
+        verify(emailOutboxRepository).save(outboxCaptor.capture());
+        EmailOutbox savedOutbox = outboxCaptor.getValue();
+
+        assertThat(savedOutbox.getEmailLog()).isSameAs(savedLog);
+        assertThat(savedOutbox.getHandoverStage()).isSameAs(stage);
+        assertThat(savedOutbox.getRecipientEmail()).isEqualTo("a@b.com");
+        assertThat(savedOutbox.getSubject()).isEqualTo("제목");
+        assertThat(savedOutbox.getBody()).isEqualTo("본문");
+        assertThat(savedOutbox.getStatus()).isEqualTo(EmailOutboxStatus.PENDING);
+    }
+
+    @Test
+    void enqueueRetry_requestsRetryOnExistingLog_andAddsNewOutboxRowReferencingIt() {
+        EmailLog existingLog = mock(EmailLog.class);
+        when(existingLog.getHandoverStage()).thenReturn(null);
+        when(existingLog.getRecipientEmail()).thenReturn("retry@b.com");
+        EmailContent content = new EmailContent("재발송 제목", "재발송 본문");
+
+        emailOutboxService.enqueueRetry(existingLog, content);
+
+        verify(existingLog).recordRetryRequested();
+        // enqueueRetry는 새 EmailLog를 만들지 않는다 - 기존 로그를 재사용해 이력을 보존한다
+        verify(emailLogRepository, org.mockito.Mockito.never()).save(any());
+
+        ArgumentCaptor<EmailOutbox> outboxCaptor = ArgumentCaptor.forClass(EmailOutbox.class);
+        verify(emailOutboxRepository).save(outboxCaptor.capture());
+        EmailOutbox savedOutbox = outboxCaptor.getValue();
+
+        assertThat(savedOutbox.getEmailLog()).isSameAs(existingLog);
+        assertThat(savedOutbox.getRecipientEmail()).isEqualTo("retry@b.com");
+        assertThat(savedOutbox.getSubject()).isEqualTo("재발송 제목");
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/global/email/sender/GmailSenderTest.java
+++ b/src/test/java/com/mamoki/ieojuda/global/email/sender/GmailSenderTest.java
@@ -1,0 +1,75 @@
+package com.mamoki.ieojuda.global.email.sender;
+
+import com.mamoki.ieojuda.global.email.contract.EmailContent;
+import com.mamoki.ieojuda.global.email.contract.EmailSendResult;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.github.resilience4j.retry.RetryConfig;
+import io.github.resilience4j.retry.RetryRegistry;
+import jakarta.mail.internet.MimeMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mail.MailSendException;
+import org.springframework.mail.javamail.JavaMailSender;
+
+import java.time.Duration;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+// issue #51 - Resilience4j 재시도/회로차단이 GmailSender의 EmailSender 계약(never throws)을 지키면서
+// 짧은 재시도로 일시 장애를 흡수하는지 검증한다.
+class GmailSenderTest {
+
+    private JavaMailSender javaMailSender;
+    private GmailSender gmailSender;
+
+    @BeforeEach
+    void setUp() {
+        javaMailSender = mock(JavaMailSender.class);
+        when(javaMailSender.createMimeMessage()).thenReturn(mock(MimeMessage.class));
+
+        RetryRegistry retryRegistry = RetryRegistry.of(Map.of("emailSend",
+                RetryConfig.custom().maxAttempts(3).waitDuration(Duration.ofMillis(1)).build()));
+        CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.of(Map.of("emailSend",
+                CircuitBreakerConfig.ofDefaults()));
+        gmailSender = new GmailSender(javaMailSender, retryRegistry, circuitBreakerRegistry);
+    }
+
+    @Test
+    void send_whenFirstAttemptsFailThenSucceed_retriesAndReturnsSuccess() {
+        doThrow(new MailSendException("boom"))
+                .doThrow(new MailSendException("boom"))
+                .doNothing()
+                .when(javaMailSender).send(any(MimeMessage.class));
+
+        EmailSendResult result = gmailSender.send("to@example.com", new EmailContent("제목", "본문"));
+
+        assertThat(result.success()).isTrue();
+        verify(javaMailSender, times(3)).send(any(MimeMessage.class));
+    }
+
+    @Test
+    void send_whenAllAttemptsFail_returnsFailureClassifiedByFailureAnalyzer() {
+        doThrow(new MailSendException("boom")).when(javaMailSender).send(any(MimeMessage.class));
+
+        EmailSendResult result = gmailSender.send("to@example.com", new EmailContent("제목", "본문"));
+
+        assertThat(result.success()).isFalse();
+        verify(javaMailSender, times(3)).send(any(MimeMessage.class));
+    }
+
+    @Test
+    void send_whenSucceedsOnFirstTry_sendsExactlyOnce() {
+        EmailSendResult result = gmailSender.send("to@example.com", new EmailContent("제목", "본문"));
+
+        assertThat(result.success()).isTrue();
+        verify(javaMailSender, times(1)).send(any(MimeMessage.class));
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/global/storage/S3EvidenceStorageClientTest.java
+++ b/src/test/java/com/mamoki/ieojuda/global/storage/S3EvidenceStorageClientTest.java
@@ -1,0 +1,118 @@
+package com.mamoki.ieojuda.global.storage;
+
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import com.mamoki.ieojuda.global.storage.config.S3Properties;
+import com.mamoki.ieojuda.global.storage.contract.EvidenceUpload;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.github.resilience4j.retry.RetryConfig;
+import io.github.resilience4j.retry.RetryRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.core.sync.ResponseTransformer;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectResponse;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+
+import java.io.ByteArrayInputStream;
+import java.time.Duration;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+// issue #51 - Resilience4j 재시도/회로차단이 S3EvidenceStorageClient의 기존 예외 계약
+// (SdkException/NoSuchKeyException -> CustomException(EVIDENCE_STORAGE_FAILED/EVIDENCE_NOT_FOUND))을
+// 유지하면서 짧은 재시도로 일시 장애를 흡수하는지 검증한다.
+class S3EvidenceStorageClientTest {
+
+    private S3Client s3Client;
+    private S3EvidenceStorageClient storageClient;
+
+    @BeforeEach
+    void setUp() {
+        s3Client = mock(S3Client.class);
+        S3Properties s3Properties = mock(S3Properties.class);
+        when(s3Properties.getBucket()).thenReturn("test-bucket");
+
+        RetryConfig retryConfig = RetryConfig.custom().maxAttempts(3).waitDuration(Duration.ofMillis(1)).build();
+        RetryRegistry retryRegistry = RetryRegistry.of(Map.of(
+                "s3Put", retryConfig, "s3Get", retryConfig, "s3Delete", retryConfig));
+        CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.of(Map.of(
+                "s3Put", CircuitBreakerConfig.ofDefaults(),
+                "s3Get", CircuitBreakerConfig.ofDefaults(),
+                "s3Delete", CircuitBreakerConfig.ofDefaults()));
+        storageClient = new S3EvidenceStorageClient(s3Client, s3Properties, retryRegistry, circuitBreakerRegistry);
+    }
+
+    @Test
+    void store_whenFirstAttemptsFailThenSucceed_retriesAndSucceeds() {
+        doThrow(SdkException.builder().message("boom").build())
+                .doThrow(SdkException.builder().message("boom").build())
+                .doReturn(PutObjectResponse.builder().build())
+                .when(s3Client).putObject(any(PutObjectRequest.class), any(software.amazon.awssdk.core.sync.RequestBody.class));
+
+        EvidenceUpload upload = new EvidenceUpload("proof.pdf", "application/pdf",
+                () -> new ByteArrayInputStream(new byte[]{1, 2, 3}), 3);
+
+        var stored = storageClient.store(1L, upload);
+
+        assertThat(stored.fileSize()).isEqualTo(3);
+        verify(s3Client, times(3)).putObject(any(PutObjectRequest.class), any(software.amazon.awssdk.core.sync.RequestBody.class));
+    }
+
+    @Test
+    void store_whenAllAttemptsFail_throwsEvidenceStorageFailed() {
+        doThrow(SdkException.builder().message("boom").build())
+                .when(s3Client).putObject(any(PutObjectRequest.class), any(software.amazon.awssdk.core.sync.RequestBody.class));
+        EvidenceUpload upload = new EvidenceUpload("proof.pdf", "application/pdf",
+                () -> new ByteArrayInputStream(new byte[]{1}), 1);
+
+        assertThatThrownBy(() -> storageClient.store(1L, upload))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.EVIDENCE_STORAGE_FAILED));
+        verify(s3Client, times(3)).putObject(any(PutObjectRequest.class), any(software.amazon.awssdk.core.sync.RequestBody.class));
+    }
+
+    @Test
+    void delete_whenAllAttemptsFail_throwsEvidenceStorageFailed() {
+        doThrow(SdkException.builder().message("boom").build())
+                .when(s3Client).deleteObject(any(DeleteObjectRequest.class));
+
+        assertThatThrownBy(() -> storageClient.delete("evidence/1/uuid.pdf"))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.EVIDENCE_STORAGE_FAILED));
+        verify(s3Client, times(3)).deleteObject(any(DeleteObjectRequest.class));
+    }
+
+    @Test
+    void delete_whenSucceedsOnFirstTry_deletesExactlyOnce() {
+        when(s3Client.deleteObject(any(DeleteObjectRequest.class))).thenReturn(DeleteObjectResponse.builder().build());
+
+        storageClient.delete("evidence/1/uuid.pdf");
+
+        verify(s3Client, times(1)).deleteObject(any(DeleteObjectRequest.class));
+    }
+
+    @Test
+    void load_whenKeyDoesNotExist_throwsEvidenceNotFound() {
+        when(s3Client.getObject(any(GetObjectRequest.class), any(ResponseTransformer.class)))
+                .thenThrow(NoSuchKeyException.builder().message("not found").build());
+
+        assertThatThrownBy(() -> storageClient.load("evidence/missing.pdf"))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.EVIDENCE_NOT_FOUND));
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/global/validation/InputSizeConstraintTest.java
+++ b/src/test/java/com/mamoki/ieojuda/global/validation/InputSizeConstraintTest.java
@@ -164,7 +164,7 @@ class InputSizeConstraintTest {
 
     @Test
     void evidenceFilenameMatchesTheDatabaseColumnLimit() {
-        EvidenceSubmitService service = new EvidenceSubmitService(null, null, null, null, null, null, null, null);
+        EvidenceSubmitService service = new EvidenceSubmitService(null, null, null, null, null, null, null, null, null);
         MockMultipartFile valid = new MockMultipartFile(
                 "file", "x".repeat(255), "application/pdf", new byte[]{1});
         MockMultipartFile oversized = new MockMultipartFile(


### PR DESCRIPTION
## 연관 Issue
- Closes #51

## 요약
SMTP/S3 외부 호출을 DB 트랜잭션에서 분리하는 트랜잭셔널 아웃박스를 도입하고, Resilience4j로 재시도/회로차단을 적용해 발송 감사 신뢰성을 개선합니다.

## 변경 사항
- 이메일 발송 7개 지점(HandoverStage, Confirmer, DisputeContact, Plan, Recipient, EmailAudit, PosthumousAccess/OTP)을 EmailOutboxService 경유로 전환 — SMTP 실패 시에도 SENT로 오기록되던 버그 수정
- EmailLog에 REQUESTED/SENT/FAILED 상태·requestedAt·failureReason 추가, EmailOutbox/EmailOutboxScheduler로 FOR UPDATE SKIP LOCKED 기반 정확히 한 번 처리 보장
- S3 보정 삭제 실패 시 EvidenceOrphanCleanup 큐에 기록해 재처리하도록 변경 (기존엔 예외를 삼키고 로그만 남김)
- GmailSender / S3EvidenceStorageClient에 Resilience4j 재시도+회로차단 적용, SMTP/S3 타임아웃 설정
- 관련 단위·통합 테스트 추가 (부분 실패, 재처리 멱등성, 실제 워커 처리까지 검증)
- develop(issue #76~82) 병합 및 충돌 해결 — HandoverStageService의 InviteKind/사후인증링크/단계자동완료 로직과 아웃박스 전환을 함께 반영

## 범위

### 포함
- 이메일 발송 아웃박스화, S3 고아 정리 재처리 큐, 외부 클라이언트 타임아웃/재시도/회로차단, 발송 상태 감사 필드

### 제외
- 공급자 message-id/webhook 기반 배달·반송·열람 확인 (Gmail SMTP 특성상 별도 이슈로 분리)

## 스크린샷 / 미리 보기
- 백엔드 전용 변경으로 UI 스크린샷 없음