### PR TITLE
[Feat/#90]: 결정론적 충돌 점검 규칙 보강

### DIFF
--- a/src/main/java/com/mamoki/ieojuda/domain/plan/dto/AiStructuredItemDto.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/dto/AiStructuredItemDto.java
@@ -11,6 +11,7 @@ public record AiStructuredItemDto(
         String disclosureScope, // DisclosureScope.name()과 동일한 문자열(FAMILY/WORK/RELATIONSHIP)이어야 함
         String sourceExcerpt,   // 원문 근거 또는 선택값 근거
         Integer sortOrder,      // 같은 응답 안 항목들끼리의 실행 순서 (낮을수록 먼저)
-        String actionType       // "실행 순서 점검" 충돌 판정용 분류 - DELETE/TRANSFER/OTHER 중 하나여야 함
+        String actionType,      // "실행 순서 점검" 충돌 판정용 분류 - DELETE/TRANSFER/OTHER 중 하나여야 함
+        String semanticType     // issue #90 - CLOUD_DELETE/FILE_PRESERVE/CHANNEL_CLOSE/CLIENT_NOTIFY/DEVICE_RESET/RECORD_EXPORT 중 하나, 해당 없으면 null
 ) {
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/dto/ItemResponse.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/dto/ItemResponse.java
@@ -18,7 +18,9 @@ public record ItemResponse(
         @Schema(description = "이 항목의 근거가 되는 원문 문장") String sourceExcerpt,
         @Schema(description = "검토 상태", example = "PROPOSED", allowableValues = {"PROPOSED", "APPROVED"}) String status,
         @Schema(description = "같은 대화 턴에서 만들어진 항목들끼리의 실행 순서 (낮을수록 먼저)") Integer sortOrder,
-        @Schema(description = "실행 순서 충돌 판정용 분류", example = "DELETE", allowableValues = {"DELETE", "TRANSFER", "OTHER"}) String actionType
+        @Schema(description = "실행 순서 충돌 판정용 분류", example = "DELETE", allowableValues = {"DELETE", "TRANSFER", "OTHER"}) String actionType,
+        @Schema(description = "순서 쌍 충돌 판정용 세부 분류(해당 없으면 null)", example = "CLOUD_DELETE",
+                allowableValues = {"CLOUD_DELETE", "FILE_PRESERVE", "CHANNEL_CLOSE", "CLIENT_NOTIFY", "DEVICE_RESET", "RECORD_EXPORT"}) String semanticType
 ) {
     public static ItemResponse from(Item item) {
         return new ItemResponse(
@@ -33,7 +35,8 @@ public record ItemResponse(
                 item.getSourceExcerpt(),
                 item.getStatus().name(),
                 item.getSortOrder(),
-                item.getActionType() == null ? null : item.getActionType().name()
+                item.getActionType() == null ? null : item.getActionType().name(),
+                item.getSemanticType() == null ? null : item.getSemanticType().name()
         );
     }
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/dto/ItemUpdateRequest.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/dto/ItemUpdateRequest.java
@@ -17,6 +17,7 @@ public record ItemUpdateRequest(
         @jakarta.validation.constraints.Size(max = 2000, message = "선행 조건은 2,000자 이하여야 합니다.") String precondition,
         @NotBlank(message = "공개 범위를 선택해 주세요.")
         @jakarta.validation.constraints.Size(max = 30, message = "공개 범위 값은 30자 이하여야 합니다.") String disclosureScope,
-        @jakarta.validation.constraints.Size(max = 30, message = "행동 유형 값은 30자 이하여야 합니다.") String actionType
+        @jakarta.validation.constraints.Size(max = 30, message = "행동 유형 값은 30자 이하여야 합니다.") String actionType,
+        @jakarta.validation.constraints.Size(max = 30, message = "세부 분류 값은 30자 이하여야 합니다.") String semanticType
 ) {
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/dto/OrderCheckItemResponse.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/dto/OrderCheckItemResponse.java
@@ -10,6 +10,8 @@ public record OrderCheckItemResponse(
         @Schema(description = "실행 순서 (낮을수록 먼저, 화면 표시 번호는 이 순서 기준 1부터)") Integer sortOrder,
         @Schema(description = "짧은 제목") String title,
         @Schema(description = "실행 순서 충돌 판정용 분류", example = "DELETE", allowableValues = {"DELETE", "TRANSFER", "OTHER"}) String actionType,
+        @Schema(description = "순서 쌍 충돌 판정용 세부 분류(해당 없으면 null)", example = "CLOUD_DELETE",
+                allowableValues = {"CLOUD_DELETE", "FILE_PRESERVE", "CHANNEL_CLOSE", "CLIENT_NOTIFY", "DEVICE_RESET", "RECORD_EXPORT"}) String semanticType,
         @Schema(description = "담당자 이름") String recipientName,
         @Schema(description = "대기 기간(시간 단위)") Integer maxWaitHours,
         @Schema(description = "담당자 수락 상태", example = "PENDING", allowableValues = {"PENDING", "ACCEPTED", "DECLINED", "EXPIRED"}) String acceptanceStatus,

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/entity/Item.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/entity/Item.java
@@ -69,10 +69,16 @@ public class Item {
     @Column(name = "action_type", length = 30)
     private ItemActionType actionType;
 
+    // issue #90 - actionType보다 더 구체적인 분류(6종). 3개의 순서 쌍(클라우드 삭제/파일 보존,
+    // 채널 폐쇄/거래처 통지, 기기 초기화/기록 반출) 판정에 쓰이며, 해당 없는 항목은 null.
+    @Enumerated(EnumType.STRING)
+    @Column(name = "semantic_type", length = 30)
+    private ItemSemanticType semanticType;
+
     @Builder
     public Item(LifeArea lifeArea, String targetName, String locationType, String action, String title, String content,
                 String precondition, DisclosureScope disclosureScope, String sourceExcerpt,
-                Integer sortOrder, ItemActionType actionType) {
+                Integer sortOrder, ItemActionType actionType, ItemSemanticType semanticType) {
         this.lifeArea = lifeArea;
         this.targetName = targetName;
         this.locationType = locationType;
@@ -84,6 +90,7 @@ public class Item {
         this.sourceExcerpt = sourceExcerpt;
         this.sortOrder = sortOrder;
         this.actionType = actionType != null ? actionType : ItemActionType.OTHER;
+        this.semanticType = semanticType;
         this.status = ItemStatus.PROPOSED;
     }
 
@@ -94,7 +101,8 @@ public class Item {
 
     // 대화창 인라인 "수정" 버튼 - AI가 만든 초안을 사용자가 직접 고침
     public void updateContent(String targetName, String locationType, String action, String title, String content,
-                               String precondition, DisclosureScope disclosureScope, ItemActionType actionType) {
+                               String precondition, DisclosureScope disclosureScope, ItemActionType actionType,
+                               ItemSemanticType semanticType) {
         this.targetName = targetName;
         this.locationType = locationType;
         this.action = action;
@@ -103,6 +111,7 @@ public class Item {
         this.precondition = precondition;
         this.disclosureScope = disclosureScope;
         this.actionType = actionType != null ? actionType : ItemActionType.OTHER;
+        this.semanticType = semanticType;
     }
 
     // 드래그로 실행 순서 변경

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/entity/ItemSemanticType.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/entity/ItemSemanticType.java
@@ -1,0 +1,13 @@
+package com.mamoki.ieojuda.domain.plan.entity;
+
+// issue #90 - 명세서 "AI 구조화 및 충돌 정책"의 결정론적 규칙 중 순서 쌍으로 검사하는 3가지를
+// 판정하기 위한 세부 분류. actionType(DELETE/TRANSFER/OTHER)보다 한 단계 더 구체적이며,
+// 이 6가지 중 어디에도 해당하지 않는 항목은 null로 둔다(모든 항목이 이 분류를 가질 필요는 없음).
+public enum ItemSemanticType {
+    CLOUD_DELETE,   // 클라우드/계정 삭제 - FILE_PRESERVE보다 먼저 오면 충돌
+    FILE_PRESERVE,  // 사진·업무 파일 보존(인계)
+    CHANNEL_CLOSE,  // 거래처 연락 채널 폐쇄 - CLIENT_NOTIFY보다 먼저 오면 충돌
+    CLIENT_NOTIFY,  // 거래처 통지
+    DEVICE_RESET,   // 기기 초기화 - RECORD_EXPORT보다 먼저 오면 충돌
+    RECORD_EXPORT   // 기록 반출
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/repository/ItemRepository.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/repository/ItemRepository.java
@@ -21,4 +21,7 @@ public interface ItemRepository extends JpaRepository<Item, UUID> {
 
     // "실행 순서 점검" 화면 - 담당자가 배정된(=발송 대상이 확정된) 항목만 순서 점검 대상
     List<Item> findByLifeArea_Plan_PlanIdAndRecipientIsNotNullOrderBySortOrderAscItemIdAsc(UUID planId);
+
+    // issue #90 - "담당자 누락"도 순서 점검 화면의 충돌 규칙 중 하나라, 담당자 없는 항목도 포함해야 한다
+    List<Item> findByLifeArea_Plan_PlanIdOrderBySortOrderAscItemIdAsc(UUID planId);
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/service/ConversationService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/service/ConversationService.java
@@ -12,6 +12,7 @@ import com.mamoki.ieojuda.domain.plan.entity.Conversation;
 import com.mamoki.ieojuda.domain.plan.entity.DisclosureScope;
 import com.mamoki.ieojuda.domain.plan.entity.Item;
 import com.mamoki.ieojuda.domain.plan.entity.ItemActionType;
+import com.mamoki.ieojuda.domain.plan.entity.ItemSemanticType;
 import com.mamoki.ieojuda.domain.plan.entity.ItemStatus;
 import com.mamoki.ieojuda.domain.plan.entity.LifeArea;
 import com.mamoki.ieojuda.domain.plan.entity.LifeAreaCategory;
@@ -189,6 +190,7 @@ public class ConversationService {
                     .sourceExcerpt(dto.sourceExcerpt())
                     .sortOrder(dto.sortOrder() != null ? dto.sortOrder() : 0) // AI가 지시를 안 지키고 null을 줄 경우 대비
                     .actionType(parseActionType(dto.actionType())) // 순서 충돌 판정용 - AI가 형식을 안 지켜도 turn 전체를 막을 정도는 아니라 OTHER로 대체
+                    .semanticType(parseSemanticType(dto.semanticType())) // issue #90 - 6종 중 하나가 아니거나 없으면 null(해당 없음)
                     .build();
             savedItems.add(itemRepository.save(item));
         }
@@ -200,6 +202,15 @@ public class ConversationService {
             return ItemActionType.valueOf(actionType);
         } catch (IllegalArgumentException | NullPointerException e) {
             return ItemActionType.OTHER;
+        }
+    }
+
+    // issue #90 - actionType과 달리 6종 중 어디에도 해당하지 않는 게 정상 케이스이므로 실패 시 OTHER가 아니라 null
+    private ItemSemanticType parseSemanticType(String semanticType) {
+        try {
+            return ItemSemanticType.valueOf(semanticType);
+        } catch (IllegalArgumentException | NullPointerException e) {
+            return null;
         }
     }
 

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/service/ItemOrderService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/service/ItemOrderService.java
@@ -5,16 +5,18 @@ import com.mamoki.ieojuda.domain.plan.dto.OrderCheckItemResponse;
 import com.mamoki.ieojuda.domain.plan.dto.OrderCheckResponse;
 import com.mamoki.ieojuda.domain.plan.dto.OrderConfirmResponse;
 import com.mamoki.ieojuda.domain.plan.entity.Item;
-import com.mamoki.ieojuda.domain.plan.entity.ItemActionType;
+import com.mamoki.ieojuda.domain.plan.entity.ItemSemanticType;
 import com.mamoki.ieojuda.domain.plan.entity.Plan;
 import com.mamoki.ieojuda.domain.plan.repository.ItemRepository;
 import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
+import com.mamoki.ieojuda.domain.recipient.repository.RecipientRepository;
 import com.mamoki.ieojuda.global.exception.CustomException;
 import com.mamoki.ieojuda.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.UUID;
@@ -25,25 +27,30 @@ import java.util.stream.Collectors;
 
 // 명세서 "실행 순서 점검" 화면 - 담당자가 배정된 항목들을 사용자가 드래그로 재정렬하고,
 // 삭제형 항목이 인계형 항목보다 먼저 오는 순서 충돌이 없을 때만 확정할 수 있다.
+// issue #90 - 명세서 "AI 구조화 및 충돌 정책"의 결정론적 규칙 6종을 전부 이 화면의 충돌 카드로 노출한다.
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ItemOrderService {
 
+    // issue #90 (제안) - 한 담당자가 전체 항목의 과반(50% 초과)을 맡으면 권한 집중으로 경고
+    private static final double AUTHORITY_CONCENTRATION_THRESHOLD = 0.5;
+
     private final PlanOwnershipReader planOwnershipReader;
     private final ItemRepository itemRepository;
+    private final RecipientRepository recipientRepository;
 
     public OrderCheckResponse getOrderCheck(UUID userId, UUID planId) {
         planOwnershipReader.findOwnedPlan(userId, planId);
-        List<Item> items = itemRepository.findByLifeArea_Plan_PlanIdAndRecipientIsNotNullOrderBySortOrderAscItemIdAsc(planId);
-        return OrderCheckResponse.of(buildItemResponses(items));
+        List<Item> items = itemRepository.findByLifeArea_Plan_PlanIdOrderBySortOrderAscItemIdAsc(planId);
+        return OrderCheckResponse.of(buildItemResponses(planId, items));
     }
 
     // 드래그로 바뀐 순서를 저장 - 순서가 바뀌었으므로 기존 확정 상태는 초기화한다
     @Transactional
     public OrderCheckResponse reorder(UUID userId, UUID planId, ItemReorderRequest request) {
         Plan plan = planOwnershipReader.findOwnedPlan(userId, planId);
-        List<Item> items = itemRepository.findByLifeArea_Plan_PlanIdAndRecipientIsNotNullOrderBySortOrderAscItemIdAsc(planId);
+        List<Item> items = itemRepository.findByLifeArea_Plan_PlanIdOrderBySortOrderAscItemIdAsc(planId);
 
         Map<UUID, Item> itemsById = items.stream().collect(Collectors.toMap(Item::getItemId, item -> item));
         Set<UUID> requestedIds = new HashSet<>(request.itemIds());
@@ -57,17 +64,17 @@ public class ItemOrderService {
         }
         plan.resetOrderConfirmation();
 
-        List<Item> reordered = itemRepository.findByLifeArea_Plan_PlanIdAndRecipientIsNotNullOrderBySortOrderAscItemIdAsc(planId);
-        return OrderCheckResponse.of(buildItemResponses(reordered));
+        List<Item> reordered = itemRepository.findByLifeArea_Plan_PlanIdOrderBySortOrderAscItemIdAsc(planId);
+        return OrderCheckResponse.of(buildItemResponses(planId, reordered));
     }
 
     // "순서 확정하기" - 충돌이 하나라도 남아있으면 확정할 수 없다
     @Transactional
     public OrderConfirmResponse confirm(UUID userId, UUID planId) {
         Plan plan = planOwnershipReader.findOwnedPlan(userId, planId);
-        List<Item> items = itemRepository.findByLifeArea_Plan_PlanIdAndRecipientIsNotNullOrderBySortOrderAscItemIdAsc(planId);
+        List<Item> items = itemRepository.findByLifeArea_Plan_PlanIdOrderBySortOrderAscItemIdAsc(planId);
 
-        boolean hasConflict = buildItemResponses(items).stream().anyMatch(OrderCheckItemResponse::conflict);
+        boolean hasConflict = buildItemResponses(planId, items).stream().anyMatch(OrderCheckItemResponse::conflict);
         if (hasConflict) {
             throw new CustomException(ErrorCode.ITEM_ORDER_CONFLICT);
         }
@@ -76,49 +83,130 @@ public class ItemOrderService {
         return OrderConfirmResponse.from(plan);
     }
 
-    // 같은 locationType(자료 위치) 안에서 DELETE형 항목이 TRANSFER형 항목보다 먼저(또는 같이) 오면 충돌로 판정한다
-    private List<OrderCheckItemResponse> buildItemResponses(List<Item> items) {
-        Map<String, List<Item>> byLocation = items.stream()
-                .filter(item -> item.getLocationType() != null && !item.getLocationType().isBlank())
-                .collect(Collectors.groupingBy(Item::getLocationType));
+    // issue #90 - 명세서 "AI 구조화 및 충돌 정책"의 순서 쌍 규칙 3종. semanticType이 이 쌍에 해당하고
+    // 같은 locationType(같은 계정·채널·기기)을 공유하는 항목끼리만 비교한다 - locationType이 다르면
+    // 서로 무관한 대상이므로 타입만 같다고 엉뚱하게 충돌로 묶이지 않는다.
+    private static final List<SemanticPairRule> SEMANTIC_PAIR_RULES = List.of(
+            new SemanticPairRule(ItemSemanticType.CLOUD_DELETE, ItemSemanticType.FILE_PRESERVE,
+                    "%s을(를) 먼저 정리하면 %s을(를) 인계할 수 없어요. %s을(를) 나중으로 실행하는 걸 추천해요.",
+                    "%s이(가) 먼저 정리되면 이 항목을 인계할 수 없어요. %s을(를) 나중으로 실행하는 걸 추천해요."),
+            new SemanticPairRule(ItemSemanticType.CHANNEL_CLOSE, ItemSemanticType.CLIENT_NOTIFY,
+                    "%s을(를) 먼저 폐쇄하면 %s을(를) 통지할 수 없어요. %s을(를) 나중으로 실행하는 걸 추천해요.",
+                    "%s이(가) 먼저 폐쇄되면 이 항목으로 통지할 수 없어요. %s을(를) 나중으로 실행하는 걸 추천해요."),
+            new SemanticPairRule(ItemSemanticType.DEVICE_RESET, ItemSemanticType.RECORD_EXPORT,
+                    "%s을(를) 먼저 초기화하면 %s을(를) 반출할 수 없어요. %s을(를) 나중으로 실행하는 걸 추천해요.",
+                    "%s이(가) 먼저 초기화되면 이 항목을 반출할 수 없어요. %s을(를) 나중으로 실행하는 걸 추천해요.")
+    );
 
-        Map<UUID, String> conflictMessages = new HashMap<>();
-        for (List<Item> group : byLocation.values()) {
-            if (group.size() < 2) {
-                continue;
-            }
-            List<Item> deletes = group.stream().filter(item -> item.getActionType() == ItemActionType.DELETE).toList();
-            List<Item> transfers = group.stream().filter(item -> item.getActionType() == ItemActionType.TRANSFER).toList();
+    private record SemanticPairRule(ItemSemanticType earlier, ItemSemanticType later,
+                                     String earlierMessageTemplate, String laterMessageTemplate) {
+    }
 
-            for (Item deleteItem : deletes) {
-                for (Item transferItem : transfers) {
-                    if (sortOrderOf(deleteItem) <= sortOrderOf(transferItem)) {
-                        conflictMessages.put(deleteItem.getItemId(), String.format(
-                                "%s을(를) 먼저 정리하면 %s을(를) 인계할 수 없어요. %s을(를) 나중으로 실행하는 걸 추천해요.",
-                                deleteItem.getLocationType(), transferItem.getTitle(), deleteItem.getTitle()));
-                        conflictMessages.put(transferItem.getItemId(), String.format(
-                                "%s이(가) 먼저 정리되면 이 항목을 인계할 수 없어요. %s을(를) 나중으로 실행하는 걸 추천해요.",
-                                deleteItem.getTitle(), deleteItem.getTitle()));
-                    }
-                }
-            }
-        }
+    private List<OrderCheckItemResponse> buildItemResponses(UUID planId, List<Item> items) {
+        Map<UUID, List<String>> conflictReasons = new HashMap<>();
+        checkSemanticPairRules(items, conflictReasons);
+        checkMissingRecipient(items, conflictReasons);
+        checkMissingBackup(planId, items, conflictReasons);
+        checkAuthorityConcentration(items, conflictReasons);
 
         return items.stream().map(item -> {
-            String message = conflictMessages.get(item.getItemId());
+            List<String> reasons = conflictReasons.get(item.getItemId());
+            String message = reasons == null ? null : String.join(" ", reasons);
             Recipient recipient = item.getRecipient();
             return new OrderCheckItemResponse(
                     item.getItemId(),
                     item.getSortOrder(),
                     item.getTitle(),
                     item.getActionType() == null ? null : item.getActionType().name(),
-                    recipient.getName(),
-                    recipient.getMaxWaitHours(),
-                    recipient.getAcceptanceStatus().name(),
+                    item.getSemanticType() == null ? null : item.getSemanticType().name(),
+                    recipient == null ? null : recipient.getName(),
+                    recipient == null ? null : recipient.getMaxWaitHours(),
+                    recipient == null ? null : recipient.getAcceptanceStatus().name(),
                     message != null,
                     message
             );
         }).toList();
+    }
+
+    // 규칙 1~3 - 같은 locationType(같은 계정·채널·기기) 안에서만 순서 쌍을 비교한다 (담당자 유무와 무관)
+    private void checkSemanticPairRules(List<Item> items, Map<UUID, List<String>> conflictReasons) {
+        Map<String, List<Item>> byLocation = items.stream()
+                .filter(item -> item.getLocationType() != null && !item.getLocationType().isBlank())
+                .collect(Collectors.groupingBy(Item::getLocationType));
+
+        for (List<Item> group : byLocation.values()) {
+            if (group.size() < 2) {
+                continue;
+            }
+            for (SemanticPairRule rule : SEMANTIC_PAIR_RULES) {
+                List<Item> earlierItems = group.stream().filter(item -> item.getSemanticType() == rule.earlier()).toList();
+                List<Item> laterItems = group.stream().filter(item -> item.getSemanticType() == rule.later()).toList();
+
+                for (Item earlierItem : earlierItems) {
+                    for (Item laterItem : laterItems) {
+                        if (sortOrderOf(earlierItem) <= sortOrderOf(laterItem)) {
+                            addReason(conflictReasons, earlierItem.getItemId(), String.format(
+                                    rule.earlierMessageTemplate(), earlierItem.getLocationType(), laterItem.getTitle(), earlierItem.getTitle()));
+                            addReason(conflictReasons, laterItem.getItemId(), String.format(
+                                    rule.laterMessageTemplate(), earlierItem.getTitle(), earlierItem.getTitle()));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // 규칙 4 - 담당자 누락
+    private void checkMissingRecipient(List<Item> items, Map<UUID, List<String>> conflictReasons) {
+        for (Item item : items) {
+            if (item.getRecipient() == null) {
+                addReason(conflictReasons, item.getItemId(), "담당자가 배정되지 않았어요. 담당자를 지정해 주세요.");
+            }
+        }
+    }
+
+    // 규칙 6 - 대체 담당자 부재. 대체 담당자 자신은 대상에서 제외한다(대체 담당자에게 또 대체 담당자가 필요한 건 아님)
+    private void checkMissingBackup(UUID planId, List<Item> items, Map<UUID, List<String>> conflictReasons) {
+        List<Recipient> planRecipients = recipientRepository.findByPlan_PlanId(planId);
+        Set<UUID> primaryIdsWithBackup = planRecipients.stream()
+                .filter(r -> Boolean.TRUE.equals(r.getIsBackup()) && r.getBackupFor() != null)
+                .map(r -> r.getBackupFor().getAssigneeId())
+                .collect(Collectors.toSet());
+
+        for (Item item : items) {
+            Recipient recipient = item.getRecipient();
+            if (recipient == null || Boolean.TRUE.equals(recipient.getIsBackup())) {
+                continue;
+            }
+            if (!primaryIdsWithBackup.contains(recipient.getAssigneeId())) {
+                addReason(conflictReasons, item.getItemId(), String.format(
+                        "%s의 대체 담당자가 없어요. 무응답 시 다음 단계가 막힐 수 있어요. 대체 담당자를 등록해 주세요.", recipient.getName()));
+            }
+        }
+    }
+
+    // 규칙 5 - 권한 집중. 전체 항목(담당자 미배정 포함) 대비 한 담당자의 배정 비율이 기준을 넘으면 그 담당자의 항목 전부를 표시
+    private void checkAuthorityConcentration(List<Item> items, Map<UUID, List<String>> conflictReasons) {
+        if (items.isEmpty()) {
+            return;
+        }
+        Map<UUID, List<Item>> byRecipient = items.stream()
+                .filter(item -> item.getRecipient() != null)
+                .collect(Collectors.groupingBy(item -> item.getRecipient().getAssigneeId()));
+
+        for (List<Item> assignedItems : byRecipient.values()) {
+            if ((double) assignedItems.size() / items.size() > AUTHORITY_CONCENTRATION_THRESHOLD) {
+                String recipientName = assignedItems.get(0).getRecipient().getName();
+                for (Item item : assignedItems) {
+                    addReason(conflictReasons, item.getItemId(), String.format(
+                            "%s에게 전체 항목의 절반이 넘게 몰려 있어요. 다른 담당자에게 일부를 나눠보는 걸 추천해요.", recipientName));
+                }
+            }
+        }
+    }
+
+    private void addReason(Map<UUID, List<String>> conflictReasons, UUID itemId, String reason) {
+        conflictReasons.computeIfAbsent(itemId, key -> new ArrayList<>()).add(reason);
     }
 
     private int sortOrderOf(Item item) {

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/service/ItemOrderService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/service/ItemOrderService.java
@@ -185,7 +185,8 @@ public class ItemOrderService {
         }
     }
 
-    // 규칙 5 - 권한 집중. 전체 항목(담당자 미배정 포함) 대비 한 담당자의 배정 비율이 기준을 넘으면 그 담당자의 항목 전부를 표시
+    // 규칙 5 - 권한 집중. 전체 항목(담당자 미배정 포함) 대비 한 담당자의 배정 비율이 기준을 넘으면 그 담당자의 항목 전부를 표시.
+    // 담당자가 한 명뿐이면 재분배할 대상이 없으므로 검사하지 않는다.
     private void checkAuthorityConcentration(List<Item> items, Map<UUID, List<String>> conflictReasons) {
         if (items.isEmpty()) {
             return;
@@ -193,6 +194,9 @@ public class ItemOrderService {
         Map<UUID, List<Item>> byRecipient = items.stream()
                 .filter(item -> item.getRecipient() != null)
                 .collect(Collectors.groupingBy(item -> item.getRecipient().getAssigneeId()));
+        if (byRecipient.size() < 2) {
+            return;
+        }
 
         for (List<Item> assignedItems : byRecipient.values()) {
             if ((double) assignedItems.size() / items.size() > AUTHORITY_CONCENTRATION_THRESHOLD) {

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/service/ItemReviewService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/service/ItemReviewService.java
@@ -8,6 +8,7 @@ import com.mamoki.ieojuda.domain.plan.dto.ItemUpdateRequest;
 import com.mamoki.ieojuda.domain.plan.entity.DisclosureScope;
 import com.mamoki.ieojuda.domain.plan.entity.Item;
 import com.mamoki.ieojuda.domain.plan.entity.ItemActionType;
+import com.mamoki.ieojuda.domain.plan.entity.ItemSemanticType;
 import com.mamoki.ieojuda.domain.plan.repository.ItemRepository;
 import com.mamoki.ieojuda.global.exception.CustomException;
 import com.mamoki.ieojuda.global.exception.ErrorCode;
@@ -75,8 +76,16 @@ public class ItemReviewService {
             throw new CustomException(ErrorCode.INVALID_INPUT);
         }
 
+        // issue #90 - actionType과 달리 6종 중 어디에도 해당하지 않는 게 정상 케이스이므로 값이 없으면 null
+        ItemSemanticType semanticType;
+        try {
+            semanticType = request.semanticType() == null ? null : ItemSemanticType.valueOf(request.semanticType());
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(ErrorCode.INVALID_INPUT);
+        }
+
         item.updateContent(request.targetName(), request.locationType(), request.action(), request.title(), request.content(),
-                request.precondition(), disclosureScope, actionType);
+                request.precondition(), disclosureScope, actionType, semanticType);
 
         return ItemResponse.from(item);
     }

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/service/PlanPackageService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/service/PlanPackageService.java
@@ -21,6 +21,7 @@ import java.util.LinkedHashMap;
 import java.util.UUID;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 // 명세서 "역할별 패키지 미리보기" - 작성자가 생전에 역할별 공개 내용을 검토하고 직접 승인(봉인)한다.
 // issue #81: 봉인 주체를 작성자로 옮기되, 사망 신고 시점의 PlanVersion 스냅샷 봉인(DeathReportService)은
@@ -54,8 +55,12 @@ public class PlanPackageService {
         return new PackagePreviewResponse(packages);
     }
 
-    // 봉인 차단 검사(이슈 #81 명시 범위 3가지, 순서대로) - 과도한 권한 집중 판정은 기준 비율이 아직
-    // 정해지지 않아 #90에서 다룬다.
+    // issue #90 (제안) - 한 담당자가 전체 항목의 과반(50% 초과)을 맡으면 권한 집중으로 판정.
+    // ItemOrderService의 화면 표시용 판정과 같은 기준값을 쓴다.
+    private static final double AUTHORITY_CONCENTRATION_THRESHOLD = 0.5;
+
+    // 봉인 차단 검사(md 스펙 2-2절 5단계, 순서대로) - 권한 집중·실행순서확정 판정은 #81 당시
+    // 기준이 없어 #90으로 미뤄졌고, 이번에 함께 반영한다.
     @Transactional
     public PlanResponse seal(UUID userId, UUID planId) {
         Plan plan = planOwnershipReader.findOwnedPlan(userId, planId);
@@ -78,8 +83,26 @@ public class PlanPackageService {
             }
         }
 
+        if (hasAuthorityConcentration(items)) {
+            throw new CustomException(ErrorCode.PACKAGE_SEAL_BLOCKED);
+        }
+
+        if (plan.getOrderConfirmedAt() == null) {
+            throw new CustomException(ErrorCode.ORDER_NOT_CONFIRMED);
+        }
+
         plan.seal();
         return PlanResponse.from(plan);
+    }
+
+    private boolean hasAuthorityConcentration(List<Item> items) {
+        Map<UUID, Long> countByRecipientId = items.stream()
+                .collect(Collectors.groupingBy(item -> item.getRecipient().getAssigneeId(), Collectors.counting()));
+        // 담당자가 한 명뿐이면 "몰림"을 비교할 대상 자체가 없다 - 재분배할 다른 담당자가 있을 때만 의미 있는 경고
+        if (countByRecipientId.size() < 2) {
+            return false;
+        }
+        return countByRecipientId.values().stream().anyMatch(count -> (double) count / items.size() > AUTHORITY_CONCENTRATION_THRESHOLD);
     }
 
     private boolean containsCredential(Item item) {

--- a/src/main/java/com/mamoki/ieojuda/global/exception/ErrorCode.java
+++ b/src/main/java/com/mamoki/ieojuda/global/exception/ErrorCode.java
@@ -93,6 +93,7 @@ public enum ErrorCode {
     CONFIRMER_RESEND_NOT_ALLOWED(HttpStatus.CONFLICT, "CONFIRMER_RESEND_NOT_ALLOWED", "현재 수락 상태에서는 수락 요청을 다시 보낼 수 없습니다."),
     DISPUTE_CONTACT_RESEND_NOT_ALLOWED(HttpStatus.CONFLICT, "DISPUTE_CONTACT_RESEND_NOT_ALLOWED", "이미 검증이 완료된 연락처에는 검증 메일을 다시 보낼 수 없습니다."),
     ITEM_ORDER_CONFLICT(HttpStatus.CONFLICT, "ITEM_ORDER_CONFLICT", "순서 충돌이 있어 확정할 수 없습니다."),
+    ORDER_NOT_CONFIRMED(HttpStatus.CONFLICT, "ORDER_NOT_CONFIRMED", "실행 순서가 아직 확정되지 않아 패키지를 봉인할 수 없습니다."),
     PARTNER_NOT_ASSIGNED(HttpStatus.CONFLICT, "PARTNER_NOT_ASSIGNED", "이 사건에는 아직 담당 파트너사가 배정되지 않았습니다."),
     EVIDENCE_ALREADY_DELETED(HttpStatus.CONFLICT, "EVIDENCE_ALREADY_DELETED", "이미 삭제된 증빙입니다."),
     DUPLICATE_REQUEST(HttpStatus.CONFLICT, "DUPLICATE_REQUEST", "이미 처리 중이거나 처리된 요청입니다."),

--- a/src/main/java/com/mamoki/ieojuda/global/openai/component/OpenAIClient.java
+++ b/src/main/java/com/mamoki/ieojuda/global/openai/component/OpenAIClient.java
@@ -54,6 +54,14 @@ public class OpenAIClient {
                     "순서를 지킬 필요가 없는 항목들끼리는 모두 0을 매기세요. " +
                     "각 항목마다 actionType도 판단하세요: 계정·자료를 삭제·탈퇴·정리·초기화하는 항목이면 DELETE, " +
                     "자료·정보·접근권한을 누군가에게 전달·인계·공개하는 항목이면 TRANSFER, 둘 다 아니면(예: 단순 알림) OTHER로 표시하세요. " +
+                    "각 항목마다 semanticType도 다음 6가지 중 하나에 해당하면 표시하고, 해당하지 않으면 null로 두세요: " +
+                    "클라우드·SNS 등 계정 자체를 삭제·탈퇴하는 항목은 CLOUD_DELETE, 그 계정에 있던 사진·문서 등 자료를 보존·전달하는 " +
+                    "항목은 FILE_PRESERVE, 거래처와 연락하던 채널(이메일·전화 등)을 해지·폐쇄하는 항목은 CHANNEL_CLOSE, 그 채널로 " +
+                    "거래처에 상황을 알리는 항목은 CLIENT_NOTIFY, 회사 PC·노트북 등 기기를 초기화·반납하는 항목은 DEVICE_RESET, " +
+                    "그 기기에 있던 업무 기록을 반출·인계하는 항목은 RECORD_EXPORT로 표시하세요. " +
+                    "같은 계정·채널·기기를 다루는 두 항목이 CLOUD_DELETE/FILE_PRESERVE, CHANNEL_CLOSE/CLIENT_NOTIFY, " +
+                    "DEVICE_RESET/RECORD_EXPORT 쌍을 이루면 반드시 locationType을 서로 동일하게 맞춰서, 삭제·폐쇄·초기화 쪽이 " +
+                    "보존·통지·반출 쪽보다 나중 sortOrder를 갖도록 하세요. " +
                     "절대로 사망 여부 판정, 증빙 진위 판단, 상속 권리 판단을 하지 마세요. " +
                     "비밀번호·PIN·OTP 등 자격증명을 묻거나 추론하지 마세요. " +
                     "실제 계정 작업을 대신 수행하지 말고, 사용자 승인 없이 계획을 확정하지 마세요. " +
@@ -66,7 +74,8 @@ public class OpenAIClient {
                     "\"disclosureScope\":\"FAMILY 또는 WORK 또는 RELATIONSHIP 중 하나\"," +
                     "\"sourceExcerpt\":\"이 항목의 근거가 되는 원문 문장\"," +
                     "\"sortOrder\":실행 순서를 나타내는 정수(낮을수록 먼저)," +
-                    "\"actionType\":\"DELETE 또는 TRANSFER 또는 OTHER 중 하나\"}]}";
+                    "\"actionType\":\"DELETE 또는 TRANSFER 또는 OTHER 중 하나\"," +
+                    "\"semanticType\":\"CLOUD_DELETE 또는 FILE_PRESERVE 또는 CHANNEL_CLOSE 또는 CLIENT_NOTIFY 또는 DEVICE_RESET 또는 RECORD_EXPORT 중 하나, 해당 없으면 null\"}]}";
 
     private static final String JSON_RESPONSE_FORMAT_TYPE = "json_object";
     // 창의성이 필요 없는 구조화 작업이라 낮게 고정해서 같은 입력에 최대한 일관된 결과(특히 sortOrder)가 나오게 함

--- a/src/test/java/com/mamoki/ieojuda/domain/plan/controller/PlanPackageHttpIntegrationTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/plan/controller/PlanPackageHttpIntegrationTest.java
@@ -67,6 +67,7 @@ class PlanPackageHttpIntegrationTest {
     private User user;
     private Plan plan;
     private Recipient recipient;
+    private Recipient backupRecipient;
     private Item item;
     private String accessToken;
 
@@ -84,6 +85,11 @@ class PlanPackageHttpIntegrationTest {
                 .plan(plan).lifeArea(lifeArea).name("이지수").email("jisoo-pkg-" + UUID.randomUUID() + "@test.com")
                 .roleType(RoleType.RELATIONSHIP_MANAGER).isBackup(false)
                 .disclosureScope(DisclosureScope.RELATIONSHIP).maxWaitHours(168).backupFor(null).build());
+        // issue #90 - "대체 담당자 부재" 규칙이 순서 확정을 막지 않도록 대체 담당자를 함께 등록
+        backupRecipient = recipientRepository.saveAndFlush(Recipient.builder()
+                .plan(plan).lifeArea(lifeArea).name("대체-이지수").email("backup-jisoo-pkg-" + UUID.randomUUID() + "@test.com")
+                .roleType(RoleType.RELATIONSHIP_MANAGER).isBackup(true)
+                .disclosureScope(DisclosureScope.RELATIONSHIP).maxWaitHours(168).backupFor(recipient).build());
         item = itemRepository.saveAndFlush(Item.builder()
                 .lifeArea(lifeArea).targetName("이지수").locationType("인스타그램").action("인스타그램 아이디로 SNS 계정을 정리해줘")
                 .title("SNS 계정 처리").content("비공개로 전환").precondition("")
@@ -98,6 +104,7 @@ class PlanPackageHttpIntegrationTest {
     @AfterEach
     void tearDown() {
         itemRepository.delete(item);
+        recipientRepository.delete(backupRecipient);
         recipientRepository.delete(recipient);
         lifeAreaRepository.findByPlan_PlanId(plan.getPlanId()).forEach(lifeAreaRepository::delete);
         conversationRepository.findByPlan_PlanId(plan.getPlanId()).forEach(conversationRepository::delete);
@@ -133,6 +140,10 @@ class PlanPackageHttpIntegrationTest {
         confirmerRepository.saveAndFlush(c2);
 
         try {
+            // issue #90 - 봉인 전에 실행 순서를 확정해야 한다(ORDER_NOT_CONFIRMED 방지)
+            HttpResponse<String> confirmOrderResponse = post("/api/plans/" + plan.getPlanId() + "/items/order/confirm");
+            assertThat(confirmOrderResponse.statusCode()).isEqualTo(200);
+
             HttpResponse<String> response = post("/api/plans/" + plan.getPlanId() + "/packages/seal");
 
             assertThat(response.statusCode()).isEqualTo(200);

--- a/src/test/java/com/mamoki/ieojuda/domain/plan/service/ItemOrderServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/plan/service/ItemOrderServiceTest.java
@@ -1,0 +1,268 @@
+package com.mamoki.ieojuda.domain.plan.service;
+
+import com.mamoki.ieojuda.domain.plan.dto.ItemReorderRequest;
+import com.mamoki.ieojuda.domain.plan.entity.DisclosureScope;
+import com.mamoki.ieojuda.domain.plan.entity.Item;
+import com.mamoki.ieojuda.domain.plan.entity.ItemActionType;
+import com.mamoki.ieojuda.domain.plan.entity.ItemSemanticType;
+import com.mamoki.ieojuda.domain.plan.entity.LifeArea;
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.plan.repository.ItemRepository;
+import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
+import com.mamoki.ieojuda.domain.recipient.entity.RoleType;
+import com.mamoki.ieojuda.domain.recipient.repository.RecipientRepository;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+// issue #90 완료 조건 - "명세서의 결정론적 규칙 6종이 모두 검사된다".
+// 각 테스트는 검증 대상 규칙 하나만 걸리도록, 기본 픽스처(recipientA/B는 서로 대체 담당자로 등록되어
+// 있고 50:50으로 항목을 나눠 맡음)를 "아무 규칙도 안 걸리는 깨끗한 상태"로 잡아두고 시작한다.
+class ItemOrderServiceTest {
+
+    private static final UUID USER_ID = UUID.randomUUID();
+    private static final UUID PLAN_ID = UUID.randomUUID();
+
+    private PlanOwnershipReader planOwnershipReader;
+    private ItemRepository itemRepository;
+    private RecipientRepository recipientRepository;
+    private ItemOrderService itemOrderService;
+
+    private Plan plan;
+    private Recipient recipientA;
+    private Recipient recipientB;
+
+    @BeforeEach
+    void setUp() {
+        planOwnershipReader = mock(PlanOwnershipReader.class);
+        itemRepository = mock(ItemRepository.class);
+        recipientRepository = mock(RecipientRepository.class);
+        itemOrderService = new ItemOrderService(planOwnershipReader, itemRepository, recipientRepository);
+
+        plan = mock(Plan.class);
+        when(planOwnershipReader.findOwnedPlan(USER_ID, PLAN_ID)).thenReturn(plan);
+
+        recipientA = buildRecipient("이지수");
+        recipientB = buildRecipient("김민수");
+        // 서로가 서로의 대체 담당자 - "대체 담당자 부재" 규칙이 기본 상태에서는 걸리지 않도록
+        Recipient backupOfA = buildBackupRecipient("대체A", recipientA);
+        Recipient backupOfB = buildBackupRecipient("대체B", recipientB);
+        when(recipientRepository.findByPlan_PlanId(PLAN_ID))
+                .thenReturn(List.of(recipientA, recipientB, backupOfA, backupOfB));
+    }
+
+    private Recipient buildRecipient(String name) {
+        Recipient recipient = Recipient.builder().plan(plan).lifeArea(mock(LifeArea.class)).name(name)
+                .email(name + "@test.com").roleType(RoleType.RELATIONSHIP_MANAGER).isBackup(false)
+                .disclosureScope(DisclosureScope.RELATIONSHIP).maxWaitHours(168).backupFor(null).build();
+        setField(recipient, "assigneeId", UUID.randomUUID());
+        return recipient;
+    }
+
+    private Recipient buildBackupRecipient(String name, Recipient backupFor) {
+        Recipient recipient = Recipient.builder().plan(plan).lifeArea(mock(LifeArea.class)).name(name)
+                .email(name + "@test.com").roleType(RoleType.RELATIONSHIP_MANAGER).isBackup(true)
+                .disclosureScope(DisclosureScope.RELATIONSHIP).maxWaitHours(168).backupFor(backupFor).build();
+        setField(recipient, "assigneeId", UUID.randomUUID());
+        return recipient;
+    }
+
+    private Item buildItem(Recipient recipient, String locationType, ItemActionType actionType,
+                            ItemSemanticType semanticType, int sortOrder) {
+        Item item = Item.builder()
+                .lifeArea(mock(LifeArea.class)).targetName("대상").locationType(locationType)
+                .action("행동").title("제목-" + sortOrder).content("내용")
+                .disclosureScope(DisclosureScope.RELATIONSHIP).sourceExcerpt("근거")
+                .sortOrder(sortOrder).actionType(actionType).semanticType(semanticType).build();
+        if (recipient != null) {
+            item.assignRecipient(recipient);
+        }
+        setField(item, "itemId", UUID.randomUUID());
+        return item;
+    }
+
+    // itemId/assigneeId는 @GeneratedValue라 영속화 전에는 null이므로 테스트에서 직접 채운다
+    private void setField(Object entity, String fieldName, Object value) {
+        try {
+            Field field = entity.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(entity, value);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void stubItems(Item... items) {
+        when(itemRepository.findByLifeArea_Plan_PlanIdOrderBySortOrderAscItemIdAsc(PLAN_ID)).thenReturn(List.of(items));
+    }
+
+    @Test
+    void getOrderCheck_whenCloudDeleteBeforeFilePreserveInSameLocation_flagsBothAsConflict() {
+        Item cloudDelete = buildItem(recipientA, "구글드라이브", ItemActionType.DELETE, ItemSemanticType.CLOUD_DELETE, 0);
+        Item filePreserve = buildItem(recipientB, "구글드라이브", ItemActionType.TRANSFER, ItemSemanticType.FILE_PRESERVE, 1);
+        stubItems(cloudDelete, filePreserve);
+
+        var response = itemOrderService.getOrderCheck(USER_ID, PLAN_ID);
+
+        assertThat(response.items()).allSatisfy(item -> assertThat(item.conflict()).isTrue());
+    }
+
+    @Test
+    void getOrderCheck_whenChannelCloseBeforeClientNotifyInSameLocation_flagsBothAsConflict() {
+        Item channelClose = buildItem(recipientA, "거래처 이메일", ItemActionType.DELETE, ItemSemanticType.CHANNEL_CLOSE, 0);
+        Item clientNotify = buildItem(recipientB, "거래처 이메일", ItemActionType.TRANSFER, ItemSemanticType.CLIENT_NOTIFY, 1);
+        stubItems(channelClose, clientNotify);
+
+        var response = itemOrderService.getOrderCheck(USER_ID, PLAN_ID);
+
+        assertThat(response.items()).allSatisfy(item -> assertThat(item.conflict()).isTrue());
+    }
+
+    @Test
+    void getOrderCheck_whenDeviceResetBeforeRecordExportInSameLocation_flagsBothAsConflict() {
+        Item deviceReset = buildItem(recipientA, "회사 노트북", ItemActionType.DELETE, ItemSemanticType.DEVICE_RESET, 0);
+        Item recordExport = buildItem(recipientB, "회사 노트북", ItemActionType.TRANSFER, ItemSemanticType.RECORD_EXPORT, 1);
+        stubItems(deviceReset, recordExport);
+
+        var response = itemOrderService.getOrderCheck(USER_ID, PLAN_ID);
+
+        assertThat(response.items()).allSatisfy(item -> assertThat(item.conflict()).isTrue());
+    }
+
+    @Test
+    void getOrderCheck_whenLaterTypeComesFirst_noConflict() {
+        Item filePreserve = buildItem(recipientA, "구글드라이브", ItemActionType.TRANSFER, ItemSemanticType.FILE_PRESERVE, 0);
+        Item cloudDelete = buildItem(recipientB, "구글드라이브", ItemActionType.DELETE, ItemSemanticType.CLOUD_DELETE, 1);
+        stubItems(filePreserve, cloudDelete);
+
+        var response = itemOrderService.getOrderCheck(USER_ID, PLAN_ID);
+
+        assertThat(response.items()).allSatisfy(item -> assertThat(item.conflict()).isFalse());
+    }
+
+    // 같은 semanticType 쌍이라도 locationType이 다르면(서로 무관한 계정) 충돌로 묶이지 않아야 한다
+    @Test
+    void getOrderCheck_whenSameSemanticPairButDifferentLocationType_noConflict() {
+        Item cloudDelete = buildItem(recipientA, "인스타그램", ItemActionType.DELETE, ItemSemanticType.CLOUD_DELETE, 0);
+        Item filePreserve = buildItem(recipientB, "구글드라이브", ItemActionType.TRANSFER, ItemSemanticType.FILE_PRESERVE, 1);
+        stubItems(cloudDelete, filePreserve);
+
+        var response = itemOrderService.getOrderCheck(USER_ID, PLAN_ID);
+
+        assertThat(response.items()).allSatisfy(item -> assertThat(item.conflict()).isFalse());
+    }
+
+    @Test
+    void getOrderCheck_whenItemsHaveNoSemanticType_noConflict() {
+        Item first = buildItem(recipientA, "인스타그램", ItemActionType.DELETE, null, 0);
+        Item second = buildItem(recipientB, "인스타그램", ItemActionType.TRANSFER, null, 1);
+        stubItems(first, second);
+
+        var response = itemOrderService.getOrderCheck(USER_ID, PLAN_ID);
+
+        assertThat(response.items()).allSatisfy(item -> assertThat(item.conflict()).isFalse());
+    }
+
+    // 규칙 4 - 담당자 누락
+    @Test
+    void getOrderCheck_whenItemHasNoRecipient_flagsMissingRecipient() {
+        Item unassigned = buildItem(null, "인스타그램", ItemActionType.OTHER, null, 0);
+        Item assigned = buildItem(recipientA, "트위터", ItemActionType.OTHER, null, 1);
+        stubItems(unassigned, assigned);
+
+        var response = itemOrderService.getOrderCheck(USER_ID, PLAN_ID);
+
+        var unassignedResult = response.items().stream().filter(i -> i.itemId().equals(unassigned.getItemId())).findFirst().orElseThrow();
+        var assignedResult = response.items().stream().filter(i -> i.itemId().equals(assigned.getItemId())).findFirst().orElseThrow();
+        assertThat(unassignedResult.conflict()).isTrue();
+        assertThat(unassignedResult.conflictMessage()).contains("담당자가 배정되지 않았어요");
+        assertThat(unassignedResult.recipientName()).isNull();
+        assertThat(assignedResult.conflict()).isFalse();
+    }
+
+    // 규칙 6 - 대체 담당자 부재
+    @Test
+    void getOrderCheck_whenRecipientHasNoBackup_flagsMissingBackup() {
+        Recipient noBackupRecipient = buildRecipient("박서준");
+        Recipient hasBackupRecipient = buildRecipient("최유진");
+        Recipient backupOfHasBackup = buildBackupRecipient("대체최유진", hasBackupRecipient);
+        // 이 테스트만의 담당자 구성으로 교체 - 박서준은 대체 담당자가 없고, 최유진은 있음
+        when(recipientRepository.findByPlan_PlanId(PLAN_ID))
+                .thenReturn(List.of(noBackupRecipient, hasBackupRecipient, backupOfHasBackup));
+        Item withoutBackup = buildItem(noBackupRecipient, "인스타그램", ItemActionType.OTHER, null, 0);
+        Item withBackup = buildItem(hasBackupRecipient, "트위터", ItemActionType.OTHER, null, 1);
+        stubItems(withoutBackup, withBackup);
+
+        var response = itemOrderService.getOrderCheck(USER_ID, PLAN_ID);
+
+        var withoutBackupResult = response.items().stream().filter(i -> i.itemId().equals(withoutBackup.getItemId())).findFirst().orElseThrow();
+        var withBackupResult = response.items().stream().filter(i -> i.itemId().equals(withBackup.getItemId())).findFirst().orElseThrow();
+        assertThat(withoutBackupResult.conflict()).isTrue();
+        assertThat(withoutBackupResult.conflictMessage()).contains("대체 담당자가 없어요");
+        assertThat(withBackupResult.conflict()).isFalse();
+    }
+
+    // 규칙 5 - 권한 집중 (전체 항목의 과반을 한 담당자가 맡으면 경고)
+    @Test
+    void getOrderCheck_whenOneRecipientHandlesMoreThanHalf_flagsAuthorityConcentration() {
+        Item first = buildItem(recipientA, "인스타그램", ItemActionType.OTHER, null, 0);
+        Item second = buildItem(recipientA, "트위터", ItemActionType.OTHER, null, 1);
+        Item third = buildItem(recipientA, "페이스북", ItemActionType.OTHER, null, 2);
+        Item fourth = buildItem(recipientB, "링크드인", ItemActionType.OTHER, null, 3);
+        stubItems(first, second, third, fourth);
+
+        var response = itemOrderService.getOrderCheck(USER_ID, PLAN_ID);
+
+        // recipientA가 4개 중 3개(75% > 50%) 담당 - 3개 전부 권한 집중으로 표시, recipientB의 1개는 정상
+        long concentrationFlagged = response.items().stream()
+                .filter(item -> item.conflictMessage() != null && item.conflictMessage().contains("절반이 넘게 몰려"))
+                .count();
+        assertThat(concentrationFlagged).isEqualTo(3);
+        var fourthResult = response.items().stream().filter(i -> i.itemId().equals(fourth.getItemId())).findFirst().orElseThrow();
+        assertThat(fourthResult.conflict()).isFalse();
+    }
+
+    // 정확히 50:50이면 "과반 초과"가 아니므로 권한 집중이 아니다
+    @Test
+    void getOrderCheck_whenExactlyHalfEach_noAuthorityConcentrationConflict() {
+        Item first = buildItem(recipientA, "인스타그램", ItemActionType.OTHER, null, 0);
+        Item second = buildItem(recipientB, "트위터", ItemActionType.OTHER, null, 1);
+        stubItems(first, second);
+
+        var response = itemOrderService.getOrderCheck(USER_ID, PLAN_ID);
+
+        assertThat(response.items()).allSatisfy(item -> assertThat(item.conflict()).isFalse());
+    }
+
+    @Test
+    void confirm_whenConflictExists_throwsItemOrderConflict() {
+        Item cloudDelete = buildItem(recipientA, "구글드라이브", ItemActionType.DELETE, ItemSemanticType.CLOUD_DELETE, 0);
+        Item filePreserve = buildItem(recipientB, "구글드라이브", ItemActionType.TRANSFER, ItemSemanticType.FILE_PRESERVE, 1);
+        stubItems(cloudDelete, filePreserve);
+
+        assertThatThrownBy(() -> itemOrderService.confirm(USER_ID, PLAN_ID))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.ITEM_ORDER_CONFLICT));
+    }
+
+    @Test
+    void reorder_whenAllItemIdsProvided_updatesSortOrderAndResetsConfirmation() {
+        Item first = buildItem(recipientA, "인스타그램", ItemActionType.OTHER, null, 0);
+        Item second = buildItem(recipientB, "트위터", ItemActionType.OTHER, null, 1);
+        stubItems(first, second);
+
+        itemOrderService.reorder(USER_ID, PLAN_ID, new ItemReorderRequest(List.of(second.getItemId(), first.getItemId())));
+
+        org.mockito.Mockito.verify(plan).resetOrderConfirmation();
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/domain/plan/service/ItemReviewServiceBolaTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/plan/service/ItemReviewServiceBolaTest.java
@@ -59,7 +59,7 @@ class ItemReviewServiceBolaTest {
     @Test
     void updateRejectsNonOwnerAndDoesNotTouchItemRepository() {
         ItemUpdateRequest request = new ItemUpdateRequest(
-                "대상", "위치", "행동", "제목", "내용", null, "FAMILY", "OTHER");
+                "대상", "위치", "행동", "제목", "내용", null, "FAMILY", "OTHER", null);
 
         assertThatThrownBy(() -> itemReviewService.update(ATTACKER_ID, PLAN_ID, ITEM_ID, request))
                 .isInstanceOfSatisfying(CustomException.class,

--- a/src/test/java/com/mamoki/ieojuda/domain/plan/service/PlanPackageServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/plan/service/PlanPackageServiceTest.java
@@ -28,8 +28,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-// issue #81 - 역할별 패키지 미리보기 및 작성자 봉인. 봉인 차단 검사 3가지(확인자수/금지정보/근거)를 검증한다.
-// 권한 집중·실행순서확정 검사는 #90 소관이라 이 이슈 범위에서 제외한다(사용자 확인됨).
+// issue #81/#90 - 역할별 패키지 미리보기 및 작성자 봉인. 봉인 차단 검사 5가지
+// (확인자수/금지정보/근거/권한집중/실행순서확정)를 순서대로 검증한다.
 class PlanPackageServiceTest {
 
     private PlanOwnershipReader planOwnershipReader;
@@ -168,6 +168,39 @@ class PlanPackageServiceTest {
                         e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.PACKAGE_SEAL_BLOCKED));
     }
 
+    // issue #90 - 한 담당자가 전체 항목의 과반(50% 초과)을 맡으면 봉인 차단
+    @Test
+    void seal_whenOneRecipientHandlesMoreThanHalf_throwsPackageSealBlocked() {
+        stubAcceptedConfirmers(2);
+        Recipient r1 = buildRecipient(UUID.randomUUID(), "이지수");
+        Recipient r2 = buildRecipient(UUID.randomUUID(), "김민수");
+        Item item1 = buildItem(r1, "계정1 정리", "비공개 전환", "", "근거1");
+        Item item2 = buildItem(r1, "계정2 정리", "비공개 전환", "", "근거2");
+        Item item3 = buildItem(r2, "계정3 정리", "비공개 전환", "", "근거3");
+        when(itemRepository.findByLifeArea_Plan_PlanIdAndRecipientIsNotNullOrderBySortOrderAscItemIdAsc(PLAN_ID))
+                .thenReturn(List.of(item1, item2, item3));
+
+        assertThatThrownBy(() -> planPackageService.seal(USER_ID, PLAN_ID))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.PACKAGE_SEAL_BLOCKED));
+        assertThat(plan.getStatus()).isNotEqualTo(PlanStatus.SEALED);
+    }
+
+    // issue #90 - 실행 순서가 아직 확정(orderConfirmedAt != null)되지 않았으면 봉인 차단
+    @Test
+    void seal_whenOrderNotConfirmed_throwsOrderNotConfirmed() {
+        stubAcceptedConfirmers(2);
+        Recipient r1 = buildRecipient(UUID.randomUUID(), "이지수");
+        Item item = buildItem(r1, "계정 정리", "비공개 전환", "", "지수에게 SNS 정리를 부탁");
+        when(itemRepository.findByLifeArea_Plan_PlanIdAndRecipientIsNotNullOrderBySortOrderAscItemIdAsc(PLAN_ID))
+                .thenReturn(List.of(item));
+
+        assertThatThrownBy(() -> planPackageService.seal(USER_ID, PLAN_ID))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.ORDER_NOT_CONFIRMED));
+        assertThat(plan.getStatus()).isNotEqualTo(PlanStatus.SEALED);
+    }
+
     @Test
     void seal_whenAllChecksPass_sealsThePlan() {
         stubAcceptedConfirmers(2);
@@ -175,6 +208,7 @@ class PlanPackageServiceTest {
         Item item = buildItem(r1, "계정 정리", "비공개 전환", "", "지수에게 SNS 정리를 부탁");
         when(itemRepository.findByLifeArea_Plan_PlanIdAndRecipientIsNotNullOrderBySortOrderAscItemIdAsc(PLAN_ID))
                 .thenReturn(List.of(item));
+        plan.confirmOrder();
 
         var response = planPackageService.seal(USER_ID, PLAN_ID);
 

--- a/src/test/java/com/mamoki/ieojuda/domain/plan/service/PlanSummaryServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/plan/service/PlanSummaryServiceTest.java
@@ -75,7 +75,7 @@ class PlanSummaryServiceTest {
     @Test
     void getMySummary_aggregatesEveryCollaboratorResponse() {
         ItemResponse item = new ItemResponse(UUID.randomUUID(), "target", "location", "action", "title", "content",
-                "", "FAMILY", "excerpt", "PROPOSED", 0, "OTHER");
+                "", "FAMILY", "excerpt", "PROPOSED", 0, "OTHER", null);
         when(lifeAreaService.getLifeAreas(USER_ID, PLAN_ID)).thenReturn(List.of(
                 new LifeAreaResponse("FAMILY", List.of(item, item, item)),
                 new LifeAreaResponse("RELATIONSHIP_CLEANUP", List.of()),
@@ -94,9 +94,9 @@ class PlanSummaryServiceTest {
                 List.of(acceptedAssignee, pendingAssignee), List.of(acceptedConfirmer, pendingConfirmer)));
 
         OrderCheckItemResponse conflicting = new OrderCheckItemResponse(
-                UUID.randomUUID(), 0, "삭제 항목", "DELETE", "담당자", 24, "ACCEPTED", true, "충돌 사유");
+                UUID.randomUUID(), 0, "삭제 항목", "DELETE", "CLOUD_DELETE", "담당자", 24, "ACCEPTED", true, "충돌 사유");
         OrderCheckItemResponse clean = new OrderCheckItemResponse(
-                UUID.randomUUID(), 1, "정상 항목", "OTHER", "담당자", 24, "ACCEPTED", false, null);
+                UUID.randomUUID(), 1, "정상 항목", "OTHER", null, "담당자", 24, "ACCEPTED", false, null);
         when(itemOrderService.getOrderCheck(USER_ID, PLAN_ID))
                 .thenReturn(OrderCheckResponse.of(List.of(conflicting, conflicting, clean)));
 

--- a/src/test/java/com/mamoki/ieojuda/global/validation/InputSizeConstraintTest.java
+++ b/src/test/java/com/mamoki/ieojuda/global/validation/InputSizeConstraintTest.java
@@ -67,7 +67,8 @@ class InputSizeConstraintTest {
                     "content", 2000,
                     "precondition", 2000,
                     "disclosureScope", 30,
-                    "actionType", 30
+                    "actionType", 30,
+                    "semanticType", 30
             )),
             Map.entry(SelfWarningEmailRequest.class, Map.of("email", 255)),
             Map.entry(BackupRegisterRequest.class, Map.of("name", 100, "email", 255)),
@@ -128,15 +129,15 @@ class InputSizeConstraintTest {
         Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
         ItemUpdateRequest validItem = new ItemUpdateRequest(
                 "x".repeat(100), "x".repeat(100), "x".repeat(2000),
-                "x".repeat(200), "x".repeat(2000), "x".repeat(2000), "PRIVATE", "OTHER"
+                "x".repeat(200), "x".repeat(2000), "x".repeat(2000), "PRIVATE", "OTHER", "x".repeat(30)
         );
         ItemUpdateRequest oversizedItem = new ItemUpdateRequest(
                 "x".repeat(101), "x".repeat(101), "x".repeat(2001),
-                "x".repeat(201), "x".repeat(2001), "x".repeat(2001), "PRIVATE", "OTHER"
+                "x".repeat(201), "x".repeat(2001), "x".repeat(2001), "PRIVATE", "OTHER", "x".repeat(31)
         );
 
         assertThat(validator.validate(validItem)).isEmpty();
-        assertThat(validator.validate(oversizedItem)).hasSize(6);
+        assertThat(validator.validate(oversizedItem)).hasSize(7);
         assertThat(validator.validate(new ObjectionRequest("token", "x".repeat(1000)))).isEmpty();
         assertThat(validator.validate(new ObjectionRequest("token", "x".repeat(1001)))).hasSize(1);
     }


### PR DESCRIPTION
Closes #90

## 요약
명세서 "AI 구조화 및 충돌 정책"의 결정론적 규칙 6종을 모두 GET /api/plans/{planId}/items/order 응답의 충돌 카드로 노출한다.

- `ItemSemanticType`(CLOUD_DELETE/FILE_PRESERVE/CHANNEL_CLOSE/CLIENT_NOTIFY/DEVICE_RESET/RECORD_EXPORT) 신설. AI 구조화 응답이 이 6종으로 항목을 분류하도록 프롬프트에 지시를 추가하고, Item/DTO 전체에 필드 배선
- 순서 쌍 규칙 3종을 같은 locationType 안에서만 비교하도록 구현 - 타입만 같고 대상(계정·채널·기기)이 다른 항목끼리 엉뚱하게 충돌로 묶이지 않음
- 담당자 누락: 순서 점검 대상에서 담당자 미배정 항목을 더 이상 제외하지 않고 포함해 충돌로 표시
- 대체 담당자 부재: HandoffCheckService와 동일한 backupFor 판정 재사용
- 권한 집중(사용자 확인: 전체 항목의 50% 초과): 담당자별 배정 비율 계산, 담당자가 1명뿐이면 재분배 대상이 없으므로 검사 제외
- PlanPackageService.seal()에 누락되어 있던 봉인 차단 검사 2단계(권한 집중, 실행 순서 확정 - md 스펙 2-2절, #81 당시 #90으로 미뤄짐) 추가, 신규 ErrorCode.ORDER_NOT_CONFIRMED
- 항목당 여러 규칙이 동시에 걸릴 수 있어 conflictMessage를 다중 사유 누적·결합하도록 변경

## md 스펙과의 의도적 차이
- "클라우드 삭제" 규칙: md 스펙 제안(DELETE vs TRANSFER 기존 방식 유지)과 달리, 대화에서 결정한 대로 나머지 2개 순서쌍 규칙과 함께 semanticType 기반으로 통일
- "권한 집중": 담당자가 1명뿐이면 검사하지 않는 예외를 추가함 (그렇지 않으면 단일 담당자 플랜이 항상 100% 집중으로 판정되어 영원히 봉인 불가능해지는 결함을 테스트로 발견)

## 테스트 플랜
- [x] `ItemOrderServiceTest`(12개), `PlanPackageServiceTest`(신규 2개 포함) 전체 통과
- [x] `PlanPackageHttpIntegrationTest` - 새 검사 순서에 맞춰 픽스처(대체 담당자, 순서 확정 호출) 보강 후 통과
- [x] 전체 테스트 스위트 258개 중 257개 통과, 나머지 1개는 develop에도 동일하게 존재하는 무관한 기존 결함(PR #108의 .env 이관 관련)

🤖 Generated with [Claude Code](https://claude.com/claude-code)