### PR TITLE
[Feat/#92]: 이의 제기 연락처 검증 메일 재발송 API 추가

### DIFF
--- a/src/main/java/com/mamoki/ieojuda/domain/confirmer/controller/DisputeContactController.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/confirmer/controller/DisputeContactController.java
@@ -57,4 +57,13 @@ public class DisputeContactController {
         disputeContactService.verify(token);
         return ResponseEntity.ok(RsData.success(null));
     }
+
+    @Operation(summary = "이의 제기 연락처 검증 메일 다시 보내기", description = "첫 검증 메일을 놓쳤을 때 새 검증 메일을 보냅니다. 이전 검증 링크는 무효화됩니다. 이미 검증이 완료된 연락처에는 보낼 수 없습니다.")
+    @PostMapping("/dispute-contacts/{contactId}/verification-email")
+    public ResponseEntity<RsData<DisputeContactResponse>> resendVerificationEmail(
+            @AuthenticationPrincipal UUID userId,
+            @Parameter(description = "이의 제기 연락처 ID") @PathVariable UUID contactId
+    ) {
+        return ResponseEntity.ok(RsData.success(disputeContactService.resendVerificationEmail(userId, contactId)));
+    }
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/confirmer/service/DisputeContactService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/confirmer/service/DisputeContactService.java
@@ -90,6 +90,24 @@ public class DisputeContactService {
         return true;
     }
 
+    // "대기 이의제기 설정" 화면 - 검증 메일을 놓쳤을 때 다시 보내기. Recipient/Confirmer의 재발송과 동일 패턴
+    // (플랫 경로 + 소유권은 plan.user로 직접 확인 - 노션 명세서가 /plans/{planId}/ 없이 /dispute-contacts/{id}/뿐이라 planId를 받지 않음)
+    @Transactional
+    public DisputeContactResponse resendVerificationEmail(UUID userId, UUID contactId) {
+        DisputeContact contact = disputeContactRepository.findById(contactId)
+                .orElseThrow(() -> new CustomException(ErrorCode.DISPUTE_CONTACT_NOT_FOUND));
+        if (!contact.getPlan().getUser().getUserId().equals(userId)) {
+            throw new CustomException(ErrorCode.DISPUTE_CONTACT_NOT_FOUND);
+        }
+        if (Boolean.TRUE.equals(contact.getIsVerified())) {
+            throw new CustomException(ErrorCode.DISPUTE_CONTACT_RESEND_NOT_ALLOWED);
+        }
+
+        // issueInviteToken()이 기존 토큰 해시를 덮어쓰므로, 이전 토큰은 더 이상 조회되지 않아 자동으로 무효화된다
+        boolean emailSent = issueTokenAndSendVerificationEmail(contact);
+        return DisputeContactResponse.of(contact, emailSent);
+    }
+
     private DisputeContact findContact(UUID planId, UUID contactId) {
         DisputeContact contact = disputeContactRepository.findById(contactId)
                 .orElseThrow(() -> new CustomException(ErrorCode.DISPUTE_CONTACT_NOT_FOUND));

--- a/src/main/java/com/mamoki/ieojuda/global/config/SecurityConfig.java
+++ b/src/main/java/com/mamoki/ieojuda/global/config/SecurityConfig.java
@@ -87,6 +87,7 @@ public class SecurityConfig {
                 new RateLimitRule("evidence-submit", "/api/release-cases/*/evidence/submit", "POST", 10, Duration.ofHours(1)),
                 new RateLimitRule("objection", "/api/release-cases/*/disputes", "POST", 10, Duration.ofHours(1)),
                 new RateLimitRule("dispute-verify", "/api/dispute-contacts/*/verify", null, 20, Duration.ofHours(1)),
+                new RateLimitRule("dispute-contact-resend", "/api/dispute-contacts/*/verification-email", "POST", 5, Duration.ofHours(1)),
                 new RateLimitRule("self-warning-email", "/api/self-warning-email/**", null, 20, Duration.ofHours(1)),
                 new RateLimitRule("posthumous-otp", "/api/posthumous-access/*/otp", "POST", 5, Duration.ofHours(1)),
                 new RateLimitRule("posthumous-verify", "/api/posthumous-access/*/verify", "POST", 10, Duration.ofHours(1)),

--- a/src/main/java/com/mamoki/ieojuda/global/exception/ErrorCode.java
+++ b/src/main/java/com/mamoki/ieojuda/global/exception/ErrorCode.java
@@ -91,6 +91,7 @@ public enum ErrorCode {
     BACKUP_RECIPIENT_EMAIL_DUPLICATED(HttpStatus.CONFLICT, "BACKUP_RECIPIENT_EMAIL_DUPLICATED", "대체 담당자 이메일은 주 담당자와 같을 수 없습니다."),
     RECIPIENT_RESEND_NOT_ALLOWED(HttpStatus.CONFLICT, "RECIPIENT_RESEND_NOT_ALLOWED", "현재 수락 상태에서는 수락 요청을 다시 보낼 수 없습니다."),
     CONFIRMER_RESEND_NOT_ALLOWED(HttpStatus.CONFLICT, "CONFIRMER_RESEND_NOT_ALLOWED", "현재 수락 상태에서는 수락 요청을 다시 보낼 수 없습니다."),
+    DISPUTE_CONTACT_RESEND_NOT_ALLOWED(HttpStatus.CONFLICT, "DISPUTE_CONTACT_RESEND_NOT_ALLOWED", "이미 검증이 완료된 연락처에는 검증 메일을 다시 보낼 수 없습니다."),
     ITEM_ORDER_CONFLICT(HttpStatus.CONFLICT, "ITEM_ORDER_CONFLICT", "순서 충돌이 있어 확정할 수 없습니다."),
     PARTNER_NOT_ASSIGNED(HttpStatus.CONFLICT, "PARTNER_NOT_ASSIGNED", "이 사건에는 아직 담당 파트너사가 배정되지 않았습니다."),
     EVIDENCE_ALREADY_DELETED(HttpStatus.CONFLICT, "EVIDENCE_ALREADY_DELETED", "이미 삭제된 증빙입니다."),

--- a/src/test/java/com/mamoki/ieojuda/domain/confirmer/service/DisputeContactServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/confirmer/service/DisputeContactServiceTest.java
@@ -1,0 +1,114 @@
+package com.mamoki.ieojuda.domain.confirmer.service;
+
+import com.mamoki.ieojuda.domain.account.entity.User;
+import com.mamoki.ieojuda.domain.confirmer.entity.DisputeContact;
+import com.mamoki.ieojuda.domain.confirmer.repository.DisputeContactRepository;
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.plan.service.PlanOwnershipReader;
+import com.mamoki.ieojuda.global.config.AppProperties;
+import com.mamoki.ieojuda.global.email.outbox.EmailOutboxService;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import com.mamoki.ieojuda.global.ratelimit.PublicLinkAuditor;
+import com.mamoki.ieojuda.global.ratelimit.TokenLookupGuard;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+// issue #92 완료 조건 - "검증 메일을 다시 보낼 수 있다" / "재발송 시 이전 링크는 무효화된다"의
+// Recipient/Confirmer 재발송과 동일한 패턴(플랫 경로 + plan.user로 소유권 확인, 이미 검증 완료 시 409)
+class DisputeContactServiceTest {
+
+    private static final UUID USER_ID = UUID.randomUUID();
+    private static final UUID OTHER_USER_ID = UUID.randomUUID();
+    private static final UUID CONTACT_ID = UUID.randomUUID();
+
+    private PlanOwnershipReader planOwnershipReader;
+    private DisputeContactRepository disputeContactRepository;
+    private EmailOutboxService emailOutboxService;
+    private AppProperties appProperties;
+    private TokenLookupGuard tokenLookupGuard;
+    private PublicLinkAuditor publicLinkAuditor;
+    private DisputeContactService disputeContactService;
+
+    private Plan plan;
+
+    @BeforeEach
+    void setUp() {
+        planOwnershipReader = mock(PlanOwnershipReader.class);
+        disputeContactRepository = mock(DisputeContactRepository.class);
+        emailOutboxService = mock(EmailOutboxService.class);
+        appProperties = mock(AppProperties.class);
+        tokenLookupGuard = mock(TokenLookupGuard.class);
+        publicLinkAuditor = mock(PublicLinkAuditor.class);
+        disputeContactService = new DisputeContactService(planOwnershipReader, disputeContactRepository,
+                emailOutboxService, appProperties, tokenLookupGuard, publicLinkAuditor);
+
+        when(appProperties.getInviteTokenTtlHours()).thenReturn(48L);
+        when(appProperties.getBaseUrl()).thenReturn("https://ieoduda.example.com");
+        when(appProperties.getContactEmail()).thenReturn("support@ieoduda.example.com");
+
+        User owner = mock(User.class);
+        when(owner.getUserId()).thenReturn(USER_ID);
+        plan = mock(Plan.class);
+        when(plan.getUser()).thenReturn(owner);
+    }
+
+    private DisputeContact buildContact(boolean verified) {
+        DisputeContact contact = DisputeContact.builder().plan(plan).name("이지수").email("jisu@test.com").build();
+        if (verified) {
+            contact.verify();
+        }
+        when(disputeContactRepository.findById(CONTACT_ID)).thenReturn(Optional.of(contact));
+        return contact;
+    }
+
+    @Test
+    void resendVerificationEmail_whenNotYetVerified_issuesNewTokenAndSendsEmail() {
+        DisputeContact contact = buildContact(false);
+        String originalToken = contact.getInviteToken();
+
+        var response = disputeContactService.resendVerificationEmail(USER_ID, CONTACT_ID);
+
+        assertThat(response.contactId()).isEqualTo(contact.getContactId());
+        assertThat(response.emailSent()).isTrue();
+        // issueInviteToken()이 새 해시로 덮어써서 이전 토큰은 더 이상 조회되지 않는다(자동 무효화)
+        assertThat(contact.getInviteToken()).isNotEqualTo(originalToken);
+        org.mockito.Mockito.verify(emailOutboxService).enqueue(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void resendVerificationEmail_whenAlreadyVerified_throwsDisputeContactResendNotAllowed() {
+        buildContact(true);
+
+        assertThatThrownBy(() -> disputeContactService.resendVerificationEmail(USER_ID, CONTACT_ID))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.DISPUTE_CONTACT_RESEND_NOT_ALLOWED));
+    }
+
+    @Test
+    void resendVerificationEmail_whenNotOwner_throwsDisputeContactNotFound() {
+        buildContact(false);
+
+        assertThatThrownBy(() -> disputeContactService.resendVerificationEmail(OTHER_USER_ID, CONTACT_ID))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.DISPUTE_CONTACT_NOT_FOUND));
+    }
+
+    @Test
+    void resendVerificationEmail_whenContactDoesNotExist_throwsDisputeContactNotFound() {
+        when(disputeContactRepository.findById(CONTACT_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> disputeContactService.resendVerificationEmail(USER_ID, CONTACT_ID))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.DISPUTE_CONTACT_NOT_FOUND));
+    }
+}


### PR DESCRIPTION
Closes #92

## 요약
- 노션 "대기·이의 제기 설정" 명세서의 `POST /api/dispute-contacts/{id}/verification-email` 경로 그대로 신설 (이슈/md 스펙이 제안한 `/plans/{planId}/` 포함 경로 대신, 담당자·확인자 재발송 API와 동일한 플랫 경로 + plan.user 기반 소유권 확인 패턴을 따름)
- 기존 토큰은 `issueInviteToken()` 재호출로 자동 무효화, `EmailType.DISPUTE_CONTACT_VERIFICATION`으로 발송 이력 기록 - 기존 헬퍼 재사용
- 이미 검증 완료된 연락처는 `ErrorCode.DISPUTE_CONTACT_RESEND_NOT_ALLOWED`(409)로 차단 (Recipient/Confirmer의 RESEND_NOT_ALLOWED와 동일 패턴)
- `SecurityConfig`에 재발송 전용 rate limit 규칙 추가 (5회/시간)
- 담당자/확인자 재발송 API는 노션과 이미 일치함을 확인 (변경 없음)

## 테스트 플랜
- [x] `DisputeContactServiceTest` 신규 작성 (재발송 성공/이미 검증됨/소유자 아님/존재하지 않음 4개 케이스)
- [x] 전체 테스트 스위트 실행 (244개 중 243개 통과, 나머지 1개는 develop에도 동일하게 존재하는 무관한 기존 결함 - PR #108의 .env 이관 관련)
- [ ] rate limit 규칙은 등록만 하고 실제 차단 동작에 대한 전용 테스트는 작성하지 않음 (SecurityConfig의 다른 규칙들과 동일한 기존 관례를 따름 - RateLimitFilterTest가 메커니즘 자체를 범용으로 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)