### PR TITLE
[Fix/#51] EmailOutbox 리팩터링 후 남은 테스트 결함 수정

### DIFF
--- a/src/test/java/com/mamoki/ieojuda/domain/evidence/service/EvidenceSubmitServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/evidence/service/EvidenceSubmitServiceTest.java
@@ -192,7 +192,7 @@ class EvidenceSubmitServiceTest {
 
         TransactionSynchronizationManager.initSynchronization();
         try {
-            evidenceSubmitService.submit("token", file, null);
+            evidenceSubmitService.submit("token", file, EvidenceType.DEATH_CERTIFICATE, null);
             // 실제 Spring 트랜잭션이 롤백된 뒤 afterCompletion을 호출하는 것과 동일하게 재현
             TransactionSynchronizationUtils.triggerAfterCompletion(
                     org.springframework.transaction.support.TransactionSynchronization.STATUS_ROLLED_BACK);

--- a/src/test/java/com/mamoki/ieojuda/domain/stage/service/HandoverStageServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/stage/service/HandoverStageServiceTest.java
@@ -71,8 +71,8 @@ class HandoverStageServiceTest {
         packageActionCompletionRepository = mock(PackageActionCompletionRepository.class);
         accessTokenRepository = mock(AccessTokenRepository.class);
         handoverStageService = new HandoverStageService(
-                releaseCaseRepository, handoverStageRepository, recipientRepository, emailLogRepository,
-                emailSender, appProperties, permissionGuard, packageActionCompletionRepository, accessTokenRepository);
+                releaseCaseRepository, handoverStageRepository, recipientRepository, emailOutboxService,
+                appProperties, permissionGuard, packageActionCompletionRepository, accessTokenRepository);
 
         when(appProperties.getContactEmail()).thenReturn("support@ieoduda.example");
         when(appProperties.getInviteTokenTtlHours()).thenReturn(72L);
@@ -128,7 +128,6 @@ class HandoverStageServiceTest {
 
         handoverStageService.createStagesAndDispatchFirst(localCase, List.of(recipient));
 
-        verify(recipient).issueInviteToken(anyString(), any());
         verify(emailOutboxService).enqueue(
                 eq(plan), any(HandoverStage.class), eq(EmailType.POSTHUMOUS_HANDOFF_LINK),
                 eq("recipient@example.com"), any(EmailContent.class));

--- a/src/test/java/com/mamoki/ieojuda/domain/stage/service/StageDispatchHttpIntegrationTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/stage/service/StageDispatchHttpIntegrationTest.java
@@ -241,26 +241,27 @@ class StageDispatchHttpIntegrationTest {
         assertThat(stage2Outbox.getBody()).contains("/posthumous-access/");
         assertThat(stage2Outbox.getBody()).doesNotContain("/recipient-acceptances/");
 
-        // 버그 회귀 방지 - 메일 본문에 박힌 링크를 그대로 뽑아서 #76의 실제 인증 API를 호출해본다.
-        // (이전엔 링크 문자열만 /posthumous-access/로 바뀌고 토큰은 여전히 recipient.inviteToken에
+        // 메일 본문에 박힌 링크에서 토큰을 뽑아 둔다 (버그 회귀 방지 - #76의 실제 인증 API를 호출해볼 것이다.
+        // 이전엔 링크 문자열만 /posthumous-access/로 바뀌고 토큰은 여전히 recipient.inviteToken에
         // 저장되고 있어서, 이 호출이 전부 TOKEN_INVALID로 실패했었다 - 단위 테스트로는 못 잡던 버그)
         java.util.regex.Matcher linkMatcher = java.util.regex.Pattern
-                .compile("/posthumous-access/([\\w-]+)").matcher(stage2EmailCaptor.getValue().body());
+                .compile("/posthumous-access/([\\w-]+)").matcher(stage2Outbox.getBody());
         assertThat(linkMatcher.find()).as("메일 본문에 사후 인증 링크가 있어야 한다").isTrue();
         String dispatchedPlainToken = linkMatcher.group(1);
-
-        HttpResponse<String> linkCheckResponse = get("/api/posthumous-access/" + dispatchedPlainToken);
-        assertThat(linkCheckResponse.statusCode()).isEqualTo(200);
-        assertThat(linkCheckResponse.body()).contains("\"recipientName\":\"담당자2\"");
 
         ReleaseCase reloadedCase = releaseCaseRepository.findById(releaseCase.getCaseId()).orElseThrow();
         assertThat(reloadedCase.getStatus()).isNotEqualTo(ReleaseCaseStatus.COMPLETED); // 아직 2단계가 안 끝남
 
-        // 실제 워커가 아웃박스를 처리한 상황을 재현 - completeStageIfAllActionsDone은 SENT 상태에서만
-        // 다음 완료를 받아들이므로, 2단계 담당자가 실제로 링크를 받으려면 이 단계가 선행되어야 한다.
+        // 실제 워커가 아웃박스를 처리한 상황을 재현 - checkUsable()은 SENT 상태에서만 링크를 허용하므로,
+        // 실제 SMTP 발송(=SENT 전환)이 일어나기 전까지는 링크 접근도 아직 허용되지 않는 게 맞다.
         emailOutboxScheduler.dispatchPending();
         HandoverStage sentStage2 = handoverStageRepository.findById(stage2.getStageId()).orElseThrow();
         assertThat(sentStage2.getStatus()).isEqualTo(HandoverStageStatus.SENT);
+
+        // SENT로 전환된 뒤에야 사후 인증 API가 실제로 통과해야 한다.
+        HttpResponse<String> linkCheckResponse = get("/api/posthumous-access/" + dispatchedPlainToken);
+        assertThat(linkCheckResponse.statusCode()).isEqualTo(200);
+        assertThat(linkCheckResponse.body()).contains("\"recipientName\":\"담당자2\"");
 
         // 2단계(마지막 단계) 담당자가 완료 -> 사건 전체가 COMPLETED 되어야 한다(완료조건 2)
         String stage2Session = issueVerifiedSession(sentStage2);


### PR DESCRIPTION
## 연관 Issue
관련: #51 (PR #105에서 도입된 EmailOutbox 리팩터링)

## 요약
PR #105(EmailOutbox 패턴 도입)가 develop에 머지된 뒤, 그 리팩터링을 완전히 반영하지 못한 테스트 코드 때문에 develop이 컴파일조차 되지 않는 상태였습니다. #89 작업을 시작하려고 최신 develop을 받아 테스트를 돌리다가 발견했습니다.

## 작업 내용
- `HandoverStageServiceTest`: `HandoverStageService` 생성자가 이미 `emailLogRepository`/`emailSender`가 아니라 `emailOutboxService`를 받도록 바뀌었는데, 테스트의 생성자 호출부만 갱신되지 않아 컴파일 자체가 실패했음 → 수정. 같은 테스트 안에 `sendHandoffInvite()`가 더 이상 호출하지 않는(#79에서 이미 제거된) `recipient.issueInviteToken()`을 검증하던 낡은 assertion도 제거.
- `StageDispatchHttpIntegrationTest`: `checkUsable()`은 `HandoverStageStatus.SENT`일 때만 사후 인증 링크를 허용하는데, 이 테스트는 `emailOutboxScheduler.dispatchPending()`(실제 SENT 전환)보다 먼저 링크 검증을 호출하고 있어 401로 실패하고 있었음 → 검증 순서를 `dispatchPending()` 이후로 이동.
- `EvidenceSubmitServiceTest`: #51 작업에서 추가된 롤백 재현 테스트가 #88의 `evidenceType` 필수 파라미터를 반영하지 않은 옛 시그니처로 `submit()`을 호출하고 있어 컴파일 실패 → 인자 추가.

## DB 마이그레이션 메모
로컬 dev DB(`ddl-auto=update`)의 `email_logs` 테이블에 `EmailLog.requestedAt`(신규 `NOT NULL` 컬럼) 추가가 기존 행 때문에 막혀 있었습니다. 남아있던 행은 전부 세션 중 테스트로 생긴 더미였고, 사용자 승인 하에 `TRUNCATE TABLE email_logs CASCADE;`로 정리했습니다(`email_outbox`가 FK로 참조하고 있어 CASCADE 필요). 팀 공용 DB나 배포 DB에는 해당 없음 — 로컬 개발 환경 한정입니다.

## 범위(포함/제외)
- 포함: 위 3개 테스트 파일의 컴파일/런타임 결함 수정
- 제외: EmailOutbox 자체의 설계·정책 변경 (PR #105의 스콥, 이 PR은 그 이후 테스트 정합성만 다룸)

## 완료 조건 체크
- [x] `develop` + 이 브랜치 기준으로 전체 테스트가 컴파일되고 통과한다

## 테스트
- `./gradlew clean test` — 227/227 통과 (0 failed, 0 errors)

## 머지
사용자 승인 대기 — 안내 후 머지 예정