### PR TITLE
[Fix/#43]: 외부 파트너 증빙 할당 및 접근 격리

### DIFF
--- a/src/main/java/com/mamoki/ieojuda/domain/audit/entity/AdminActionType.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/audit/entity/AdminActionType.java
@@ -6,6 +6,7 @@ public enum AdminActionType {
     CASE_ASSIGN_PARTNER,  // 사건에 파트너사 배정
     EVIDENCE_DECISION,    // 증빙 승인/반려/추가자료요청
     EVIDENCE_DELETE,      // 증빙 원본 삭제(수동 재처리 또는 자동 스케줄러)
+    EVIDENCE_DOWNLOAD,    // issue #43 - 증빙 원본 다운로드(1회성 링크 발급 및 소비)
     EMAIL_OUTBOX_DISPATCH_FAILED, // issue #51 - 이메일 아웃박스 최대 재시도 초과(DEAD 전이)
     EVIDENCE_ORPHAN_CLEANUP // issue #51 - 트랜잭션 롤백 후 S3 고아 객체 정리 실패
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/evidence/entity/EvidenceDownloadToken.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/evidence/entity/EvidenceDownloadToken.java
@@ -1,0 +1,63 @@
+package com.mamoki.ieojuda.domain.evidence.entity;
+
+import com.mamoki.ieojuda.domain.partner.entity.PartnerReviewer;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+// issue #43 - "짧은 수명의 1회성 다운로드 URL". 배정된 검토자가 원본을 열람하려면 먼저 이 토큰을
+// 발급받아야 하고, 실제 다운로드는 이 토큰을 한 번 소비해야 성립한다 - 로그인 세션(JWT)만으로
+// 원본에 계속 접근할 수 있는 상태를 막기 위한 별도 계층이다. 원문 토큰은 저장하지 않고 해시만 저장한다.
+@Entity
+@Table(name = "evidence_download_tokens")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EvidenceDownloadToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "token_id")
+    private UUID tokenId;
+
+    @Column(name = "token_hash", length = 64, nullable = false, unique = true)
+    private String tokenHash;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "evidence_id", nullable = false)
+    private Evidence evidence;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reviewer_id", nullable = false)
+    private PartnerReviewer reviewer;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(name = "used_at")
+    private LocalDateTime usedAt;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public EvidenceDownloadToken(String tokenHash, Evidence evidence, PartnerReviewer reviewer, LocalDateTime expiresAt) {
+        this.tokenHash = tokenHash;
+        this.evidence = evidence;
+        this.reviewer = reviewer;
+        this.expiresAt = expiresAt;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public boolean isUsed() {
+        return usedAt != null;
+    }
+
+    public boolean isExpired() {
+        return expiresAt.isBefore(LocalDateTime.now());
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/evidence/repository/EvidenceDownloadTokenRepository.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/evidence/repository/EvidenceDownloadTokenRepository.java
@@ -1,0 +1,25 @@
+package com.mamoki.ieojuda.domain.evidence.repository;
+
+import com.mamoki.ieojuda.domain.evidence.entity.EvidenceDownloadToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface EvidenceDownloadTokenRepository extends JpaRepository<EvidenceDownloadToken, UUID> {
+
+    Optional<EvidenceDownloadToken> findByTokenHash(String tokenHash);
+
+    // 계정/증빙 삭제 시 이 증빙에 발급된 다운로드 토큰을 함께 정리하기 위한 조회
+    List<EvidenceDownloadToken> findByEvidence_EvidenceId(UUID evidenceId);
+
+    // issue #43 - "1회성" 소비를 조건부 UPDATE 한 번으로 원자 처리 (issue #41의 SecurityToken과 같은 패턴)
+    @Modifying
+    @Query("UPDATE EvidenceDownloadToken t SET t.usedAt = :usedAt WHERE t.tokenId = :tokenId AND t.usedAt IS NULL")
+    int markUsedIfUnused(@Param("tokenId") UUID tokenId, @Param("usedAt") LocalDateTime usedAt);
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/partner/controller/PartnerReviewController.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/partner/controller/PartnerReviewController.java
@@ -2,6 +2,7 @@ package com.mamoki.ieojuda.domain.partner.controller;
 
 import java.util.UUID;
 
+import com.mamoki.ieojuda.domain.partner.dto.EvidenceDownloadLinkResponse;
 import com.mamoki.ieojuda.domain.partner.dto.PartnerReviewDecisionRequest;
 import com.mamoki.ieojuda.domain.partner.dto.PartnerReviewResponse;
 import com.mamoki.ieojuda.domain.partner.service.PartnerReviewService;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 // 명세서 "외부 파트너 증빙 검토" 화면 - 외부 법무·장례 파트너 전용
@@ -40,13 +42,25 @@ public class PartnerReviewController {
         return ResponseEntity.ok(RsData.success(partnerReviewService.getReview(userId, reviewId)));
     }
 
-    @Operation(summary = "증빙 원본 다운로드")
-    @GetMapping("/file")
-    public ResponseEntity<byte[]> getFile(
+    // issue #43 - 원본은 로그인 세션만으로 계속 내려받을 수 없다. 먼저 짧은 수명의 1회성 다운로드
+    // 토큰을 발급받고, 그 토큰으로 한 번만 실제 원본을 요청할 수 있다.
+    @Operation(summary = "증빙 원본 다운로드 링크 발급", description = "짧은 수명(5분)의 1회성 다운로드 토큰을 발급합니다. 이 토큰으로 /file 엔드포인트를 한 번만 호출할 수 있습니다.")
+    @PostMapping("/file")
+    public ResponseEntity<RsData<EvidenceDownloadLinkResponse>> requestDownloadLink(
             @AuthenticationPrincipal UUID userId,
             @Parameter(description = "검토 ID (증빙 ID)") @PathVariable UUID reviewId
     ) {
-        byte[] file = partnerReviewService.getFile(userId, reviewId);
+        return ResponseEntity.ok(RsData.success(partnerReviewService.requestDownloadLink(userId, reviewId)));
+    }
+
+    @Operation(summary = "증빙 원본 다운로드", description = "발급받은 1회성 다운로드 토큰을 소비해 원본을 내려받습니다. 같은 토큰으로 두 번 호출할 수 없습니다.")
+    @GetMapping("/file")
+    public ResponseEntity<byte[]> getFile(
+            @AuthenticationPrincipal UUID userId,
+            @Parameter(description = "검토 ID (증빙 ID)") @PathVariable UUID reviewId,
+            @Parameter(description = "1회성 다운로드 토큰") @RequestParam String token
+    ) {
+        byte[] file = partnerReviewService.downloadFile(userId, reviewId, token);
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_OCTET_STREAM)
                 .body(file);

--- a/src/main/java/com/mamoki/ieojuda/domain/partner/dto/EvidenceDownloadLinkResponse.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/partner/dto/EvidenceDownloadLinkResponse.java
@@ -1,0 +1,12 @@
+package com.mamoki.ieojuda.domain.partner.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+// issue #43 - 짧은 수명의 1회성 다운로드 토큰 발급 결과. 이 토큰으로 한 번만 원본을 내려받을 수 있다.
+public record EvidenceDownloadLinkResponse(
+        @Schema(description = "1회성 다운로드 토큰") String downloadToken,
+        @Schema(description = "토큰 만료 시각") LocalDateTime expiresAt
+) {
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/partner/service/PartnerReviewService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/partner/service/PartnerReviewService.java
@@ -1,5 +1,6 @@
 package com.mamoki.ieojuda.domain.partner.service;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 import com.mamoki.ieojuda.domain.account.entity.AdminPermission;
@@ -8,7 +9,11 @@ import com.mamoki.ieojuda.domain.audit.entity.AdminActionType;
 import com.mamoki.ieojuda.domain.audit.service.AdminActionAuditService;
 import com.mamoki.ieojuda.domain.confirmer.service.DisputeContactService;
 import com.mamoki.ieojuda.domain.evidence.entity.Evidence;
+import com.mamoki.ieojuda.domain.evidence.entity.EvidenceDownloadToken;
+import com.mamoki.ieojuda.domain.evidence.entity.EvidenceReviewStatus;
+import com.mamoki.ieojuda.domain.evidence.repository.EvidenceDownloadTokenRepository;
 import com.mamoki.ieojuda.domain.evidence.repository.EvidenceRepository;
+import com.mamoki.ieojuda.domain.partner.dto.EvidenceDownloadLinkResponse;
 import com.mamoki.ieojuda.domain.partner.dto.PartnerReviewDecisionRequest;
 import com.mamoki.ieojuda.domain.partner.dto.PartnerReviewResponse;
 import com.mamoki.ieojuda.domain.partner.entity.PartnerReviewer;
@@ -16,6 +21,7 @@ import com.mamoki.ieojuda.domain.partner.repository.PartnerReviewerRepository;
 import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCase;
 import com.mamoki.ieojuda.domain.securitytoken.entity.SecurityTokenPurpose;
 import com.mamoki.ieojuda.domain.securitytoken.service.SecurityTokenService;
+import com.mamoki.ieojuda.global.email.token.TokenProvider;
 import com.mamoki.ieojuda.global.exception.CustomException;
 import com.mamoki.ieojuda.global.exception.ErrorCode;
 import com.mamoki.ieojuda.global.idempotency.service.IdempotencyGuard;
@@ -29,13 +35,20 @@ import org.springframework.transaction.annotation.Transactional;
 // 명세서 "외부 파트너 증빙 검토" 화면 - 외부 법무·장례 파트너 전용. 역할별 패키지(계획 내용)는 절대 노출하지 않는다.
 // reviewId는 evidenceId와 1:1로 취급한다(증빙 1건 = 검토 1건).
 // issue #59 - EVIDENCE_REVIEW 세부 권한 + 소속 파트너사가 배정된 사건만 조작 가능(조직 경계) + 판정은 재인증 필요
+// issue #43 - 접근 경계는 조직(소속 파트너사) 단위까지다 - 개별 검토자 사전 지정은 두지 않는다(목록·개인별
+// 배정 UX는 별도 브랜치에서 다룬다). 다만 판정은 1회 상태 전이로 제한하고, 원본 다운로드는 짧은 수명의
+// 1회성 토큰을 소비해야 하며, 다운로드·판정 이력은 호출자(actor) 기준으로 감사된다.
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class PartnerReviewService {
 
+    // 다운로드 링크는 발급 즉시 쓰는 것을 전제로 하므로 짧게 둔다
+    private static final long DOWNLOAD_TOKEN_TTL_MINUTES = 5;
+
     private final EvidenceRepository evidenceRepository;
     private final PartnerReviewerRepository partnerReviewerRepository;
+    private final EvidenceDownloadTokenRepository evidenceDownloadTokenRepository;
     private final EvidenceStorageClient evidenceStorageClient;
     private final PermissionGuard permissionGuard;
     private final ReauthGuard reauthGuard;
@@ -47,29 +60,70 @@ public class PartnerReviewService {
     public PartnerReviewResponse getReview(UUID userId, UUID reviewId) {
         permissionGuard.require(userId, AdminPermission.EVIDENCE_REVIEW);
         Evidence evidence = findEvidence(reviewId);
-        requireAssignedPartner(findReviewerByUser(userId), evidence);
+        requireAssignedPartner(findActiveReviewerByUser(userId), evidence);
         return PartnerReviewResponse.from(evidence);
     }
 
-    // 증빙 원본 다운로드 - JSON 응답에 바이너리를 섞지 않기 위해 별도 엔드포인트로 분리
-    public byte[] getFile(UUID userId, UUID reviewId) {
+    // issue #43 - 원본을 직접 스트리밍하지 않고, 먼저 짧은 수명의 1회성 다운로드 토큰을 발급한다.
+    // 실제 원본은 이 토큰을 소비하는 downloadFile()에서만 내려간다.
+    @Transactional
+    public EvidenceDownloadLinkResponse requestDownloadLink(UUID userId, UUID reviewId) {
         permissionGuard.require(userId, AdminPermission.EVIDENCE_REVIEW);
         Evidence evidence = findEvidence(reviewId);
-        requireAssignedPartner(findReviewerByUser(userId), evidence);
-        return evidenceStorageClient.load(evidence.getStorageKey());
+        PartnerReviewer reviewer = findActiveReviewerByUser(userId);
+        requireAssignedPartner(reviewer, evidence);
+
+        String plainToken = TokenProvider.generatePlainToken();
+        LocalDateTime expiresAt = LocalDateTime.now().plusMinutes(DOWNLOAD_TOKEN_TTL_MINUTES);
+        evidenceDownloadTokenRepository.save(EvidenceDownloadToken.builder()
+                .tokenHash(TokenProvider.hashToken(plainToken))
+                .evidence(evidence)
+                .reviewer(reviewer)
+                .expiresAt(expiresAt)
+                .build());
+
+        return new EvidenceDownloadLinkResponse(plainToken, expiresAt);
+    }
+
+    // 증빙 원본 다운로드 - 1회성 토큰을 소비해야 하고, 호출자 기준으로 감사된다
+    @Transactional
+    public byte[] downloadFile(UUID userId, UUID reviewId, String plainToken) {
+        User actor = permissionGuard.require(userId, AdminPermission.EVIDENCE_REVIEW);
+        Evidence evidence = findEvidence(reviewId);
+        PartnerReviewer reviewer = findActiveReviewerByUser(userId);
+        requireAssignedPartner(reviewer, evidence);
+
+        EvidenceDownloadToken token = evidenceDownloadTokenRepository.findByTokenHash(TokenProvider.hashToken(plainToken))
+                .orElseThrow(() -> new CustomException(ErrorCode.TOKEN_INVALID));
+        if (!token.getEvidence().getEvidenceId().equals(evidence.getEvidenceId())) {
+            throw new CustomException(ErrorCode.TOKEN_INVALID);
+        }
+        if (token.isExpired()) {
+            throw new CustomException(ErrorCode.ACCESS_LINK_EXPIRED);
+        }
+        int updated = evidenceDownloadTokenRepository.markUsedIfUnused(token.getTokenId(), LocalDateTime.now());
+        if (updated == 0) {
+            throw new CustomException(ErrorCode.ACCESS_LINK_ALREADY_USED);
+        }
+
+        byte[] file = evidenceStorageClient.load(evidence.getStorageKey());
+        adminActionAuditService.record(actor, AdminActionType.EVIDENCE_DOWNLOAD, reviewId, true, null);
+        return file;
     }
 
     @Transactional
     public PartnerReviewResponse decide(UUID reviewId, UUID userId, PartnerReviewDecisionRequest request, String idempotencyKey) {
         User actor = permissionGuard.require(userId, AdminPermission.EVIDENCE_REVIEW);
         Evidence evidence = findEvidence(reviewId);
-        PartnerReviewer reviewer = findReviewerByUser(userId);
-
-        // 이해충돌·권한 만료로 비활성화된 검토자는 결정할 수 없음 (명세서 "다른 검토자에게 재배정")
-        if (!Boolean.TRUE.equals(reviewer.getIsActive())) {
-            throw new CustomException(ErrorCode.REVIEWER_CONFLICT_OF_INTEREST);
-        }
+        PartnerReviewer reviewer = findActiveReviewerByUser(userId);
         requireAssignedPartner(reviewer, evidence);
+
+        // issue #43 - 판정을 1회 상태 전이로 제한한다. APPROVED/REJECTED는 종결 상태라 다시 판정할 수 없다
+        // (ADDITIONAL_INFO_REQUESTED는 종결이 아니라 추가 자료를 받은 뒤 다시 판정할 수 있어야 한다).
+        if (evidence.getReviewStatus() == EvidenceReviewStatus.APPROVED
+                || evidence.getReviewStatus() == EvidenceReviewStatus.REJECTED) {
+            throw new CustomException(ErrorCode.EVIDENCE_ALREADY_DECIDED);
+        }
 
         // 되돌리기 까다로운 고위험 조작이라 비밀번호 재확인 없이는 실행하지 않고, 성공/실패를 감사 로그에 남긴다.
         try {
@@ -82,6 +136,8 @@ public class PartnerReviewService {
         // 정상적인 재시도까지 막는 일이 없다.
         idempotencyGuard.claim("partner-review-decision", idempotencyKey);
 
+        // 개별 사전 배정이 없는 조직 단위 접근이므로, 실제로 판정을 내린 사람이 누구인지는
+        // 판정 시점에만 기록할 수 있다(표시·감사용 - 접근 제어에는 쓰지 않는다).
         evidence.assignReviewer(reviewer);
 
         switch (request.decision()) {
@@ -112,7 +168,8 @@ public class PartnerReviewService {
     }
 
     // issue #59 - 검토자 소속 파트너사와 사건에 배정된 파트너사가 같아야만 조작 가능. 아직 배정되지 않은
-    // 사건은 어떤 검토자도 손댈 수 없다(운영자 배정이 먼저 있어야 함).
+    // 사건은 어떤 검토자도 손댈 수 없다(운영자 배정이 먼저 있어야 함). issue #43 - 접근 경계는 이 조직
+    // 단위까지고, 그 안에서 어떤 활성 검토자가 처리하는지는 제한하지 않는다(목록·개인별 배정은 별도 브랜치).
     private void requireAssignedPartner(PartnerReviewer reviewer, Evidence evidence) {
         ReleaseCase releaseCase = evidence.getReleaseCase();
         if (releaseCase.getAssignedPartner() == null) {
@@ -135,8 +192,13 @@ public class PartnerReviewService {
         return evidence;
     }
 
-    private PartnerReviewer findReviewerByUser(UUID userId) {
-        return partnerReviewerRepository.findByUser_UserId(userId)
+    // 이해충돌·권한 만료로 비활성화된 검토자는 조회·다운로드·판정 어느 것도 할 수 없음 (명세서 "다른 검토자에게 재배정")
+    private PartnerReviewer findActiveReviewerByUser(UUID userId) {
+        PartnerReviewer reviewer = partnerReviewerRepository.findByUser_UserId(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.PARTNER_REVIEWER_NOT_FOUND));
+        if (!Boolean.TRUE.equals(reviewer.getIsActive())) {
+            throw new CustomException(ErrorCode.REVIEWER_CONFLICT_OF_INTEREST);
+        }
+        return reviewer;
     }
 }

--- a/src/main/java/com/mamoki/ieojuda/global/exception/ErrorCode.java
+++ b/src/main/java/com/mamoki/ieojuda/global/exception/ErrorCode.java
@@ -99,6 +99,7 @@ public enum ErrorCode {
     ORDER_NOT_CONFIRMED(HttpStatus.CONFLICT, "ORDER_NOT_CONFIRMED", "실행 순서가 아직 확정되지 않아 패키지를 봉인할 수 없습니다."),
     PARTNER_NOT_ASSIGNED(HttpStatus.CONFLICT, "PARTNER_NOT_ASSIGNED", "이 사건에는 아직 담당 파트너사가 배정되지 않았습니다."),
     EVIDENCE_ALREADY_DELETED(HttpStatus.CONFLICT, "EVIDENCE_ALREADY_DELETED", "이미 삭제된 증빙입니다."),
+    EVIDENCE_ALREADY_DECIDED(HttpStatus.CONFLICT, "EVIDENCE_ALREADY_DECIDED", "이미 판정이 완료된 증빙은 다시 판정할 수 없습니다."),
     DUPLICATE_REQUEST(HttpStatus.CONFLICT, "DUPLICATE_REQUEST", "이미 처리 중이거나 처리된 요청입니다."),
     CONCURRENT_MODIFICATION(HttpStatus.CONFLICT, "CONCURRENT_MODIFICATION", "다른 요청이 먼저 처리되어 현재 상태와 충돌합니다. 다시 시도해 주세요."),
 

--- a/src/test/java/com/mamoki/ieojuda/domain/partner/controller/PartnerReviewOrgAccessHttpIntegrationTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/partner/controller/PartnerReviewOrgAccessHttpIntegrationTest.java
@@ -1,0 +1,267 @@
+package com.mamoki.ieojuda.domain.partner.controller;
+
+import com.mamoki.ieojuda.domain.account.entity.AdminPermission;
+import com.mamoki.ieojuda.domain.account.entity.User;
+import com.mamoki.ieojuda.domain.account.entity.UserRole;
+import com.mamoki.ieojuda.domain.account.repository.UserRepository;
+import com.mamoki.ieojuda.domain.audit.repository.AdminActionAuditLogRepository;
+import com.mamoki.ieojuda.domain.confirmer.entity.Confirmer;
+import com.mamoki.ieojuda.domain.confirmer.entity.Relationship;
+import com.mamoki.ieojuda.domain.confirmer.repository.ConfirmerRepository;
+import com.mamoki.ieojuda.domain.evidence.entity.Evidence;
+import com.mamoki.ieojuda.domain.evidence.entity.EvidenceType;
+import com.mamoki.ieojuda.domain.evidence.repository.EvidenceDownloadTokenRepository;
+import com.mamoki.ieojuda.domain.evidence.repository.EvidenceRepository;
+import com.mamoki.ieojuda.domain.partner.entity.ExternalPartner;
+import com.mamoki.ieojuda.domain.partner.entity.PartnerReviewer;
+import com.mamoki.ieojuda.domain.partner.entity.PartnerType;
+import com.mamoki.ieojuda.domain.partner.repository.ExternalPartnerRepository;
+import com.mamoki.ieojuda.domain.partner.repository.PartnerReviewerRepository;
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.plan.entity.PlanVersion;
+import com.mamoki.ieojuda.domain.plan.repository.PlanRepository;
+import com.mamoki.ieojuda.domain.plan.repository.PlanVersionRepository;
+import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCase;
+import com.mamoki.ieojuda.domain.releasecase.repository.ReleaseCaseRepository;
+import com.mamoki.ieojuda.global.jwt.component.JwtTokenProvider;
+import com.mamoki.ieojuda.global.storage.EvidenceStorageClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+// issue #43 완료 조건 통합 검증 - 접근 경계는 조직(소속 파트너사) 단위까지다(개별 검토자 사전 지정은
+// 별도 브랜치에서 다룬다). 그래서 "지정되지 않은 파트너는 접근할 수 없다"는 여기서는 "배정 안 된 사건
+// 또는 다른 조직의 파트너는 접근할 수 없다"로, "다른 조직의 파트너는 판정을 변경할 수 없다"는 그대로
+// 검증하고, 같은 조직의 어떤 활성 검토자든 접근할 수 있음도 함께 확인한다.
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class PartnerReviewOrgAccessHttpIntegrationTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private PlanRepository planRepository;
+    @Autowired
+    private PlanVersionRepository planVersionRepository;
+    @Autowired
+    private ReleaseCaseRepository releaseCaseRepository;
+    @Autowired
+    private ExternalPartnerRepository externalPartnerRepository;
+    @Autowired
+    private PartnerReviewerRepository partnerReviewerRepository;
+    @Autowired
+    private EvidenceRepository evidenceRepository;
+    @Autowired
+    private ConfirmerRepository confirmerRepository;
+    @Autowired
+    private EvidenceDownloadTokenRepository evidenceDownloadTokenRepository;
+    @Autowired
+    private AdminActionAuditLogRepository adminActionAuditLogRepository;
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @MockitoBean
+    private EvidenceStorageClient evidenceStorageClient;
+
+    private final HttpClient httpClient = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build();
+
+    private User owner;
+    private Plan plan;
+    private PlanVersion planVersion;
+    private ReleaseCase releaseCase;
+    private ExternalPartner partnerOrg;
+    private ExternalPartner otherPartnerOrg;
+    private Confirmer confirmer;
+    private Evidence evidence;
+
+    private User reviewerAUser;
+    private String reviewerAToken;
+
+    private User reviewerBUser; // 같은 조직, 개별 사전 배정은 없지만 접근은 가능해야 함
+    private String reviewerBToken;
+
+    private User otherOrgReviewerUser;
+    private String otherOrgReviewerToken;
+
+    @BeforeEach
+    void setUp() {
+        when(evidenceStorageClient.load(any())).thenReturn(new byte[]{1, 2, 3});
+
+        owner = userRepository.saveAndFlush(User.builder()
+                .email("owner-" + UUID.randomUUID() + "@test.com").password("hash").name("작성자").build());
+        plan = planRepository.saveAndFlush(Plan.builder().user(owner).build());
+        planVersion = planVersionRepository.saveAndFlush(
+                PlanVersion.builder().plan(plan).versionNum(1).snapshotData("{}").build());
+        releaseCase = releaseCaseRepository.saveAndFlush(ReleaseCase.builder().plan(plan).planVersion(planVersion).build());
+
+        partnerOrg = externalPartnerRepository.saveAndFlush(
+                ExternalPartner.builder().name("파트너A").partnerType(PartnerType.LEGAL).contactInfo("contact-a").build());
+        otherPartnerOrg = externalPartnerRepository.saveAndFlush(
+                ExternalPartner.builder().name("파트너B").partnerType(PartnerType.LEGAL).contactInfo("contact-b").build());
+        releaseCase.assignPartner(partnerOrg);
+        // saveAndFlush(detached entity)는 merge()라서 새 관리 인스턴스를 반환한다 - 반드시 재할당해야
+        // 이후 delete에서 최신 version을 참조해 낙관적 잠금 충돌이 나지 않는다.
+        releaseCase = releaseCaseRepository.saveAndFlush(releaseCase);
+
+        confirmer = confirmerRepository.saveAndFlush(Confirmer.builder()
+                .plan(plan).name("확인자").relationship(Relationship.FRIEND)
+                .email("confirmer-org-access-" + UUID.randomUUID() + "@test.com").build());
+        evidence = evidenceRepository.saveAndFlush(Evidence.builder()
+                .confirmer(confirmer).plan(plan).releaseCase(releaseCase)
+                .storageKey("evidence/org-access-test/key").fileName("proof.pdf").mimeType("application/pdf")
+                .integrityHash("hash").evidenceType(EvidenceType.DEATH_CERTIFICATE).build());
+
+        reviewerAUser = createUser(UserRole.EXTERNAL, Set.of(AdminPermission.EVIDENCE_REVIEW));
+        reviewerAToken = issueToken(reviewerAUser);
+        partnerReviewerRepository.saveAndFlush(PartnerReviewer.builder()
+                .partner(partnerOrg).user(reviewerAUser).name("검토자A").email(reviewerAUser.getEmail()).build());
+
+        reviewerBUser = createUser(UserRole.EXTERNAL, Set.of(AdminPermission.EVIDENCE_REVIEW));
+        reviewerBToken = issueToken(reviewerBUser);
+        partnerReviewerRepository.saveAndFlush(PartnerReviewer.builder()
+                .partner(partnerOrg).user(reviewerBUser).name("검토자B").email(reviewerBUser.getEmail()).build());
+
+        otherOrgReviewerUser = createUser(UserRole.EXTERNAL, Set.of(AdminPermission.EVIDENCE_REVIEW));
+        otherOrgReviewerToken = issueToken(otherOrgReviewerUser);
+        partnerReviewerRepository.saveAndFlush(PartnerReviewer.builder()
+                .partner(otherPartnerOrg).user(otherOrgReviewerUser).name("타조직 검토자").email(otherOrgReviewerUser.getEmail()).build());
+    }
+
+    // 재인증(ReauthGuard)이 실제 BCrypt 비교를 하므로, "hash"라는 원문 비밀번호를 인코딩해서 저장해둔다
+    // (테스트에서 결정 API를 password:"hash"로 호출하는 것과 짝을 맞춘다).
+    private User createUser(UserRole role, Set<AdminPermission> permissions) {
+        User user = User.builder().email(role + "-" + UUID.randomUUID() + "@test.com")
+                .password(passwordEncoder.encode("hash")).name(role.name()).build();
+        ReflectionTestUtils.setField(user, "role", role);
+        ReflectionTestUtils.setField(user, "permissions", permissions);
+        return userRepository.saveAndFlush(user);
+    }
+
+    private String issueToken(User user) {
+        return jwtTokenProvider.generateAccessToken(user.getUserId(), user.getEmail(), user.getRole().name(), user.getTokenVersion());
+    }
+
+    @AfterEach
+    void tearDown() {
+        evidenceDownloadTokenRepository.deleteAll(evidenceDownloadTokenRepository.findByEvidence_EvidenceId(evidence.getEvidenceId()));
+        evidenceRepository.deleteById(evidence.getEvidenceId());
+        confirmerRepository.deleteById(confirmer.getConfirmId());
+        partnerReviewerRepository.deleteAll(partnerReviewerRepository.findAll().stream()
+                .filter(r -> r.getPartner().getPartnerId().equals(partnerOrg.getPartnerId())
+                        || r.getPartner().getPartnerId().equals(otherPartnerOrg.getPartnerId()))
+                .toList());
+        releaseCaseRepository.deleteById(releaseCase.getCaseId());
+        planVersionRepository.delete(planVersion);
+        planRepository.delete(plan);
+        externalPartnerRepository.delete(partnerOrg);
+        externalPartnerRepository.delete(otherPartnerOrg);
+        userRepository.delete(owner);
+        userRepository.delete(reviewerAUser);
+        userRepository.delete(reviewerBUser);
+        userRepository.delete(otherOrgReviewerUser);
+    }
+
+    @Test
+    void reviewerFromDifferentOrg_cannotViewOrDownloadOrDecide() throws Exception {
+        assertThat(get("/api/partner/reviews/" + evidence.getEvidenceId(), otherOrgReviewerToken).statusCode()).isEqualTo(403);
+        assertThat(post("/api/partner/reviews/" + evidence.getEvidenceId() + "/file", otherOrgReviewerToken, null).statusCode()).isEqualTo(403);
+        assertThat(post("/api/partner/reviews/" + evidence.getEvidenceId() + "/decision", otherOrgReviewerToken,
+                "{\"decision\":\"APPROVE\",\"password\":\"hash\"}").statusCode()).isEqualTo(403);
+    }
+
+    // issue #43 - 개별 사전 배정은 없다. 같은 조직 소속이면 어떤 활성 검토자든 접근할 수 있어야 한다.
+    @Test
+    void anyActiveReviewerInAssignedOrg_canViewMetadata() throws Exception {
+        assertThat(get("/api/partner/reviews/" + evidence.getEvidenceId(), reviewerAToken).statusCode()).isEqualTo(200);
+        assertThat(get("/api/partner/reviews/" + evidence.getEvidenceId(), reviewerBToken).statusCode()).isEqualTo(200);
+    }
+
+    // 다운로드·판정 이력이 호출자(actor) 기준으로 감사되는지, 다운로드가 1회성인지 검증
+    @Test
+    void download_isSingleUseAndAuditedByActualCaller() throws Exception {
+        HttpResponse<String> linkResponse = post("/api/partner/reviews/" + evidence.getEvidenceId() + "/file", reviewerAToken, null);
+        assertThat(linkResponse.statusCode()).isEqualTo(200);
+        String token = extractJsonField(linkResponse.body(), "downloadToken");
+
+        HttpResponse<byte[]> fileResponse = httpClient.send(
+                HttpRequest.newBuilder(uri("/api/partner/reviews/" + evidence.getEvidenceId() + "/file?token=" + token))
+                        .header("Authorization", "Bearer " + reviewerAToken).GET().build(),
+                HttpResponse.BodyHandlers.ofByteArray());
+        assertThat(fileResponse.statusCode()).isEqualTo(200);
+
+        boolean audited = adminActionAuditLogRepository.findAllByOrderByOccurredAtDesc(PageRequest.of(0, 20))
+                .stream()
+                .anyMatch(log -> log.getTargetId().equals(evidence.getEvidenceId())
+                        && log.getActorUserId().equals(reviewerAUser.getUserId()));
+        assertThat(audited).isTrue();
+
+        // 같은 토큰으로 두 번째 다운로드는 거절되어야 한다(ACCESS_LINK_ALREADY_USED는 이 코드베이스 관례상 401)
+        HttpResponse<byte[]> secondAttempt = httpClient.send(
+                HttpRequest.newBuilder(uri("/api/partner/reviews/" + evidence.getEvidenceId() + "/file?token=" + token))
+                        .header("Authorization", "Bearer " + reviewerAToken).GET().build(),
+                HttpResponse.BodyHandlers.ofByteArray());
+        assertThat(secondAttempt.statusCode()).isEqualTo(401);
+    }
+
+    // issue #43 완료 조건 - 판정을 1회 상태 전이로 제한한다 (실제 HTTP 컨트롤러/재인증 체인 포함 검증)
+    @Test
+    void decide_cannotBeChangedAfterAlreadyDecided() throws Exception {
+        HttpResponse<String> first = post("/api/partner/reviews/" + evidence.getEvidenceId() + "/decision", reviewerAToken,
+                "{\"decision\":\"APPROVE\",\"password\":\"hash\"}");
+        assertThat(first.statusCode()).isEqualTo(200);
+
+        HttpResponse<String> second = post("/api/partner/reviews/" + evidence.getEvidenceId() + "/decision", reviewerBToken,
+                "{\"decision\":\"REJECT\",\"failureReason\":\"사유\",\"password\":\"hash\"}");
+        assertThat(second.statusCode()).isEqualTo(409);
+        assertThat(second.body()).contains("EVIDENCE_ALREADY_DECIDED");
+    }
+
+    private String extractJsonField(String json, String field) {
+        String marker = "\"" + field + "\":\"";
+        int start = json.indexOf(marker) + marker.length();
+        int end = json.indexOf('"', start);
+        return json.substring(start, end);
+    }
+
+    private HttpResponse<String> get(String path, String token) throws Exception {
+        return httpClient.send(HttpRequest.newBuilder(uri(path))
+                .header("Authorization", "Bearer " + token).GET().build(), HttpResponse.BodyHandlers.ofString());
+    }
+
+    private HttpResponse<String> post(String path, String token, String body) throws Exception {
+        HttpRequest.Builder builder = HttpRequest.newBuilder(uri(path))
+                .header("Authorization", "Bearer " + token)
+                .header("Content-Type", "application/json");
+        builder = body == null
+                ? builder.POST(HttpRequest.BodyPublishers.noBody())
+                : builder.POST(HttpRequest.BodyPublishers.ofString(body));
+        return httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+    }
+
+    private URI uri(String path) {
+        return URI.create("http://localhost:" + port + path);
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/domain/partner/service/PartnerReviewServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/partner/service/PartnerReviewServiceTest.java
@@ -7,9 +7,12 @@ import com.mamoki.ieojuda.domain.audit.service.AdminActionAuditService;
 import com.mamoki.ieojuda.domain.confirmer.entity.Confirmer;
 import com.mamoki.ieojuda.domain.confirmer.service.DisputeContactService;
 import com.mamoki.ieojuda.domain.evidence.entity.Evidence;
+import com.mamoki.ieojuda.domain.evidence.entity.EvidenceDownloadToken;
 import com.mamoki.ieojuda.domain.evidence.entity.EvidenceReviewStatus;
 import com.mamoki.ieojuda.domain.evidence.entity.EvidenceType;
+import com.mamoki.ieojuda.domain.evidence.repository.EvidenceDownloadTokenRepository;
 import com.mamoki.ieojuda.domain.evidence.repository.EvidenceRepository;
+import com.mamoki.ieojuda.domain.partner.dto.EvidenceDownloadLinkResponse;
 import com.mamoki.ieojuda.domain.partner.dto.PartnerReviewDecisionRequest;
 import com.mamoki.ieojuda.domain.partner.entity.ExternalPartner;
 import com.mamoki.ieojuda.domain.partner.entity.PartnerReviewer;
@@ -39,8 +42,10 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-// issue #59 회귀 테스트 - 역할(EXTERNAL) 하나만으로는 소속 파트너사에 배정되지 않은 사건·증빙을
-// 조작할 수 없어야 하고(조직 경계), 증빙 판정은 재인증 없이는 실행되지 않아야 한다.
+// issue #59 회귀 테스트 - 역할(EXTERNAL) 하나만으로는 소속 파트너사에 배정되지 않은 사건·증빙을 조작할 수
+// 없어야 하고(조직 경계), 증빙 판정은 재인증 없이는 실행되지 않아야 한다.
+// issue #43 - 접근 경계는 조직(소속 파트너사) 단위까지다(개별 검토자 사전 지정은 별도 브랜치 소관).
+// 다만 판정은 한 번 완료되면 다시 바꿀 수 없고, 원본은 1회성 토큰으로만 내려받을 수 있어야 한다.
 class PartnerReviewServiceTest {
 
     private static final UUID USER_ID = UUID.randomUUID();
@@ -50,6 +55,7 @@ class PartnerReviewServiceTest {
 
     private EvidenceRepository evidenceRepository;
     private PartnerReviewerRepository partnerReviewerRepository;
+    private EvidenceDownloadTokenRepository evidenceDownloadTokenRepository;
     private EvidenceStorageClient evidenceStorageClient;
     private PermissionGuard permissionGuard;
     private ReauthGuard reauthGuard;
@@ -69,6 +75,7 @@ class PartnerReviewServiceTest {
     void setUp() {
         evidenceRepository = mock(EvidenceRepository.class);
         partnerReviewerRepository = mock(PartnerReviewerRepository.class);
+        evidenceDownloadTokenRepository = mock(EvidenceDownloadTokenRepository.class);
         evidenceStorageClient = mock(EvidenceStorageClient.class);
         permissionGuard = mock(PermissionGuard.class);
         reauthGuard = mock(ReauthGuard.class);
@@ -77,7 +84,7 @@ class PartnerReviewServiceTest {
         securityTokenService = mock(SecurityTokenService.class);
         disputeContactService = mock(DisputeContactService.class);
         partnerReviewService = new PartnerReviewService(
-                evidenceRepository, partnerReviewerRepository, evidenceStorageClient,
+                evidenceRepository, partnerReviewerRepository, evidenceDownloadTokenRepository, evidenceStorageClient,
                 permissionGuard, reauthGuard, adminActionAuditService, idempotencyGuard,
                 securityTokenService, disputeContactService);
 
@@ -87,11 +94,13 @@ class PartnerReviewServiceTest {
         reviewerPartner = mock(ExternalPartner.class);
         when(reviewerPartner.getPartnerId()).thenReturn(REVIEWER_PARTNER_ID);
         reviewer = mock(PartnerReviewer.class);
+        when(reviewer.getReviewerId()).thenReturn(UUID.randomUUID());
         when(reviewer.getIsActive()).thenReturn(true);
         when(reviewer.getPartner()).thenReturn(reviewerPartner);
         when(partnerReviewerRepository.findByUser_UserId(USER_ID)).thenReturn(Optional.of(reviewer));
 
         releaseCase = mock(ReleaseCase.class);
+        when(releaseCase.getAssignedPartner()).thenReturn(reviewerPartner); // 기본값: 같은 조직에 배정됨
         Plan plan = mock(Plan.class);
         User planOwner = mock(User.class);
         when(planOwner.getName()).thenReturn("작성자");
@@ -99,6 +108,7 @@ class PartnerReviewServiceTest {
         Confirmer confirmer = mock(Confirmer.class);
         when(confirmer.getName()).thenReturn("확인자");
         evidence = mock(Evidence.class);
+        when(evidence.getEvidenceId()).thenReturn(REVIEW_ID);
         when(evidence.getReleaseCase()).thenReturn(releaseCase);
         when(evidence.getPlan()).thenReturn(plan);
         when(evidence.getConfirmer()).thenReturn(confirmer);
@@ -134,8 +144,7 @@ class PartnerReviewServiceTest {
     }
 
     @Test
-    void decide_whenCaseAssignedToReviewersOwnPartner_proceeds() {
-        when(releaseCase.getAssignedPartner()).thenReturn(reviewerPartner); // 같은 조직
+    void decide_whenCaseAssignedToReviewersOwnPartner_proceedsAndRecordsReviewer() {
         PartnerReviewDecisionRequest request = new PartnerReviewDecisionRequest(
                 PartnerReviewDecisionRequest.PartnerReviewDecision.APPROVE, null, "correct-pw");
 
@@ -144,11 +153,61 @@ class PartnerReviewServiceTest {
         verify(evidence).approve();
         verify(releaseCase).approveEvidenceAndStartWaiting(any());
         verify(adminActionAuditService).record(actor, AdminActionType.EVIDENCE_DECISION, REVIEW_ID, true, "APPROVE");
+        // issue #43 - 개별 사전 배정은 없지만, 실제로 판정한 사람은 표시·감사용으로 기록해둔다
+        verify(evidence).assignReviewer(reviewer);
+    }
+
+    @Test
+    void decide_whenReviewerInactive_isBlockedByConflictOfInterest() {
+        when(reviewer.getIsActive()).thenReturn(false);
+        PartnerReviewDecisionRequest request = new PartnerReviewDecisionRequest(
+                PartnerReviewDecisionRequest.PartnerReviewDecision.APPROVE, null, "pw");
+
+        assertThatThrownBy(() -> partnerReviewService.decide(REVIEW_ID, USER_ID, request, null))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.REVIEWER_CONFLICT_OF_INTEREST));
+        verify(evidence, never()).approve();
+    }
+
+    // issue #43 완료 조건 - 판정을 1회 상태 전이로 제한한다
+    @Test
+    void decide_whenAlreadyApproved_isBlockedFromDecidingAgain() {
+        when(evidence.getReviewStatus()).thenReturn(EvidenceReviewStatus.APPROVED);
+        PartnerReviewDecisionRequest request = new PartnerReviewDecisionRequest(
+                PartnerReviewDecisionRequest.PartnerReviewDecision.REJECT, "사유", "pw");
+
+        assertThatThrownBy(() -> partnerReviewService.decide(REVIEW_ID, USER_ID, request, null))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.EVIDENCE_ALREADY_DECIDED));
+        verify(evidence, never()).reject(any());
+    }
+
+    @Test
+    void decide_whenAlreadyRejected_isBlockedFromDecidingAgain() {
+        when(evidence.getReviewStatus()).thenReturn(EvidenceReviewStatus.REJECTED);
+        PartnerReviewDecisionRequest request = new PartnerReviewDecisionRequest(
+                PartnerReviewDecisionRequest.PartnerReviewDecision.APPROVE, null, "pw");
+
+        assertThatThrownBy(() -> partnerReviewService.decide(REVIEW_ID, USER_ID, request, null))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.EVIDENCE_ALREADY_DECIDED));
+        verify(evidence, never()).approve();
+    }
+
+    // 추가자료요청은 종결 상태가 아니므로, 그 이후에 다시 판정할 수 있어야 한다
+    @Test
+    void decide_whenAdditionalInfoRequested_canStillBeDecidedAgain() {
+        when(evidence.getReviewStatus()).thenReturn(EvidenceReviewStatus.ADDITIONAL_INFO_REQUESTED);
+        PartnerReviewDecisionRequest request = new PartnerReviewDecisionRequest(
+                PartnerReviewDecisionRequest.PartnerReviewDecision.APPROVE, null, "correct-pw");
+
+        partnerReviewService.decide(REVIEW_ID, USER_ID, request, null);
+
+        verify(evidence).approve();
     }
 
     @Test
     void decide_whenReauthFails_blocksTheDecisionAndRecordsTheFailure() {
-        when(releaseCase.getAssignedPartner()).thenReturn(reviewerPartner);
         doThrow(new CustomException(ErrorCode.REAUTH_FAILED))
                 .when(reauthGuard).verify(actor, "wrong-pw");
         PartnerReviewDecisionRequest request = new PartnerReviewDecisionRequest(
@@ -187,13 +246,12 @@ class PartnerReviewServiceTest {
     }
 
     @Test
-    void getFile_whenEvidenceAlreadyDeleted_isBlocked() {
+    void requestDownloadLink_whenEvidenceAlreadyDeleted_isBlocked() {
         when(evidence.getDeletedAt()).thenReturn(LocalDateTime.now());
 
-        assertThatThrownBy(() -> partnerReviewService.getFile(USER_ID, REVIEW_ID))
+        assertThatThrownBy(() -> partnerReviewService.requestDownloadLink(USER_ID, REVIEW_ID))
                 .isInstanceOfSatisfying(CustomException.class,
                         e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.EVIDENCE_ALREADY_DELETED));
-        verify(evidenceStorageClient, never()).load(any());
     }
 
     @Test
@@ -206,5 +264,81 @@ class PartnerReviewServiceTest {
                 .isInstanceOfSatisfying(CustomException.class,
                         e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.EVIDENCE_ALREADY_DELETED));
         verify(evidence, never()).approve();
+    }
+
+    // issue #43 - 원본은 발급받은 1회성 토큰으로만 내려받을 수 있고, 같은 토큰을 두 번 쓸 수 없다
+    @Test
+    void requestDownloadLink_issuesTokenForOrgMemberReviewer() {
+        EvidenceDownloadLinkResponse response = partnerReviewService.requestDownloadLink(USER_ID, REVIEW_ID);
+
+        assertThat(response.downloadToken()).isNotBlank();
+        assertThat(response.expiresAt()).isAfter(LocalDateTime.now());
+        verify(evidenceDownloadTokenRepository).save(any(EvidenceDownloadToken.class));
+    }
+
+    @Test
+    void requestDownloadLink_whenDifferentOrg_isBlocked() {
+        ExternalPartner otherPartner = mock(ExternalPartner.class);
+        when(otherPartner.getPartnerId()).thenReturn(OTHER_PARTNER_ID);
+        when(releaseCase.getAssignedPartner()).thenReturn(otherPartner);
+
+        assertThatThrownBy(() -> partnerReviewService.requestDownloadLink(USER_ID, REVIEW_ID))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.PARTNER_SCOPE_DENIED));
+        verify(evidenceDownloadTokenRepository, never()).save(any());
+    }
+
+    @Test
+    void downloadFile_whenTokenUnknown_throwsTokenInvalid() {
+        when(evidenceDownloadTokenRepository.findByTokenHash(any())).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> partnerReviewService.downloadFile(USER_ID, REVIEW_ID, "unknown-token"))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.TOKEN_INVALID));
+        verify(evidenceStorageClient, never()).load(any());
+    }
+
+    @Test
+    void downloadFile_whenTokenExpired_throwsAccessLinkExpired() {
+        EvidenceDownloadToken token = mock(EvidenceDownloadToken.class);
+        when(token.getEvidence()).thenReturn(evidence);
+        when(token.isExpired()).thenReturn(true);
+        when(evidenceDownloadTokenRepository.findByTokenHash(any())).thenReturn(Optional.of(token));
+
+        assertThatThrownBy(() -> partnerReviewService.downloadFile(USER_ID, REVIEW_ID, "expired-token"))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.ACCESS_LINK_EXPIRED));
+        verify(evidenceStorageClient, never()).load(any());
+    }
+
+    @Test
+    void downloadFile_whenTokenAlreadyUsed_throwsAccessLinkAlreadyUsed() {
+        EvidenceDownloadToken token = mock(EvidenceDownloadToken.class);
+        when(token.getEvidence()).thenReturn(evidence);
+        when(token.isExpired()).thenReturn(false);
+        when(evidenceDownloadTokenRepository.findByTokenHash(any())).thenReturn(Optional.of(token));
+        when(evidenceDownloadTokenRepository.markUsedIfUnused(any(), any())).thenReturn(0);
+
+        assertThatThrownBy(() -> partnerReviewService.downloadFile(USER_ID, REVIEW_ID, "used-token"))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.ACCESS_LINK_ALREADY_USED));
+        verify(evidenceStorageClient, never()).load(any());
+    }
+
+    @Test
+    void downloadFile_whenTokenValid_loadsFileAndRecordsAuditByActor() {
+        EvidenceDownloadToken token = mock(EvidenceDownloadToken.class);
+        when(token.getEvidence()).thenReturn(evidence);
+        when(token.isExpired()).thenReturn(false);
+        when(evidenceDownloadTokenRepository.findByTokenHash(any())).thenReturn(Optional.of(token));
+        when(evidenceDownloadTokenRepository.markUsedIfUnused(any(), any())).thenReturn(1);
+        when(evidence.getStorageKey()).thenReturn("storage/key");
+        byte[] bytes = {1, 2, 3};
+        when(evidenceStorageClient.load("storage/key")).thenReturn(bytes);
+
+        byte[] result = partnerReviewService.downloadFile(USER_ID, REVIEW_ID, "valid-token");
+
+        assertThat(result).isEqualTo(bytes);
+        verify(adminActionAuditService).record(actor, AdminActionType.EVIDENCE_DOWNLOAD, REVIEW_ID, true, null);
     }
 }


### PR DESCRIPTION
## 요약
외부 파트너가 소속 파트너사에 배정된 사건의 증빙만 조회·다운로드·판정할 수 있도록 접근 경계를 재점검합니다(경계는 조직 단위 - 개인별 사전 지정/목록 조회 UX는 별도 브랜치에서 다룹니다).

- 증빙 원본은 짧은 수명(5분)의 1회성 다운로드 토큰을 발급받아야만 내려받을 수 있음
- 판정(APPROVE/REJECT)은 1회 상태 전이로 제한 - 이미 완료된 판정은 다시 바꿀 수 없음
- decide() 시점에 검토자를 표시·감사 목적으로만 기록(접근 제어에는 사용하지 않음)
- 다운로드·판정 이력을 호출자(actor) 기준으로 감사 로그에 기록

## 테스트
298개 중 296개 통과. 나머지 2개(InputSizeConstraintTest/InputLimitHttpIntegrationTest)는 이번 변경과 무관한 기존 결함(multipart 크기 제한 플레이스홀더 미해석)입니다.

Closes #43