### PR TITLE
[Feat/#84]: 계획 홈 요약 응답 확장

### DIFF
--- a/src/main/java/com/mamoki/ieojuda/domain/plan/controller/PlanController.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/controller/PlanController.java
@@ -1,12 +1,14 @@
 package com.mamoki.ieojuda.domain.plan.controller;
 
 import com.mamoki.ieojuda.domain.plan.dto.PlanResponse;
+import com.mamoki.ieojuda.domain.plan.dto.PlanSummaryResponse;
 import com.mamoki.ieojuda.domain.plan.dto.ReleasePolicyRequest;
 import com.mamoki.ieojuda.domain.plan.dto.ReleasePolicyResponse;
 import com.mamoki.ieojuda.domain.plan.dto.ReleaseSettingsResponse;
 import com.mamoki.ieojuda.domain.plan.dto.SelfWarningEmailRequest;
 import com.mamoki.ieojuda.domain.plan.dto.SelfWarningEmailResponse;
 import com.mamoki.ieojuda.domain.plan.service.PlanService;
+import com.mamoki.ieojuda.domain.plan.service.PlanSummaryService;
 import com.mamoki.ieojuda.global.rsdata.RsData;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -32,11 +34,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class PlanController {
 
     private final PlanService planService;
+    private final PlanSummaryService planSummaryService;
 
-    @Operation(summary = "내 계획 조회", description = "로그인한 사용자의 계획을 조회합니다. 계획은 회원가입 시 자동으로 1개 생성되므로, planId를 아직 모를 때(로그인 직후 등) 사용합니다.")
+    @Operation(summary = "내 계획 조회", description = "로그인한 사용자의 계획 홈 요약을 조회합니다. 계획은 회원가입 시 자동으로 1개 생성되므로, planId를 아직 모를 때(로그인 직후 등) 사용합니다.")
     @GetMapping("/me")
-    public ResponseEntity<RsData<PlanResponse>> getMyPlan(@AuthenticationPrincipal Long userId) {
-        return ResponseEntity.ok(RsData.success(planService.getMyPlan(userId)));
+    public ResponseEntity<RsData<PlanSummaryResponse>> getMyPlan(@AuthenticationPrincipal Long userId) {
+        return ResponseEntity.ok(RsData.success(planSummaryService.getMySummary(userId)));
     }
 
     @Operation(summary = "계획 조회")

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/dto/LifeAreaSummaryResponse.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/dto/LifeAreaSummaryResponse.java
@@ -1,0 +1,19 @@
+package com.mamoki.ieojuda.domain.plan.dto;
+
+import com.mamoki.ieojuda.domain.plan.entity.LifeAreaCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+// "계획 홈" 화면 - 구역 카드 하나 (전체 항목 목록이 아니라 개수·작성 여부만)
+public record LifeAreaSummaryResponse(
+        @Schema(description = "구역 분류", example = "FAMILY", allowableValues = {"FAMILY", "RELATIONSHIP_CLEANUP", "WORK_CONTINUITY"}) String category,
+        @Schema(description = "구역 표시 이름") String label,
+        @Schema(description = "구역 한 줄 설명") String summary,
+        @Schema(description = "이 구역에 쌓인 항목 수") int itemCount,
+        @Schema(description = "항목을 하나라도 작성했는지 여부") boolean isWritten
+) {
+    public static LifeAreaSummaryResponse from(LifeAreaResponse lifeAreaResponse) {
+        LifeAreaCategory category = LifeAreaCategory.valueOf(lifeAreaResponse.category());
+        int itemCount = lifeAreaResponse.items().size();
+        return new LifeAreaSummaryResponse(category.name(), category.label(), category.summary(), itemCount, itemCount > 0);
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/dto/PlanSummaryResponse.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/dto/PlanSummaryResponse.java
@@ -1,0 +1,25 @@
+package com.mamoki.ieojuda.domain.plan.dto;
+
+import com.mamoki.ieojuda.domain.releasecase.dto.ReleaseStatusResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+// "계획 홈" 화면 전체 - 프론트가 이 화면 하나를 그리는 데 필요한 정보를 한 번의 호출로 제공한다.
+// 종합 AI 준비도 점수는 명세서에서 "제공하지 않습니다"라고 명시했으므로 포함하지 않는다.
+public record PlanSummaryResponse(
+        @Schema(description = "계획 ID") Long planId,
+        @Schema(description = "계획 상태", example = "DRAFT", allowableValues = {"DRAFT", "SEALED", "DEACTIVATED"}) String status,
+        @Schema(description = "작성자 이름") String userName,
+        @Schema(description = "구역별 요약 (가족/관계 정리/업무 연속성)") List<LifeAreaSummaryResponse> lifeAreas,
+        @Schema(description = "역할 담당자 중 수락 완료 인원") long recipientAcceptedCount,
+        @Schema(description = "역할 담당자 총 인원") long recipientTotalCount,
+        @Schema(description = "지정 확인자 중 수락 완료 인원") long confirmerAcceptedCount,
+        @Schema(description = "지정 확인자 총 인원") long confirmerTotalCount,
+        @Schema(description = "지정 확인자 이름 목록") List<String> confirmerNames,
+        @Schema(description = "대체 담당자가 등록되지 않은 역할 담당자 수") long backupMissingCount,
+        @Schema(description = "해결되지 않은 실행 순서 충돌에 걸린 항목 수") long unresolvedConflictCount,
+        @Schema(description = "선택한 대기 기간(일) - 아직 설정 안 했으면 null") Integer waitingDays,
+        @Schema(description = "진행 중인 사후 인계 사건 상태") ReleaseStatusResponse releaseCase
+) {
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/entity/LifeAreaCategory.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/entity/LifeAreaCategory.java
@@ -4,4 +4,25 @@ public enum LifeAreaCategory {
     FAMILY,               // 가족
     RELATIONSHIP_CLEANUP, // 관계 정리
     WORK_CONTINUITY       // 업무 연속성
+
+    ;
+
+    // 계획 홈 화면(#84)에서 쓰는 구역별 고정 문구 - 백엔드-구현-스펙.md 3-2 예시 그대로.
+    // (검토 필요) summary는 예시 문구를 그대로 가져온 것이라 실제로는 카테고리 설명이 아니라
+    // 항목 내용 기반 동적 요약이어야 할 수도 있음 - 기획/디자인 확인 후 조정.
+    public String label() {
+        return switch (this) {
+            case FAMILY -> "전달 메세지";
+            case RELATIONSHIP_CLEANUP -> "관계 정리";
+            case WORK_CONTINUITY -> "업무 처리";
+        };
+    }
+
+    public String summary() {
+        return switch (this) {
+            case FAMILY -> "가족·친구·지인에게";
+            case RELATIONSHIP_CLEANUP -> "SNS 계정·부고 전달";
+            case WORK_CONTINUITY -> "디자인 프로젝트 인수인계";
+        };
+    }
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/service/PlanService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/service/PlanService.java
@@ -47,13 +47,6 @@ public class PlanService {
         return PlanResponse.from(planOwnershipReader.findOwnedPlan(userId, planId));
     }
 
-    // 로그인한 사용자가 자기 planId를 모를 때(로그인 직후 등) 조회
-    public PlanResponse getMyPlan(Long userId) {
-        Plan plan = planRepository.findByUser_UserId(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.PLAN_NOT_FOUND));
-        return PlanResponse.from(plan);
-    }
-
     @Transactional
     public PlanResponse deactivate(Long userId, Long planId) {
         Plan plan = planOwnershipReader.findOwnedPlan(userId, planId);

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/service/PlanSummaryService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/service/PlanSummaryService.java
@@ -1,0 +1,81 @@
+package com.mamoki.ieojuda.domain.plan.service;
+
+import com.mamoki.ieojuda.domain.handoffcheck.dto.HandoffCheckAssigneeResponse;
+import com.mamoki.ieojuda.domain.handoffcheck.dto.HandoffCheckConfirmerResponse;
+import com.mamoki.ieojuda.domain.handoffcheck.dto.HandoffCheckStatusResponse;
+import com.mamoki.ieojuda.domain.handoffcheck.service.HandoffCheckService;
+import com.mamoki.ieojuda.domain.plan.dto.LifeAreaSummaryResponse;
+import com.mamoki.ieojuda.domain.plan.dto.OrderCheckItemResponse;
+import com.mamoki.ieojuda.domain.plan.dto.PlanSummaryResponse;
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.plan.repository.PlanRepository;
+import com.mamoki.ieojuda.domain.releasecase.dto.ReleaseStatusResponse;
+import com.mamoki.ieojuda.domain.releasecase.service.ReleaseStatusService;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+// 명세서 "계획 홈" 화면 - 프론트가 API 한 번으로 화면을 그릴 수 있도록 기존 서비스 4개의 조회 결과를 조합한다.
+// 새 쿼리를 추가하지 않고 LifeAreaService/ItemOrderService/HandoffCheckService/ReleaseStatusService를 그대로 재사용한다.
+//
+// 부분 실패 처리 방침(#84 완료 조건): 네 조회 중 하나라도 예외가 나면 부분 데이터를 만들지 않고
+// 요청 전체를 실패시킨다 - GlobalExceptionHandler가 표준 RsData 실패 응답으로 바꿔주고,
+// 이 엔드포인트는 GET(멱등)이라 프론트는 그냥 재호출하면 된다. 이 저장소의 다른 조회 API도
+// 전부 같은 방식(부분 응답 없음)이라 여기서만 다르게 갈 이유가 없다.
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PlanSummaryService {
+
+    private final PlanRepository planRepository;
+    private final LifeAreaService lifeAreaService;
+    private final ItemOrderService itemOrderService;
+    private final HandoffCheckService handoffCheckService;
+    private final ReleaseStatusService releaseStatusService;
+
+    public PlanSummaryResponse getMySummary(Long userId) {
+        Plan plan = planRepository.findByUser_UserId(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.PLAN_NOT_FOUND));
+        Long planId = plan.getPlanId();
+
+        var lifeAreas = lifeAreaService.getLifeAreas(userId, planId).stream()
+                .map(LifeAreaSummaryResponse::from)
+                .toList();
+
+        HandoffCheckStatusResponse handoffCheck = handoffCheckService.getHandoffCheck(userId, planId);
+        long recipientAcceptedCount = handoffCheck.assignees().stream()
+                .filter(HandoffCheckAssigneeResponse::isRoleAccepted).count();
+        long confirmerAcceptedCount = handoffCheck.confirmers().stream()
+                .filter(HandoffCheckConfirmerResponse::isRoleAccepted).count();
+        long backupMissingCount = handoffCheck.assignees().stream()
+                .filter(assignee -> assignee.backupName() == null).count();
+        List<String> confirmerNames = handoffCheck.confirmers().stream()
+                .map(HandoffCheckConfirmerResponse::name).toList();
+
+        // 충돌 1건마다 관련된 두 항목 모두 conflict=true로 표시되므로, 이 값은 "충돌 쌍의 수"가 아니라 "충돌에 걸린 항목 수"다.
+        long unresolvedConflictCount = itemOrderService.getOrderCheck(userId, planId).items().stream()
+                .filter(OrderCheckItemResponse::conflict).count();
+
+        ReleaseStatusResponse releaseCase = releaseStatusService.getStatus(userId, planId);
+
+        return new PlanSummaryResponse(
+                plan.getPlanId(),
+                plan.getStatus().name(),
+                plan.getUser().getName(),
+                lifeAreas,
+                recipientAcceptedCount,
+                handoffCheck.assigneeTotalCount(),
+                confirmerAcceptedCount,
+                handoffCheck.confirmerTotalCount(),
+                confirmerNames,
+                backupMissingCount,
+                unresolvedConflictCount,
+                plan.getWaitingDays(),
+                releaseCase
+        );
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/domain/plan/controller/PlanControllerValidationTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/plan/controller/PlanControllerValidationTest.java
@@ -1,6 +1,7 @@
 package com.mamoki.ieojuda.domain.plan.controller;
 
 import com.mamoki.ieojuda.domain.plan.service.PlanService;
+import com.mamoki.ieojuda.domain.plan.service.PlanSummaryService;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.http.MediaType;
@@ -15,8 +16,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class PlanControllerValidationTest {
 
     private final PlanService planService = mock(PlanService.class);
+    private final PlanSummaryService planSummaryService = mock(PlanSummaryService.class);
     private final MockMvc mockMvc = MockMvcBuilders
-            .standaloneSetup(new PlanController(planService))
+            .standaloneSetup(new PlanController(planService, planSummaryService))
             .build();
 
     @ParameterizedTest

--- a/src/test/java/com/mamoki/ieojuda/domain/plan/service/PlanSummaryServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/plan/service/PlanSummaryServiceTest.java
@@ -1,0 +1,155 @@
+package com.mamoki.ieojuda.domain.plan.service;
+
+import com.mamoki.ieojuda.domain.account.entity.User;
+import com.mamoki.ieojuda.domain.handoffcheck.dto.HandoffCheckAssigneeResponse;
+import com.mamoki.ieojuda.domain.handoffcheck.dto.HandoffCheckConfirmerResponse;
+import com.mamoki.ieojuda.domain.handoffcheck.dto.HandoffCheckStatusResponse;
+import com.mamoki.ieojuda.domain.handoffcheck.service.HandoffCheckService;
+import com.mamoki.ieojuda.domain.plan.dto.ItemResponse;
+import com.mamoki.ieojuda.domain.plan.dto.LifeAreaResponse;
+import com.mamoki.ieojuda.domain.plan.dto.OrderCheckItemResponse;
+import com.mamoki.ieojuda.domain.plan.dto.OrderCheckResponse;
+import com.mamoki.ieojuda.domain.plan.dto.PlanSummaryResponse;
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.plan.entity.PlanStatus;
+import com.mamoki.ieojuda.domain.plan.repository.PlanRepository;
+import com.mamoki.ieojuda.domain.releasecase.dto.ReleaseStatusResponse;
+import com.mamoki.ieojuda.domain.releasecase.service.ReleaseStatusService;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class PlanSummaryServiceTest {
+
+    private static final Long USER_ID = 1L;
+    private static final Long PLAN_ID = 10L;
+
+    private PlanRepository planRepository;
+    private LifeAreaService lifeAreaService;
+    private ItemOrderService itemOrderService;
+    private HandoffCheckService handoffCheckService;
+    private ReleaseStatusService releaseStatusService;
+    private PlanSummaryService planSummaryService;
+
+    private Plan plan;
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        planRepository = mock(PlanRepository.class);
+        lifeAreaService = mock(LifeAreaService.class);
+        itemOrderService = mock(ItemOrderService.class);
+        handoffCheckService = mock(HandoffCheckService.class);
+        releaseStatusService = mock(ReleaseStatusService.class);
+        planSummaryService = new PlanSummaryService(
+                planRepository, lifeAreaService, itemOrderService, handoffCheckService, releaseStatusService);
+
+        plan = mock(Plan.class);
+        when(plan.getPlanId()).thenReturn(PLAN_ID);
+        when(plan.getStatus()).thenReturn(PlanStatus.DRAFT);
+        when(plan.getWaitingDays()).thenReturn(14);
+        user = User.builder().email("owner@test.com").password("hash").name("김나무").build();
+        when(plan.getUser()).thenReturn(user);
+        when(planRepository.findByUser_UserId(USER_ID)).thenReturn(Optional.of(plan));
+    }
+
+    @Test
+    void getMySummary_throwsPlanNotFound_whenUserHasNoPlan() {
+        when(planRepository.findByUser_UserId(USER_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> planSummaryService.getMySummary(USER_ID))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.PLAN_NOT_FOUND));
+    }
+
+    @Test
+    void getMySummary_aggregatesEveryCollaboratorResponse() {
+        ItemResponse item = new ItemResponse(1L, "target", "location", "action", "title", "content",
+                "", "FAMILY", "excerpt", "PROPOSED", 0, "OTHER");
+        when(lifeAreaService.getLifeAreas(USER_ID, PLAN_ID)).thenReturn(List.of(
+                new LifeAreaResponse("FAMILY", List.of(item, item, item)),
+                new LifeAreaResponse("RELATIONSHIP_CLEANUP", List.of()),
+                new LifeAreaResponse("WORK_CONTINUITY", List.of(item))
+        ));
+
+        HandoffCheckAssigneeResponse acceptedAssignee =
+                new HandoffCheckAssigneeResponse(1L, "A", "FAMILY_MANAGER", true, true, "backup", true, null, true);
+        HandoffCheckAssigneeResponse pendingAssignee =
+                new HandoffCheckAssigneeResponse(2L, "B", "WORK_MANAGER", true, false, null, false, null, false);
+        HandoffCheckConfirmerResponse acceptedConfirmer =
+                new HandoffCheckConfirmerResponse(1L, "C", true, true, null, true);
+        HandoffCheckConfirmerResponse pendingConfirmer =
+                new HandoffCheckConfirmerResponse(2L, "D", false, false, null, false);
+        when(handoffCheckService.getHandoffCheck(USER_ID, PLAN_ID)).thenReturn(HandoffCheckStatusResponse.of(
+                List.of(acceptedAssignee, pendingAssignee), List.of(acceptedConfirmer, pendingConfirmer)));
+
+        OrderCheckItemResponse conflicting = new OrderCheckItemResponse(
+                1L, 0, "삭제 항목", "DELETE", "담당자", 24, "ACCEPTED", true, "충돌 사유");
+        OrderCheckItemResponse clean = new OrderCheckItemResponse(
+                2L, 1, "정상 항목", "OTHER", "담당자", 24, "ACCEPTED", false, null);
+        when(itemOrderService.getOrderCheck(USER_ID, PLAN_ID))
+                .thenReturn(OrderCheckResponse.of(List.of(conflicting, conflicting, clean)));
+
+        ReleaseStatusResponse releaseStatus = ReleaseStatusResponse.of(null);
+        when(releaseStatusService.getStatus(USER_ID, PLAN_ID)).thenReturn(releaseStatus);
+
+        PlanSummaryResponse summary = planSummaryService.getMySummary(USER_ID);
+
+        assertThat(summary.planId()).isEqualTo(PLAN_ID);
+        assertThat(summary.status()).isEqualTo("DRAFT");
+        assertThat(summary.userName()).isEqualTo("김나무");
+        assertThat(summary.waitingDays()).isEqualTo(14);
+        assertThat(summary.releaseCase()).isEqualTo(releaseStatus);
+
+        assertThat(summary.lifeAreas()).hasSize(3);
+        assertThat(summary.lifeAreas().get(0).itemCount()).isEqualTo(3);
+        assertThat(summary.lifeAreas().get(0).isWritten()).isTrue();
+        assertThat(summary.lifeAreas().get(1).itemCount()).isEqualTo(0);
+        assertThat(summary.lifeAreas().get(1).isWritten()).isFalse();
+
+        assertThat(summary.recipientAcceptedCount()).isEqualTo(1);
+        assertThat(summary.recipientTotalCount()).isEqualTo(2);
+        assertThat(summary.confirmerAcceptedCount()).isEqualTo(1);
+        assertThat(summary.confirmerTotalCount()).isEqualTo(2);
+        assertThat(summary.confirmerNames()).containsExactly("C", "D");
+        assertThat(summary.backupMissingCount()).isEqualTo(1);
+        assertThat(summary.unresolvedConflictCount()).isEqualTo(2);
+    }
+
+    @Test
+    void getMySummary_whenNoRecipientsOrItems_returnsZeroedCounts() {
+        when(lifeAreaService.getLifeAreas(USER_ID, PLAN_ID)).thenReturn(List.of(
+                new LifeAreaResponse("FAMILY", List.of()),
+                new LifeAreaResponse("RELATIONSHIP_CLEANUP", List.of()),
+                new LifeAreaResponse("WORK_CONTINUITY", List.of())
+        ));
+        when(handoffCheckService.getHandoffCheck(USER_ID, PLAN_ID))
+                .thenReturn(HandoffCheckStatusResponse.of(List.of(), List.of()));
+        when(itemOrderService.getOrderCheck(USER_ID, PLAN_ID)).thenReturn(OrderCheckResponse.of(List.of()));
+        when(releaseStatusService.getStatus(USER_ID, PLAN_ID)).thenReturn(ReleaseStatusResponse.of(null));
+
+        PlanSummaryResponse summary = planSummaryService.getMySummary(USER_ID);
+
+        assertThat(summary.recipientAcceptedCount()).isZero();
+        assertThat(summary.recipientTotalCount()).isZero();
+        assertThat(summary.confirmerAcceptedCount()).isZero();
+        assertThat(summary.confirmerTotalCount()).isZero();
+        assertThat(summary.confirmerNames()).isEmpty();
+        assertThat(summary.backupMissingCount()).isZero();
+        assertThat(summary.unresolvedConflictCount()).isZero();
+        assertThat(summary.lifeAreas()).allSatisfy(lifeArea -> {
+            assertThat(lifeArea.itemCount()).isZero();
+            assertThat(lifeArea.isWritten()).isFalse();
+        });
+        assertThat(summary.releaseCase().hasActiveCase()).isFalse();
+    }
+}


### PR DESCRIPTION
## 연관 Issue

- Closes #84

## 요약

계획 홈 화면 하나를 그리기 위해 프론트가 API를 4번(`plans/me` + `role-checks` + `items/order` + `release-status`) 호출해야 했던 문제를 해결합니다. 기존 `GET /api/plans/me`를 확장해 `PlanSummaryResponse` 하나로 계획 홈에 필요한 정보를 전부 내려줍니다.

## 변경 사항

- `GET /api/plans/me` 응답을 `PlanResponse`(4필드) → `PlanSummaryResponse`로 확장
- `PlanSummaryService` 신설 — `LifeAreaService`/`ItemOrderService`/`HandoffCheckService`/`ReleaseStatusService` 조회 결과만 조합, 새 쿼리 없음
- 구역별 항목 수·작성 여부(`lifeAreas`), 담당자 수락 상태, 확인자 수락 상태·이름 목록(`confirmerNames`), 대체 담당자 누락 수, 미해결 충돌 건수, 대기 기간, 사후 사건 상태 집계
- `LifeAreaCategory`에 구역별 표시용 `label()`/`summary()` 추가
- 더 이상 쓰이지 않는 `PlanService.getMyPlan()` 제거

## 범위

### 포함

- `PlanSummaryResponse`/`LifeAreaSummaryResponse` DTO 신설
- 부분 실패 처리 방침 결정: 하위 조회 중 하나라도 실패하면 부분 응답 없이 전체 요청 실패 → 프론트는 재호출(GET이라 멱등)
- `PlanSummaryServiceTest` 추가 (정상 집계, `PLAN_NOT_FOUND`, 빈 계정 케이스)

### 제외

- 종합 AI 준비도 점수 (명세서에서 "제공하지 않습니다"로 명시)
- `HandoffCheckService`가 `HandoffCheckRepository`를 아직 주입받지 않는 문제 (#85 범위)
- 역할 담당자(recipient) 이름 목록 — 이번엔 목업에 나온 확인자(confirmer) 이름만 추가함

## 스크린샷 / 미리 보기

프론트 UI가 없는 백엔드 PR이라 화면 스크린샷 대신 실제 로컬 서버에 로그인해서 받은 응답입니다.

```json
GET /api/plans/me

{
  "planId": 134,
  "status": "DRAFT",
  "userName": "김나무",
  "lifeAreas": [
    { "category": "FAMILY", "label": "전달 메세지", "summary": "가족·친구·지인에게", "itemCount": 0, "isWritten": false },
    { "category": "RELATIONSHIP_CLEANUP", "label": "관계 정리", "summary": "SNS 계정·부고 전달", "itemCount": 0, "isWritten": false },
    { "category": "WORK_CONTINUITY", "label": "업무 처리", "summary": "디자인 프로젝트 인수인계", "itemCount": 0, "isWritten": false }
  ],
  "recipientAcceptedCount": 0,
  "recipientTotalCount": 0,
  "confirmerAcceptedCount": 0,
  "confirmerTotalCount": 0,
  "confirmerNames": [],
  "backupMissingCount": 0,
  "unresolvedConflictCount": 0,
  "waitingDays": null,
  "releaseCase": { "hasActiveCase": false, "status": null, "waitingEndsAt": null, "remainingDays": null, "canceledAt": null }
}