### PR TITLE
[Feat/#91]: 금지정보 저장 시점 검증 추가

### DIFF
--- a/src/main/java/com/mamoki/ieojuda/domain/plan/service/ConversationService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/service/ConversationService.java
@@ -27,6 +27,7 @@ import com.mamoki.ieojuda.global.exception.ErrorCode;
 import com.mamoki.ieojuda.global.openai.component.OpenAIClient;
 import com.mamoki.ieojuda.global.openai.dto.OpenAIMessageDto;
 import com.mamoki.ieojuda.global.openai.dto.OpenAIResponse;
+import com.mamoki.ieojuda.global.validation.CredentialDetector;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -86,6 +87,11 @@ public class ConversationService {
         Conversation conversation = findConversation(userId, planId, conversationId);
         Plan plan = conversation.getPlan();
 
+        // issue #91 1차 방어 - 자격증명 의심 입력은 저장도, AI 전송도 하지 않는다 (명세서 "삶의 구역 작성" 예외 처리)
+        if (CredentialDetector.containsCredential(userContent)) {
+            throw new CustomException(ErrorCode.SUSPECTED_CREDENTIAL_INPUT);
+        }
+
         // step 1. 이 세션 안에서 지금까지의 대화 이력 로드
         List<LifeAreaMessage> history = lifeAreaMessageRepository
                 .findByConversation_ConversationIdOrderByMessageIdAsc(conversation.getConversationId());
@@ -105,6 +111,13 @@ public class ConversationService {
             openAiHistory.add(new OpenAIMessageDto(toOpenAiRole(message.getRole()), message.getContent()));
         }
         openAiHistory.add(new OpenAIMessageDto(toOpenAiRole(MessageRole.USER), userMessage.getContent()));
+
+        // issue #91 2차 방어 - 1차 방어가 생기기 전에 저장된 과거 이력에 자격증명이 남아있을 가능성에 대비해
+        // OpenAI로 나가기 직전 전체 이력을 다시 검사한다. 여기서 걸리면 트랜잭션이 롤백되어 방금 저장한
+        // 사용자 메세지도 함께 취소된다.
+        if (openAiHistory.stream().anyMatch(message -> CredentialDetector.containsCredential(message.content()))) {
+            throw new CustomException(ErrorCode.SUSPECTED_CREDENTIAL_INPUT);
+        }
 
         // step 4. OpenAI 호출 - 계획 만들기 폼이 없어졌으므로 별도 seedContext 없이 대화 이력만으로 판단
         OpenAIResponse response = openAIClient.getChatCompletion(openAiHistory);

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/service/ItemReviewService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/service/ItemReviewService.java
@@ -11,6 +11,7 @@ import com.mamoki.ieojuda.domain.plan.entity.ItemActionType;
 import com.mamoki.ieojuda.domain.plan.repository.ItemRepository;
 import com.mamoki.ieojuda.global.exception.CustomException;
 import com.mamoki.ieojuda.global.exception.ErrorCode;
+import com.mamoki.ieojuda.global.validation.CredentialDetector;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -36,6 +37,12 @@ public class ItemReviewService {
         // 명세서 예외 처리: 원문 근거 없는 항목은 승인할 수 없음
         if (item.getSourceExcerpt() == null || item.getSourceExcerpt().isBlank()) {
             throw new CustomException(ErrorCode.UNGROUNDED_ITEM_NOT_APPROVABLE);
+        }
+        // issue #91 3차 방어 - 대화 저장 시점 검증을 우회해 들어온(예: 인라인 수정) 자격증명도 승인 시점에 다시 막는다
+        if (CredentialDetector.containsCredential(item.getAction())
+                || CredentialDetector.containsCredential(item.getContent())
+                || CredentialDetector.containsCredential(item.getLocationType())) {
+            throw new CustomException(ErrorCode.SUSPECTED_CREDENTIAL_INPUT);
         }
         item.approve();
 

--- a/src/main/java/com/mamoki/ieojuda/global/exception/ErrorCode.java
+++ b/src/main/java/com/mamoki/ieojuda/global/exception/ErrorCode.java
@@ -16,7 +16,7 @@ public enum ErrorCode {
     // 계획 / 삶의 구역 / AI 구조화 관련 예외 (400)
     INVALID_WAITING_PERIOD(HttpStatus.BAD_REQUEST, "INVALID_WAITING_PERIOD", "대기 기간은 7일 이상 30일 이하여야 합니다."),
     CONSENT_REQUIRED(HttpStatus.BAD_REQUEST, "CONSENT_REQUIRED", "사후 인계 조건과 안전 범위를 확인해 주세요."),
-    SUSPECTED_CREDENTIAL_INPUT(HttpStatus.BAD_REQUEST, "SUSPECTED_CREDENTIAL_INPUT", "비밀번호 등 자격증명으로 의심되는 내용은 저장할 수 없습니다."),
+    SUSPECTED_CREDENTIAL_INPUT(HttpStatus.BAD_REQUEST, "SUSPECTED_CREDENTIAL_INPUT", "비밀번호·PIN·OTP·복구 코드로 보이는 내용은 저장할 수 없습니다. 위치 유형만 적어 주세요."),
     UNGROUNDED_ITEM_NOT_APPROVABLE(HttpStatus.BAD_REQUEST, "UNGROUNDED_ITEM_NOT_APPROVABLE", "원문 근거가 없는 항목은 승인할 수 없습니다."),
     ITEM_NOT_APPROVED(HttpStatus.BAD_REQUEST, "ITEM_NOT_APPROVED", "승인되지 않은 항목에는 담당자를 등록할 수 없습니다."),
     PROHIBITED_ACTION_DETECTED(HttpStatus.BAD_REQUEST, "PROHIBITED_ACTION_DETECTED", "AI가 처리할 수 없는 금지 행동이 포함되어 있습니다."),

--- a/src/test/java/com/mamoki/ieojuda/domain/plan/service/ConversationServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/plan/service/ConversationServiceTest.java
@@ -1,0 +1,133 @@
+package com.mamoki.ieojuda.domain.plan.service;
+
+import tools.jackson.databind.ObjectMapper;
+import com.mamoki.ieojuda.domain.plan.entity.Conversation;
+import com.mamoki.ieojuda.domain.plan.entity.LifeAreaMessage;
+import com.mamoki.ieojuda.domain.plan.entity.MessageRole;
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.plan.repository.ConversationRepository;
+import com.mamoki.ieojuda.domain.plan.repository.ItemRepository;
+import com.mamoki.ieojuda.domain.plan.repository.LifeAreaMessageRepository;
+import com.mamoki.ieojuda.domain.plan.repository.LifeAreaRepository;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import com.mamoki.ieojuda.global.openai.component.OpenAIClient;
+import com.mamoki.ieojuda.global.openai.dto.OpenAIMessageDto;
+import com.mamoki.ieojuda.global.openai.dto.OpenAIResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+// issue #91 완료 조건 - "자격증명 의심 입력이 저장되지 않는다" / "OpenAI로 전송되지 않는다"의
+// 대화 메세지 저장 시점(1차) · OpenAI 전송 직전(2차) 방어선을 검증한다.
+class ConversationServiceTest {
+
+    private static final UUID USER_ID = UUID.randomUUID();
+    private static final UUID PLAN_ID = UUID.randomUUID();
+    private static final UUID CONVERSATION_ID = UUID.randomUUID();
+
+    private PlanOwnershipReader planOwnershipReader;
+    private ConversationRepository conversationRepository;
+    private LifeAreaMessageRepository lifeAreaMessageRepository;
+    private LifeAreaRepository lifeAreaRepository;
+    private ItemRepository itemRepository;
+    private OpenAIClient openAIClient;
+    private ConversationService conversationService;
+
+    private Plan plan;
+    private Conversation conversation;
+
+    @BeforeEach
+    void setUp() {
+        planOwnershipReader = mock(PlanOwnershipReader.class);
+        conversationRepository = mock(ConversationRepository.class);
+        lifeAreaMessageRepository = mock(LifeAreaMessageRepository.class);
+        lifeAreaRepository = mock(LifeAreaRepository.class);
+        itemRepository = mock(ItemRepository.class);
+        openAIClient = mock(OpenAIClient.class);
+        conversationService = new ConversationService(planOwnershipReader, conversationRepository,
+                lifeAreaMessageRepository, lifeAreaRepository, itemRepository, openAIClient, new ObjectMapper());
+
+        plan = mock(Plan.class);
+        when(plan.getPlanId()).thenReturn(PLAN_ID);
+        conversation = mock(Conversation.class);
+        when(conversation.getConversationId()).thenReturn(CONVERSATION_ID);
+        when(conversation.getPlan()).thenReturn(plan);
+        when(planOwnershipReader.findOwnedPlan(USER_ID, PLAN_ID)).thenReturn(plan);
+        when(conversationRepository.findById(CONVERSATION_ID)).thenReturn(Optional.of(conversation));
+        when(lifeAreaMessageRepository.findByConversation_ConversationIdOrderByMessageIdAsc(CONVERSATION_ID))
+                .thenReturn(List.of());
+        when(lifeAreaMessageRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    }
+
+    @Test
+    void sendMessage_whenUserContentContainsCredentialValue_throwsWithoutSavingOrCallingOpenAI() {
+        assertThatThrownBy(() -> conversationService.sendMessage(
+                USER_ID, PLAN_ID, CONVERSATION_ID, "인스타그램 비밀번호는 abcd1234야"))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.SUSPECTED_CREDENTIAL_INPUT));
+
+        verify(lifeAreaMessageRepository, never()).save(any());
+        verify(openAIClient, never()).getChatCompletion(any());
+    }
+
+    // 1차 방어(저장 전 검증)가 생기기 전에 저장된 과거 이력에 자격증명이 남아있는 상황을 재현
+    @Test
+    void sendMessage_whenPastHistoryContainsCredentialValue_throwsBeforeCallingOpenAI() {
+        LifeAreaMessage taintedPastMessage = LifeAreaMessage.builder()
+                .conversation(conversation).role(MessageRole.USER)
+                .content("복구코드: XY12-9988").build();
+        when(lifeAreaMessageRepository.findByConversation_ConversationIdOrderByMessageIdAsc(CONVERSATION_ID))
+                .thenReturn(List.of(taintedPastMessage));
+
+        assertThatThrownBy(() -> conversationService.sendMessage(
+                USER_ID, PLAN_ID, CONVERSATION_ID, "인스타그램 계정을 정리해줘"))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.SUSPECTED_CREDENTIAL_INPUT));
+
+        verify(openAIClient, never()).getChatCompletion(any());
+    }
+
+    // md 스펙 #91 오탐 대응 기준 - 키워드만 있고 값이 없는 문장은 막지 않는다
+    @Test
+    void sendMessage_whenTextMentionsKeywordWithoutValue_proceedsToOpenAI() {
+        OpenAIResponse response = new OpenAIResponse(List.of(
+                new OpenAIResponse.Choice(new OpenAIMessageDto("assistant",
+                        "{\"type\":\"QUESTION\",\"question\":\"어떤 계정인가요?\"}"))));
+        when(openAIClient.getChatCompletion(any())).thenReturn(response);
+
+        var result = conversationService.sendMessage(
+                USER_ID, PLAN_ID, CONVERSATION_ID, "비밀번호는 지수가 알고 있어요");
+
+        assertThat(result.type()).isEqualTo("QUESTION");
+        verify(openAIClient).getChatCompletion(any());
+    }
+
+    @Test
+    void sendMessage_whenNoCredentialAnywhere_savesAndCallsOpenAI() {
+        OpenAIResponse response = new OpenAIResponse(List.of(
+                new OpenAIResponse.Choice(new OpenAIMessageDto("assistant",
+                        "{\"type\":\"QUESTION\",\"question\":\"어떤 계정인가요?\"}"))));
+        when(openAIClient.getChatCompletion(any())).thenReturn(response);
+
+        var result = conversationService.sendMessage(
+                USER_ID, PLAN_ID, CONVERSATION_ID, "인스타그램 계정을 정리해줘");
+
+        assertThat(result.type()).isEqualTo("QUESTION");
+        // 사용자 발화 저장 1회 + AI 응답 원문 저장 1회
+        verify(lifeAreaMessageRepository, times(2)).save(any());
+        verify(openAIClient).getChatCompletion(any());
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/domain/plan/service/ItemReviewServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/plan/service/ItemReviewServiceTest.java
@@ -1,0 +1,106 @@
+package com.mamoki.ieojuda.domain.plan.service;
+
+import com.mamoki.ieojuda.domain.plan.dto.ItemReviewRequest;
+import com.mamoki.ieojuda.domain.plan.entity.DisclosureScope;
+import com.mamoki.ieojuda.domain.plan.entity.Item;
+import com.mamoki.ieojuda.domain.plan.entity.ItemActionType;
+import com.mamoki.ieojuda.domain.plan.entity.LifeArea;
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.plan.repository.ItemRepository;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+// issue #91 완료 조건 - "자격증명 의심 입력이 저장되지 않는다"의 승인 시점 방어선.
+// 대화 저장 시점 검증(ConversationServiceTest)을 우회해 들어온 항목(예: 인라인 수정)도 승인 단계에서 다시 막아야 한다.
+class ItemReviewServiceTest {
+
+    private static final UUID USER_ID = UUID.randomUUID();
+    private static final UUID PLAN_ID = UUID.randomUUID();
+    private static final UUID ITEM_ID = UUID.randomUUID();
+
+    private ItemRepository itemRepository;
+    private PlanOwnershipReader planOwnershipReader;
+    private ItemReviewService itemReviewService;
+
+    private Plan plan;
+    private LifeArea lifeArea;
+
+    @BeforeEach
+    void setUp() {
+        itemRepository = mock(ItemRepository.class);
+        planOwnershipReader = mock(PlanOwnershipReader.class);
+        itemReviewService = new ItemReviewService(itemRepository, planOwnershipReader);
+
+        plan = mock(Plan.class);
+        when(plan.getPlanId()).thenReturn(PLAN_ID);
+        lifeArea = mock(LifeArea.class);
+        when(lifeArea.getPlan()).thenReturn(plan);
+        when(planOwnershipReader.findOwnedPlan(USER_ID, PLAN_ID)).thenReturn(plan);
+    }
+
+    private Item buildItem(String action, String content, String locationType) {
+        Item item = Item.builder()
+                .lifeArea(lifeArea).targetName("대상").locationType(locationType).action(action)
+                .title("제목").content(content).precondition("")
+                .disclosureScope(DisclosureScope.RELATIONSHIP).sourceExcerpt("원문 근거")
+                .sortOrder(0).actionType(ItemActionType.OTHER).build();
+        when(itemRepository.findById(ITEM_ID)).thenReturn(Optional.of(item));
+        return item;
+    }
+
+    @Test
+    void approve_whenActionContainsCredentialValue_throwsSuspectedCredentialInput() {
+        buildItem("인스타그램 비밀번호는 abcd1234야", "비공개 전환", "인스타그램");
+
+        assertThatThrownBy(() -> itemReviewService.approve(USER_ID, PLAN_ID, new ItemReviewRequest(ITEM_ID)))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.SUSPECTED_CREDENTIAL_INPUT));
+    }
+
+    @Test
+    void approve_whenContentContainsCredentialValue_throwsSuspectedCredentialInput() {
+        buildItem("계정 정리", "PIN 5678로 해제 후 탈퇴", "인스타그램");
+
+        assertThatThrownBy(() -> itemReviewService.approve(USER_ID, PLAN_ID, new ItemReviewRequest(ITEM_ID)))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.SUSPECTED_CREDENTIAL_INPUT));
+    }
+
+    @Test
+    void approve_whenLocationTypeContainsCredentialValue_throwsSuspectedCredentialInput() {
+        buildItem("계정 정리", "탈퇴 처리", "복구코드: XY12-9988");
+
+        assertThatThrownBy(() -> itemReviewService.approve(USER_ID, PLAN_ID, new ItemReviewRequest(ITEM_ID)))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.SUSPECTED_CREDENTIAL_INPUT));
+    }
+
+    // md 스펙 #91 오탐 대응 기준 - 키워드만 있고 값이 없는 문장은 승인을 막지 않는다
+    @Test
+    void approve_whenTextMentionsKeywordWithoutValue_approvesNormally() {
+        Item item = buildItem("비밀번호는 지수가 알고 있어요", "탈퇴 처리", "인스타그램");
+
+        var response = itemReviewService.approve(USER_ID, PLAN_ID, new ItemReviewRequest(ITEM_ID));
+
+        assertThat(response.itemId()).isEqualTo(item.getItemId());
+    }
+
+    @Test
+    void approve_whenNoCredentialAndHasSourceExcerpt_approvesNormally() {
+        buildItem("계정 정리", "비공개 전환", "인스타그램");
+
+        var response = itemReviewService.approve(USER_ID, PLAN_ID, new ItemReviewRequest(ITEM_ID));
+
+        assertThat(response).isNotNull();
+    }
+}


### PR DESCRIPTION
Closes #91

## 요약
- 대화 메세지 저장 전(1차) / OpenAI 전송 직전(2차, 과거 이력 포함) / 항목 승인 시점(3차)에 `CredentialDetector`(#81)를 재사용해 자격증명 의심 입력을 차단
- `ErrorCode.SUSPECTED_CREDENTIAL_INPUT`(기존 정의만 있고 사용처 0곳이던 코드)를 연결하고, 메시지에 "위치 유형만 적어 주세요" 안내 문구 보강 (완료 조건 대응)
- 패키지 봉인 시점 검증은 #81에서 이미 구현되어 있어 변경 없음
- 오탐 방지는 `CredentialDetector`의 "키워드+값 형태" 판정 기준(md 스펙 #91)에 이미 반영되어 있어 별도 우회 경로 없이 재작성 후 재전송으로 충분

## 테스트 플랜
- [x] `ConversationServiceTest`, `ItemReviewServiceTest` 신규 작성 (차단/오탐통과/정상흐름 9개 케이스)
- [x] 전체 테스트 스위트 실행 (240개 중 239개 통과, 나머지 1개는 develop에도 동일하게 존재하는 무관한 기존 결함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)