### PR TITLE
[Feat/#87]: 파트너 증빙 검토 목록 조회 API 추가

### DIFF
--- a/src/main/java/com/mamoki/ieojuda/domain/evidence/repository/EvidenceRepository.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/evidence/repository/EvidenceRepository.java
@@ -1,6 +1,7 @@
 package com.mamoki.ieojuda.domain.evidence.repository;
 
 import com.mamoki.ieojuda.domain.evidence.entity.Evidence;
+import com.mamoki.ieojuda.domain.evidence.entity.EvidenceReviewStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -26,4 +27,12 @@ public interface EvidenceRepository extends JpaRepository<Evidence, UUID> {
             "LIMIT 100 " +
             "FOR UPDATE SKIP LOCKED", nativeQuery = true)
     List<Evidence> findDueForDeletionForUpdateSkipLocked(@Param("now") LocalDateTime now);
+
+    // "외부 파트너 증빙 검토" 목록 화면(issue #87) - 배정된 파트너와 무관하게 EVIDENCE_REVIEW 권한이 있으면
+    // 전체 검토 대상을 볼 수 있다. status가 null이면 전체 상태를 조회한다.
+    @Query("SELECT e FROM Evidence e " +
+            "WHERE e.deletedAt IS NULL " +
+            "AND (:status IS NULL OR e.reviewStatus = :status) " +
+            "ORDER BY e.submittedAt ASC")
+    List<Evidence> findAllByReviewStatus(@Param("status") EvidenceReviewStatus status);
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/partner/controller/PartnerReviewListController.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/partner/controller/PartnerReviewListController.java
@@ -1,0 +1,39 @@
+package com.mamoki.ieojuda.domain.partner.controller;
+
+import java.util.List;
+import java.util.UUID;
+
+import com.mamoki.ieojuda.domain.evidence.entity.EvidenceReviewStatus;
+import com.mamoki.ieojuda.domain.partner.dto.PartnerReviewListItemResponse;
+import com.mamoki.ieojuda.domain.partner.service.PartnerReviewService;
+import com.mamoki.ieojuda.global.rsdata.RsData;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+// 명세서 "외부 파트너 증빙 검토" 화면 - 외부 법무·장례 파트너 전용
+// issue #87 - 검토 대상 목록 조회. 배정된 파트너와 무관하게 EVIDENCE_REVIEW 권한만 있으면 전체를 조회한다.
+@Tag(name = "Partner Review", description = "외부 파트너 증빙 검토 - 조회 / 승인·반려·추가자료요청")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/partner/reviews")
+public class PartnerReviewListController {
+
+    private final PartnerReviewService partnerReviewService;
+
+    @Operation(summary = "검토 목록 조회", description = "EVIDENCE_REVIEW 권한을 가진 검토자가 전체 검토 대상을 상태별로 조회합니다. 역할별 패키지는 포함하지 않습니다.")
+    @GetMapping
+    public ResponseEntity<RsData<List<PartnerReviewListItemResponse>>> getReviews(
+            @AuthenticationPrincipal UUID userId,
+            @Parameter(description = "검토 상태 필터") @RequestParam(required = false) EvidenceReviewStatus status
+    ) {
+        return ResponseEntity.ok(RsData.success(partnerReviewService.getReviews(userId, status)));
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/partner/dto/PartnerReviewListItemResponse.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/partner/dto/PartnerReviewListItemResponse.java
@@ -1,0 +1,29 @@
+package com.mamoki.ieojuda.domain.partner.dto;
+
+import com.mamoki.ieojuda.domain.evidence.entity.Evidence;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.UUID;
+import java.time.LocalDateTime;
+
+// "외부 파트너 증빙 검토" 목록 화면 - 역할별 패키지(계획 내용)는 절대 포함하지 않는다.
+// 단건 조회(PartnerReviewResponse)와 달리 목록에는 mimeType/integrityHash/reviewedAt/failureReason은 담지 않는다.
+public record PartnerReviewListItemResponse(
+        @Schema(description = "검토 ID (증빙 ID와 동일)") UUID reviewId,
+        @Schema(description = "사망 확인 대상자(계획 작성자) 이름") String targetName,
+        @Schema(description = "증빙 파일명") String fileName,
+        @Schema(description = "증빙 종류", example = "DEATH_CERTIFICATE", allowableValues = {"DEATH_CERTIFICATE", "DEATH_REPORT", "POSTMORTEM_REPORT"}) String evidenceType,
+        @Schema(description = "제출 시각") LocalDateTime submittedAt,
+        @Schema(description = "검토 상태", example = "PENDING", allowableValues = {"PENDING", "APPROVED", "REJECTED", "ADDITIONAL_INFO_REQUESTED"}) String reviewStatus
+) {
+    public static PartnerReviewListItemResponse from(Evidence evidence) {
+        return new PartnerReviewListItemResponse(
+                evidence.getEvidenceId(),
+                evidence.getPlan().getUser().getName(),
+                evidence.getFileName(),
+                evidence.getEvidenceType().name(),
+                evidence.getSubmittedAt(),
+                evidence.getReviewStatus().name()
+        );
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/partner/service/PartnerReviewService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/partner/service/PartnerReviewService.java
@@ -8,7 +8,9 @@ import com.mamoki.ieojuda.domain.audit.entity.AdminActionType;
 import com.mamoki.ieojuda.domain.audit.service.AdminActionAuditService;
 import com.mamoki.ieojuda.domain.evidence.entity.Evidence;
 import com.mamoki.ieojuda.domain.evidence.repository.EvidenceRepository;
+import com.mamoki.ieojuda.domain.evidence.entity.EvidenceReviewStatus;
 import com.mamoki.ieojuda.domain.partner.dto.PartnerReviewDecisionRequest;
+import com.mamoki.ieojuda.domain.partner.dto.PartnerReviewListItemResponse;
 import com.mamoki.ieojuda.domain.partner.dto.PartnerReviewResponse;
 import com.mamoki.ieojuda.domain.partner.entity.PartnerReviewer;
 import com.mamoki.ieojuda.domain.partner.repository.PartnerReviewerRepository;
@@ -22,6 +24,8 @@ import com.mamoki.ieojuda.global.storage.EvidenceStorageClient;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 // 명세서 "외부 파트너 증빙 검토" 화면 - 외부 법무·장례 파트너 전용. 역할별 패키지(계획 내용)는 절대 노출하지 않는다.
 // reviewId는 evidenceId와 1:1로 취급한다(증빙 1건 = 검토 1건).
@@ -44,6 +48,16 @@ public class PartnerReviewService {
         Evidence evidence = findEvidence(reviewId);
         requireAssignedPartner(findReviewerByUser(userId), evidence);
         return PartnerReviewResponse.from(evidence);
+    }
+
+    // issue #87 - 목록은 배정된 파트너와 무관하게 EVIDENCE_REVIEW 권한만 있으면 전체를 조회한다.
+    // (getReview/getFile/decide의 조직 경계 검사는 그대로 유지, 목록에는 적용하지 않기로 결정)
+    public List<PartnerReviewListItemResponse> getReviews(UUID userId, EvidenceReviewStatus status) {
+        permissionGuard.require(userId, AdminPermission.EVIDENCE_REVIEW);
+        return evidenceRepository.findAllByReviewStatus(status)
+                .stream()
+                .map(PartnerReviewListItemResponse::from)
+                .toList();
     }
 
     // 증빙 원본 다운로드 - JSON 응답에 바이너리를 섞지 않기 위해 별도 엔드포인트로 분리

--- a/src/test/java/com/mamoki/ieojuda/domain/partner/service/PartnerReviewServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/partner/service/PartnerReviewServiceTest.java
@@ -10,6 +10,7 @@ import com.mamoki.ieojuda.domain.evidence.entity.EvidenceReviewStatus;
 import com.mamoki.ieojuda.domain.evidence.entity.EvidenceType;
 import com.mamoki.ieojuda.domain.evidence.repository.EvidenceRepository;
 import com.mamoki.ieojuda.domain.partner.dto.PartnerReviewDecisionRequest;
+import com.mamoki.ieojuda.domain.partner.dto.PartnerReviewListItemResponse;
 import com.mamoki.ieojuda.domain.partner.entity.ExternalPartner;
 import com.mamoki.ieojuda.domain.partner.entity.PartnerReviewer;
 import com.mamoki.ieojuda.domain.partner.repository.PartnerReviewerRepository;
@@ -25,12 +26,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -199,5 +202,40 @@ class PartnerReviewServiceTest {
                 .isInstanceOfSatisfying(CustomException.class,
                         e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.EVIDENCE_ALREADY_DELETED));
         verify(evidence, never()).approve();
+    }
+
+    // issue #87 - 목록 조회는 getReview/getFile/decide와 달리 배정된 파트너 조직 경계를 검사하지 않는다.
+    // (다른 파트너 소속 검토자여도 EVIDENCE_REVIEW 권한만 있으면 전체가 조회되어야 한다는 요구사항)
+    @Test
+    void getReviews_returnsAllEvidencesRegardlessOfAssignedPartner() {
+        when(evidence.getEvidenceId()).thenReturn(REVIEW_ID);
+        when(evidenceRepository.findAllByReviewStatus(EvidenceReviewStatus.PENDING))
+                .thenReturn(List.of(evidence));
+
+        List<PartnerReviewListItemResponse> result = partnerReviewService.getReviews(USER_ID, EvidenceReviewStatus.PENDING);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).reviewId()).isEqualTo(REVIEW_ID);
+        verify(releaseCase, never()).getAssignedPartner();
+    }
+
+    @Test
+    void getReviews_passesNullStatusThrough_whenNoFilterGiven() {
+        when(evidenceRepository.findAllByReviewStatus(isNull())).thenReturn(List.of());
+
+        partnerReviewService.getReviews(USER_ID, null);
+
+        verify(evidenceRepository).findAllByReviewStatus(isNull());
+    }
+
+    @Test
+    void getReviews_whenUserLacksEvidenceReviewPermission_isBlockedBeforeAnyLookup() {
+        when(permissionGuard.require(USER_ID, AdminPermission.EVIDENCE_REVIEW))
+                .thenThrow(new CustomException(ErrorCode.INSUFFICIENT_PERMISSION));
+
+        assertThatThrownBy(() -> partnerReviewService.getReviews(USER_ID, EvidenceReviewStatus.PENDING))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.INSUFFICIENT_PERMISSION));
+        verify(evidenceRepository, never()).findAllByReviewStatus(any());
     }
 }


### PR DESCRIPTION
## 연관 Issue
- Closes #87

## 요약
외부 파트너 검토자가 `reviewId`를 몰라도 검토 대상 목록을 볼 수 있도록 `GET /api/partner/reviews`를 신설했습니다. 상태별(PENDING/APPROVED/REJECTED/ADDITIONAL_INFO_REQUESTED) 필터를 지원합니다.

## 변경 사항
- `PartnerReviewListController` 신규 — `GET /api/partner/reviews?status=PENDING`
- `PartnerReviewService.getReviews()` 추가 — `EVIDENCE_REVIEW` 권한만 확인 후 조회
- `EvidenceRepository.findAllByReviewStatus()` 추가 — 삭제되지 않은 증빙을 상태 필터(선택)로 조회, 제출 시각 오름차순 정렬
- `PartnerReviewListItemResponse` DTO 신규 — reviewId, targetName, fileName, evidenceType, submittedAt, reviewStatus
- `PartnerReviewServiceTest`에 성공 2건 / 실패 1건 테스트 케이스 추가

## 범위

### 포함
- 목록 조회 API 신설 및 상태 필터
- 응답에서 역할별 패키지·계획 내용 미노출 확인
- `EVIDENCE_REVIEW` 권한 검사

### 제외
- 검토 결과 제출(`POST .../decision`)은 기존 구현 그대로, 변경 없음
- `getReview`/`getFile`/`decide`의 배정된 파트너 조직 경계 검사(`requireAssignedPartner`)는 그대로 유지 — **목록 조회에는 적용하지 않음**(아래 참고)
- 배정(`assignedPartner`) 로직 자체의 전면 제거는 범위 밖 — 필요 시 별도 이슈로 분리

> 이슈 원문의 "자신에게 배정된 건만 조회"·"다른 파트너에게 배정된 건은 조회되지 않는다" 조건과 다르게 구현했습니다. 실제로는 `EVIDENCE_REVIEW` 권한만 있으면 배정 여부·소속 파트너와 무관하게 전체를 조회합니다(요청자 확인 및 지시에 따름). 리뷰 시 이 부분 의도 확인 부탁드립니다.

## 테스트 내용
- `PartnerReviewServiceTest`: 신규 3건 포함 총 11건 전부 통과 (기존 조직 경계 회귀 테스트 3건도 영향 없음 확인)
- `./gradlew build` 전체 통과
- 로컬 Postgres + 임베디드 서버로 실제 HTTP 검증: `status=PENDING` 필터 정상 동작, 필터 없이 전체 조회 시 배정 여부와 무관하게 노출 확인, 인증 없는 요청 `401` 확인