### PR TITLE
[Fix/#46]: 사건 생성 전 계획 준비도 검증기 추가 및 확인자 2명 독립 신고 강제

### DIFF
--- a/src/main/java/com/mamoki/ieojuda/domain/confirmer/service/DeathReportService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/confirmer/service/DeathReportService.java
@@ -8,9 +8,9 @@ import com.mamoki.ieojuda.domain.confirmer.entity.ReportStatus;
 import com.mamoki.ieojuda.domain.confirmer.repository.ConfirmerRepository;
 import com.mamoki.ieojuda.domain.plan.dto.PlanSnapshotDto;
 import com.mamoki.ieojuda.domain.plan.entity.Plan;
-import com.mamoki.ieojuda.domain.plan.entity.PlanStatus;
 import com.mamoki.ieojuda.domain.plan.entity.PlanVersion;
 import com.mamoki.ieojuda.domain.plan.repository.PlanVersionRepository;
+import com.mamoki.ieojuda.domain.plan.service.PlanReadinessValidator;
 import com.mamoki.ieojuda.domain.plan.service.PlanSnapshotService;
 import com.mamoki.ieojuda.domain.recipient.entity.AcceptanceStatus;
 import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCase;
@@ -26,7 +26,6 @@ import com.mamoki.ieojuda.global.exception.CustomException;
 import com.mamoki.ieojuda.global.exception.ErrorCode;
 import com.mamoki.ieojuda.global.idempotency.service.IdempotencyGuard;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,12 +34,10 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
-import java.util.Objects;
 
 // 명세서 "사망 신고 이메일" 화면 - 지정 확인자가 사망 사실을 신고한다 (로그인 불필요, REPORT_DEATH 토큰이 곧 인증).
 // issue #41 - 수락 시 발급된 ACCEPT_ROLE 토큰과는 별개인 REPORT_DEATH 전용 토큰만 여기서 받는다
 // (역할 수락 토큰이 사망 신고의 영구 접근키로 재사용되지 않도록).
-@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -57,6 +54,7 @@ public class DeathReportService {
     private final SecurityTokenService securityTokenService;
     private final EmailOutboxService emailOutboxService;
     private final AppProperties appProperties;
+    private final PlanReadinessValidator planReadinessValidator;
 
     @Transactional
     public DeathReportResponse report(String plainToken, DeathReportRequest request, String idempotencyKey) {
@@ -112,12 +110,10 @@ public class DeathReportService {
         emailOutboxService.enqueue(confirmer.getPlan(), null, EmailType.EVIDENCE_SUBMISSION_REQUEST, confirmer.getEmail(), content);
     }
 
-    // 둘 다 모르는 경우, 둘 다 같은 날짜인 경우, 한쪽만 모르는 경우는 모두 일치로 본다 - 날짜가 서로 다를 때만 불일치
+    // 둘 다 사망일을 명시했고 그 값이 같을 때만 일치로 본다.
+    // 하나라도 모르면(null)이거나 날짜가 다르면 불일치 처리 - 재확인/운영 검토로 전환한다.
     private boolean datesAgree(LocalDate a, LocalDate b) {
-        if (a == null || b == null) {
-            return true;
-        }
-        return Objects.equals(a, b);
+        return a != null && b != null && a.equals(b);
     }
 
     private ReleaseCase createReleaseCase(Plan plan) {
@@ -127,12 +123,9 @@ public class DeathReportService {
             throw new CustomException(ErrorCode.ACTIVE_RELEASE_CASE_EXISTS);
         }
 
-        // issue #81 - 작성자 봉인(Plan.status)과 사망 신고 시점 스냅샷 봉인(PlanVersion)은 독립적으로
-        // 유지한다(부록 결정 (a)). 작성자가 미리 검토·봉인하지 않았어도 발송 절차 자체는 막지 않되,
-        // 운영 가시성을 위해 남긴다.
-        if (plan.getStatus() != PlanStatus.SEALED) {
-            log.warn("[Plan Not Sealed] 작성자가 패키지를 봉인하지 않은 상태로 사후 사건이 열립니다. planId={}", plan.getPlanId());
-        }
+        // 준비되지 않았거나 비활성인 계획에서 사건이 시작되지 않도록, 사건 생성 직전 계획 준비도를
+        // 재검증한다 (봉인 이후에도 확인자 거절·항목 추가 등으로 상태가 바뀔 수 있어 독립적으로 확인).
+        planReadinessValidator.validate(plan);
 
         int nextVersionNum = (int) planVersionRepository.countByPlan_PlanId(plan.getPlanId()) + 1;
         PlanSnapshotDto snapshot = planSnapshotService.buildSnapshot(plan);

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/service/PlanReadinessValidator.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/service/PlanReadinessValidator.java
@@ -1,0 +1,68 @@
+package com.mamoki.ieojuda.domain.plan.service;
+
+import com.mamoki.ieojuda.domain.confirmer.repository.ConfirmerRepository;
+import com.mamoki.ieojuda.domain.confirmer.repository.DisputeContactRepository;
+import com.mamoki.ieojuda.domain.plan.entity.Item;
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.plan.entity.PlanStatus;
+import com.mamoki.ieojuda.domain.plan.repository.ItemRepository;
+import com.mamoki.ieojuda.domain.recipient.entity.AcceptanceStatus;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+// 사망 사건(ReleaseCase) 생성 직전에 계획이 실제로 준비된 상태인지 재검증한다.
+// PlanPackageService.seal()의 봉인 시점 검사와는 별개다 - 봉인 이후에도 확인자 거절, 항목 추가 등으로
+// 계획 상태가 바뀔 수 있으므로 사건 생성 시점에 독립적으로 다시 확인해야 한다.
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PlanReadinessValidator {
+
+    private final ConfirmerRepository confirmerRepository;
+    private final ItemRepository itemRepository;
+    private final DisputeContactRepository disputeContactRepository;
+
+    public void validate(Plan plan) {
+        if (plan.getStatus() != PlanStatus.SEALED) {
+            throw new CustomException(ErrorCode.PLAN_NOT_READY);
+        }
+        if (plan.getWaitingDays() == null) {
+            throw new CustomException(ErrorCode.WAITING_PERIOD_NOT_SET);
+        }
+        if (!Boolean.TRUE.equals(plan.getSelfWarningEmailVerified())) {
+            throw new CustomException(ErrorCode.SELF_WARNING_EMAIL_NOT_VERIFIED);
+        }
+
+        boolean hasVerifiedDisputeContact = disputeContactRepository
+                .findFirstByPlan_PlanIdOrderByContactIdDesc(plan.getPlanId())
+                .filter(contact -> Boolean.TRUE.equals(contact.getIsVerified()))
+                .isPresent();
+        if (!hasVerifiedDisputeContact) {
+            throw new CustomException(ErrorCode.DISPUTE_CONTACT_NOT_VERIFIED);
+        }
+
+        List<Item> items = itemRepository.findByLifeArea_Plan_PlanIdOrderBySortOrderAscItemIdAsc(plan.getPlanId());
+        boolean hasUnassignedItem = items.stream().anyMatch(item -> item.getRecipient() == null);
+        if (hasUnassignedItem) {
+            throw new CustomException(ErrorCode.ITEM_ASSIGNEE_MISSING);
+        }
+
+        if (plan.getOrderConfirmedAt() == null) {
+            throw new CustomException(ErrorCode.ORDER_NOT_CONFIRMED);
+        }
+
+        long distinctAcceptedConfirmers = confirmerRepository.findByPlan_PlanIdOrderByConfirmIdAsc(plan.getPlanId()).stream()
+                .filter(confirmer -> confirmer.getAcceptanceStatus() == AcceptanceStatus.ACCEPTED)
+                .map(confirmer -> confirmer.getEmail().trim().toLowerCase())
+                .distinct()
+                .count();
+        if (distinctAcceptedConfirmers < 2) {
+            throw new CustomException(ErrorCode.INSUFFICIENT_CONFIRMERS);
+        }
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/global/email/outbox/EmailOutboxRepository.java
+++ b/src/main/java/com/mamoki/ieojuda/global/email/outbox/EmailOutboxRepository.java
@@ -1,7 +1,9 @@
 package com.mamoki.ieojuda.global.email.outbox;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.UUID;
 import java.util.List;
@@ -17,4 +19,10 @@ public interface EmailOutboxRepository extends JpaRepository<EmailOutbox, UUID> 
             "LIMIT 100 " +
             "FOR UPDATE SKIP LOCKED", nativeQuery = true)
     List<EmailOutbox> findPendingForUpdateSkipLocked();
+
+    // 테스트 정리용 - EmailLog 삭제 전, 그 로그를 참조하는 아웃박스 행을 먼저 지운다. body가 @Lob이라
+    // find+delete로 엔티티를 로드하면 별도 트랜잭션에서 lob stream에 접근할 수 없어 실패하므로 벌크 삭제로 처리한다.
+    @Modifying
+    @Query("DELETE FROM EmailOutbox eo WHERE eo.emailLog.logId = :logId")
+    void deleteByEmailLog_LogId(@Param("logId") UUID logId);
 }

--- a/src/main/java/com/mamoki/ieojuda/global/exception/ErrorCode.java
+++ b/src/main/java/com/mamoki/ieojuda/global/exception/ErrorCode.java
@@ -23,12 +23,16 @@ public enum ErrorCode {
     PACKAGE_SEAL_BLOCKED(HttpStatus.BAD_REQUEST, "PACKAGE_SEAL_BLOCKED", "금지 정보나 근거 없는 항목이 있어 패키지를 봉인할 수 없습니다."),
     CIRCULAR_DEPENDENCY_DETECTED(HttpStatus.BAD_REQUEST, "CIRCULAR_DEPENDENCY_DETECTED", "발송 단계에 순환 의존 관계가 존재합니다."),
     PLAN_NOT_SEALED(HttpStatus.BAD_REQUEST, "PLAN_NOT_SEALED", "봉인된 계획만 인계 점검을 보낼 수 있습니다."),
+    PLAN_NOT_READY(HttpStatus.BAD_REQUEST, "PLAN_NOT_READY", "준비(봉인)되지 않았거나 비활성화된 계획에서는 사후 사건을 생성할 수 없습니다."),
+    WAITING_PERIOD_NOT_SET(HttpStatus.BAD_REQUEST, "WAITING_PERIOD_NOT_SET", "대기 기간이 설정되지 않아 사후 사건을 생성할 수 없습니다."),
+    SELF_WARNING_EMAIL_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "SELF_WARNING_EMAIL_NOT_VERIFIED", "본인 경고 이메일 인증이 완료되지 않아 사후 사건을 생성할 수 없습니다."),
 
     // 담당자 / 확인자 / 이의 제기 연락처 관련 예외 (400)
     INSUFFICIENT_CONFIRMERS(HttpStatus.BAD_REQUEST, "INSUFFICIENT_CONFIRMERS", "수락을 완료한 지정 확인자가 2명 미만이라 계획을 봉인할 수 없습니다."),
     RECIPIENT_NOT_ACCEPTED(HttpStatus.BAD_REQUEST, "RECIPIENT_NOT_ACCEPTED", "역할을 수락하지 않은 담당자는 발송 단계에 포함할 수 없습니다."),
     FALLBACK_RECIPIENT_MISSING(HttpStatus.BAD_REQUEST, "FALLBACK_RECIPIENT_MISSING", "대체 담당자가 없어 다음 단계를 진행할 수 없습니다."),
     DISPUTE_CONTACT_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "DISPUTE_CONTACT_NOT_VERIFIED", "이메일 인증이 완료되지 않은 이의 제기 연락처는 활성화할 수 없습니다."),
+    ITEM_ASSIGNEE_MISSING(HttpStatus.BAD_REQUEST, "ITEM_ASSIGNEE_MISSING", "담당자가 지정되지 않은 항목이 있어 사후 사건을 생성할 수 없습니다."),
 
     // 사망 신고 / 증빙 관련 예외 (400)
     DEATH_REPORT_MISMATCH(HttpStatus.BAD_REQUEST, "DEATH_REPORT_MISMATCH", "두 확인자의 신고 내용이 일치하지 않아 절차를 중지합니다."),

--- a/src/test/java/com/mamoki/ieojuda/domain/confirmer/service/DeathReportReadinessIntegrationTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/confirmer/service/DeathReportReadinessIntegrationTest.java
@@ -1,0 +1,298 @@
+package com.mamoki.ieojuda.domain.confirmer.service;
+
+import com.mamoki.ieojuda.domain.account.entity.User;
+import com.mamoki.ieojuda.domain.account.repository.UserRepository;
+import com.mamoki.ieojuda.domain.audit.entity.EmailLog;
+import com.mamoki.ieojuda.domain.audit.repository.EmailLogRepository;
+import com.mamoki.ieojuda.domain.confirmer.dto.DeathReportRequest;
+import com.mamoki.ieojuda.domain.confirmer.entity.Confirmer;
+import com.mamoki.ieojuda.domain.confirmer.entity.DisputeContact;
+import com.mamoki.ieojuda.domain.confirmer.entity.Relationship;
+import com.mamoki.ieojuda.domain.confirmer.repository.ConfirmerRepository;
+import com.mamoki.ieojuda.domain.confirmer.repository.DisputeContactRepository;
+import com.mamoki.ieojuda.domain.plan.entity.Conversation;
+import com.mamoki.ieojuda.domain.plan.entity.DisclosureScope;
+import com.mamoki.ieojuda.domain.plan.entity.Item;
+import com.mamoki.ieojuda.domain.plan.entity.ItemActionType;
+import com.mamoki.ieojuda.domain.plan.entity.LifeArea;
+import com.mamoki.ieojuda.domain.plan.entity.LifeAreaCategory;
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.plan.repository.ConversationRepository;
+import com.mamoki.ieojuda.domain.plan.repository.ItemRepository;
+import com.mamoki.ieojuda.domain.plan.repository.LifeAreaRepository;
+import com.mamoki.ieojuda.domain.plan.repository.PlanRepository;
+import com.mamoki.ieojuda.domain.plan.repository.PlanVersionRepository;
+import com.mamoki.ieojuda.domain.plan.service.PlanReadinessValidator;
+import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
+import com.mamoki.ieojuda.domain.recipient.entity.RoleType;
+import com.mamoki.ieojuda.domain.recipient.repository.RecipientRepository;
+import com.mamoki.ieojuda.domain.releasecase.repository.ReleaseCaseRepository;
+import com.mamoki.ieojuda.domain.securitytoken.entity.SecurityTokenPurpose;
+import com.mamoki.ieojuda.domain.securitytoken.repository.SecurityTokenRepository;
+import com.mamoki.ieojuda.domain.securitytoken.service.SecurityTokenService;
+import com.mamoki.ieojuda.global.email.outbox.EmailOutbox;
+import com.mamoki.ieojuda.global.email.outbox.EmailOutboxRepository;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+// 계획 준비도 게이트 - 실제 스프링 컨텍스트와 DB에 대해 리포지토리 파생 쿼리(이의 연락처 최신 1건,
+// 담당자 없는 항목 존재 여부 등)가 실제로 의도대로 동작하는지, 그리고 DeathReportService 경로 전체에서
+// 준비되지 않은 계획의 사건 생성이 실제로 막히는지 검증한다. 조건별 분기 로직 자체는
+// PlanReadinessValidatorTest(단위 테스트)에서 이미 촘촘히 검증했으므로, 여기서는 DB 연동이 필요한
+// 대표 경로만 다룬다.
+@SpringBootTest
+class DeathReportReadinessIntegrationTest {
+
+    private static final LocalDate REPORTED_DEATH_DATE = LocalDate.of(2026, 8, 15);
+
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private PlanRepository planRepository;
+    @Autowired
+    private ConversationRepository conversationRepository;
+    @Autowired
+    private LifeAreaRepository lifeAreaRepository;
+    @Autowired
+    private RecipientRepository recipientRepository;
+    @Autowired
+    private ItemRepository itemRepository;
+    @Autowired
+    private ConfirmerRepository confirmerRepository;
+    @Autowired
+    private DisputeContactRepository disputeContactRepository;
+    @Autowired
+    private ReleaseCaseRepository releaseCaseRepository;
+    @Autowired
+    private PlanVersionRepository planVersionRepository;
+    @Autowired
+    private SecurityTokenRepository securityTokenRepository;
+    @Autowired
+    private SecurityTokenService securityTokenService;
+    @Autowired
+    private EmailLogRepository emailLogRepository;
+    @Autowired
+    private EmailOutboxRepository emailOutboxRepository;
+    @Autowired
+    private PlanReadinessValidator planReadinessValidator;
+    @Autowired
+    private DeathReportService deathReportService;
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    private User user;
+    private Plan plan;
+    private Conversation conversation;
+    private LifeArea lifeArea;
+    private Recipient recipient;
+    private Item item;
+    private Confirmer confirmerA;
+    private Confirmer confirmerB;
+    private DisputeContact disputeContact;
+
+    // 이의 연락처 인증·대기 기간·본인 경고 이메일 인증·실행 순서 확정·수락 확인자 2명까지 전부 충족한
+    // 계획을 만든다. sealed=false로 호출하면 "봉인"이라는 조건 하나만 깨진 상태를 재현할 수 있다.
+    private void createFixture(boolean sealed) {
+        user = userRepository.saveAndFlush(User.builder()
+                .email("readiness-" + UUID.randomUUID() + "@test.com").password("hash").name("김철수").build());
+        plan = planRepository.saveAndFlush(Plan.builder().user(user).build());
+        conversation = conversationRepository.saveAndFlush(Conversation.builder().plan(plan).build());
+        lifeArea = lifeAreaRepository.saveAndFlush(
+                LifeArea.builder().plan(plan).conversation(conversation).category(LifeAreaCategory.RELATIONSHIP_CLEANUP).build());
+        recipient = recipientRepository.saveAndFlush(Recipient.builder()
+                .plan(plan).lifeArea(lifeArea).name("이지수").email("recipient-" + UUID.randomUUID() + "@test.com")
+                .roleType(RoleType.RELATIONSHIP_MANAGER).isBackup(false)
+                .disclosureScope(DisclosureScope.RELATIONSHIP).maxWaitHours(168).backupFor(null).build());
+        item = Item.builder()
+                .lifeArea(lifeArea).targetName("이지수").locationType("인스타그램").action("정리해줘")
+                .title("SNS 정리").content("비공개로 전환").precondition("")
+                .disclosureScope(DisclosureScope.RELATIONSHIP).sourceExcerpt("근거 발췌")
+                .sortOrder(0).actionType(ItemActionType.DELETE).build();
+        item.assignRecipient(recipient);
+        item = itemRepository.saveAndFlush(item);
+
+        confirmerA = Confirmer.builder().plan(plan).name("A").relationship(Relationship.FRIEND)
+                .email("confirmer-a-" + UUID.randomUUID() + "@test.com").build();
+        confirmerA.accept(null);
+        confirmerA = confirmerRepository.saveAndFlush(confirmerA);
+        confirmerB = Confirmer.builder().plan(plan).name("B").relationship(Relationship.FRIEND)
+                .email("confirmer-b-" + UUID.randomUUID() + "@test.com").build();
+        confirmerB.accept(null);
+        confirmerB = confirmerRepository.saveAndFlush(confirmerB);
+
+        disputeContact = DisputeContact.builder().plan(plan)
+                .email("dispute-" + UUID.randomUUID() + "@test.com").name("이의연락처").build();
+        disputeContact.verify();
+        disputeContact = disputeContactRepository.saveAndFlush(disputeContact);
+
+        plan.updateWaitingDays(14);
+        plan.requestSelfWarningEmailVerification("warn-" + UUID.randomUUID() + "@test.com", "hash", LocalDateTime.now().plusDays(1));
+        plan.verifySelfWarningEmail();
+        plan.confirmOrder();
+        if (sealed) {
+            plan.seal();
+        }
+        plan = planRepository.saveAndFlush(plan);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (plan == null) {
+            return;
+        }
+        releaseCaseRepository.findByPlan_PlanId(plan.getPlanId()).forEach(releaseCase -> {
+            new TransactionTemplate(transactionManager).executeWithoutResult(
+                    status -> securityTokenRepository.deleteByReleaseCase_CaseId(releaseCase.getCaseId()));
+            releaseCaseRepository.delete(releaseCase);
+        });
+        planVersionRepository.findByPlan_PlanId(plan.getPlanId()).forEach(planVersionRepository::delete);
+        new TransactionTemplate(transactionManager).executeWithoutResult(status -> {
+            securityTokenRepository.deleteByConfirmer_ConfirmId(confirmerA.getConfirmId());
+            securityTokenRepository.deleteByConfirmer_ConfirmId(confirmerB.getConfirmId());
+        });
+        confirmerRepository.delete(confirmerA);
+        confirmerRepository.delete(confirmerB);
+        if (disputeContact != null) {
+            disputeContactRepository.delete(disputeContact);
+        }
+        // 증빙 제출 안내 메일(사건 매칭 시 발송)이 남긴 email_outbox/email_logs 행을 plans FK보다 먼저 지운다
+        for (EmailLog emailLog : emailLogRepository.findByPlan_PlanIdOrderByRequestedAtDesc(plan.getPlanId())) {
+            new TransactionTemplate(transactionManager).executeWithoutResult(
+                    status -> emailOutboxRepository.deleteByEmailLog_LogId(emailLog.getLogId()));
+            emailLogRepository.delete(emailLog);
+        }
+        itemRepository.delete(item);
+        recipientRepository.delete(recipient);
+        lifeAreaRepository.delete(lifeArea);
+        conversationRepository.delete(conversation);
+        planRepository.delete(plan);
+        userRepository.delete(user);
+    }
+
+    @Test
+    void validate_whenAllConditionsMet_doesNotThrow() {
+        createFixture(true);
+
+        assertThatCode(() -> planReadinessValidator.validate(plan)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void validate_whenNoDisputeContactExistsInDatabase_throwsDisputeContactNotVerified() {
+        createFixture(true);
+        disputeContactRepository.delete(disputeContact);
+        disputeContact = null;
+
+        assertThatThrownBy(() -> planReadinessValidator.validate(plan))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.DISPUTE_CONTACT_NOT_VERIFIED);
+    }
+
+    @Test
+    void validate_whenItemInDatabaseHasNoAssignee_throwsItemAssigneeMissing() {
+        createFixture(true);
+        item.assignRecipient(null);
+        item = itemRepository.saveAndFlush(item);
+
+        assertThatThrownBy(() -> planReadinessValidator.validate(plan))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.ITEM_ASSIGNEE_MISSING);
+    }
+
+    @Test
+    void validate_whenPlanInDatabaseIsDeactivated_throwsPlanNotReady() {
+        createFixture(true);
+        plan.deactivate();
+        plan = planRepository.saveAndFlush(plan);
+
+        assertThatThrownBy(() -> planReadinessValidator.validate(plan))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.PLAN_NOT_READY);
+    }
+
+    @Test
+    void validate_whenWaitingDaysNotSetInDatabase_throwsWaitingPeriodNotSet() {
+        createFixture(true);
+        plan.updateWaitingDays(null);
+        plan = planRepository.saveAndFlush(plan);
+
+        assertThatThrownBy(() -> planReadinessValidator.validate(plan))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.WAITING_PERIOD_NOT_SET);
+    }
+
+    @Test
+    void validate_whenSelfWarningEmailNotVerifiedInDatabase_throwsSelfWarningEmailNotVerified() {
+        createFixture(true);
+        plan.invalidateSelfWarningEmailVerification();
+        plan = planRepository.saveAndFlush(plan);
+
+        assertThatThrownBy(() -> planReadinessValidator.validate(plan))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.SELF_WARNING_EMAIL_NOT_VERIFIED);
+    }
+
+    @Test
+    void validate_whenOrderNotConfirmedInDatabase_throwsOrderNotConfirmed() {
+        createFixture(true);
+        plan.resetOrderConfirmation();
+        plan = planRepository.saveAndFlush(plan);
+
+        assertThatThrownBy(() -> planReadinessValidator.validate(plan))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.ORDER_NOT_CONFIRMED);
+    }
+
+    @Test
+    void report_whenPlanIsNotSealed_blocksReleaseCaseCreationEvenWhenReportsMatch() {
+        createFixture(false); // 준비도 조건 중 "봉인"만 깨뜨리고 나머지는 전부 충족시킨다
+
+        String tokenA = securityTokenService.issueForConfirmer(
+                SecurityTokenPurpose.REPORT_DEATH, confirmerA, null, LocalDateTime.now().plusDays(1));
+        String tokenB = securityTokenService.issueForConfirmer(
+                SecurityTokenPurpose.REPORT_DEATH, confirmerB, null, LocalDateTime.now().plusDays(1));
+
+        deathReportService.report(tokenA, new DeathReportRequest(REPORTED_DEATH_DATE), null);
+
+        assertThatThrownBy(() -> deathReportService.report(tokenB, new DeathReportRequest(REPORTED_DEATH_DATE), null))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.PLAN_NOT_READY);
+
+        assertThat(releaseCaseRepository.findByPlan_PlanId(plan.getPlanId())).isEmpty();
+    }
+
+    @Test
+    void report_whenAllReadinessConditionsMet_createsReleaseCase() {
+        createFixture(true);
+
+        String tokenA = securityTokenService.issueForConfirmer(
+                SecurityTokenPurpose.REPORT_DEATH, confirmerA, null, LocalDateTime.now().plusDays(1));
+        String tokenB = securityTokenService.issueForConfirmer(
+                SecurityTokenPurpose.REPORT_DEATH, confirmerB, null, LocalDateTime.now().plusDays(1));
+
+        deathReportService.report(tokenA, new DeathReportRequest(REPORTED_DEATH_DATE), null);
+        deathReportService.report(tokenB, new DeathReportRequest(REPORTED_DEATH_DATE), null);
+
+        assertThat(releaseCaseRepository.findByPlan_PlanId(plan.getPlanId())).hasSize(1);
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/domain/confirmer/service/DeathReportServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/confirmer/service/DeathReportServiceTest.java
@@ -2,13 +2,18 @@ package com.mamoki.ieojuda.domain.confirmer.service;
 
 import com.mamoki.ieojuda.domain.confirmer.dto.DeathReportRequest;
 import com.mamoki.ieojuda.domain.confirmer.entity.Confirmer;
+import com.mamoki.ieojuda.domain.confirmer.entity.DisputeContact;
 import com.mamoki.ieojuda.domain.confirmer.entity.Relationship;
 import com.mamoki.ieojuda.domain.confirmer.entity.ReportStatus;
 import com.mamoki.ieojuda.domain.confirmer.repository.ConfirmerRepository;
+import com.mamoki.ieojuda.domain.confirmer.repository.DisputeContactRepository;
 import com.mamoki.ieojuda.domain.plan.dto.PlanSnapshotDto;
 import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.plan.entity.PlanStatus;
 import com.mamoki.ieojuda.domain.plan.entity.PlanVersion;
+import com.mamoki.ieojuda.domain.plan.repository.ItemRepository;
 import com.mamoki.ieojuda.domain.plan.repository.PlanVersionRepository;
+import com.mamoki.ieojuda.domain.plan.service.PlanReadinessValidator;
 import com.mamoki.ieojuda.domain.plan.service.PlanSnapshotService;
 import com.mamoki.ieojuda.domain.releasecase.repository.ReleaseCaseRepository;
 import com.mamoki.ieojuda.domain.securitytoken.entity.SecurityToken;
@@ -16,20 +21,26 @@ import com.mamoki.ieojuda.domain.securitytoken.entity.SecurityTokenPurpose;
 import com.mamoki.ieojuda.domain.securitytoken.service.SecurityTokenService;
 import com.mamoki.ieojuda.global.config.AppProperties;
 import com.mamoki.ieojuda.global.email.outbox.EmailOutboxService;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
 import com.mamoki.ieojuda.global.idempotency.service.IdempotencyGuard;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -47,6 +58,7 @@ class DeathReportServiceTest {
     private SecurityTokenService securityTokenService;
     private EmailOutboxService emailOutboxService;
     private AppProperties appProperties;
+    private PlanReadinessValidator planReadinessValidator;
     private DeathReportService deathReportService;
 
     @BeforeEach
@@ -59,12 +71,20 @@ class DeathReportServiceTest {
         securityTokenService = mock(SecurityTokenService.class);
         emailOutboxService = mock(EmailOutboxService.class);
         appProperties = mock(AppProperties.class);
+        planReadinessValidator = mock(PlanReadinessValidator.class);
         deathReportService = new DeathReportService(
                 confirmerRepository, releaseCaseRepository, planVersionRepository,
-                planSnapshotService, idempotencyGuard, securityTokenService, emailOutboxService, appProperties);
+                planSnapshotService, idempotencyGuard, securityTokenService, emailOutboxService, appProperties,
+                planReadinessValidator);
 
         when(appProperties.getBaseUrl()).thenReturn("https://ieoduda.example.com");
         when(appProperties.getContactEmail()).thenReturn("support@ieoduda.example.com");
+    }
+
+    private Confirmer confirmerAcceptedOn(Plan plan, String name, String email) {
+        Confirmer confirmer = Confirmer.builder().plan(plan).name(name).relationship(Relationship.FRIEND).email(email).build();
+        confirmer.accept(null);
+        return confirmer;
     }
 
     @Test
@@ -72,16 +92,14 @@ class DeathReportServiceTest {
         Plan plan = mock(Plan.class);
         when(plan.getPlanId()).thenReturn(PLAN_ID);
 
-        Confirmer reporting = Confirmer.builder().plan(plan).name("A").relationship(Relationship.FRIEND).email("a@test.com").build();
-        reporting.accept(null);
+        Confirmer reporting = confirmerAcceptedOn(plan, "A", "a@test.com");
         SecurityToken reportDeathToken = mock(SecurityToken.class);
         when(reportDeathToken.getConfirmer()).thenReturn(reporting);
         when(securityTokenService.resolve(eq("token-a"), eq(SecurityTokenPurpose.REPORT_DEATH))).thenReturn(reportDeathToken);
         when(securityTokenService.issueForConfirmer(eq(SecurityTokenPurpose.UPLOAD_EVIDENCE), any(), any(), any()))
                 .thenReturn("evidence-token");
 
-        Confirmer sibling = Confirmer.builder().plan(plan).name("B").relationship(Relationship.FRIEND).email("b@test.com").build();
-        sibling.accept(null);
+        Confirmer sibling = confirmerAcceptedOn(plan, "B", "b@test.com");
         sibling.report(LocalDate.of(2026, 8, 15)); // 이미 먼저 신고해서 REPORTED 상태
         when(confirmerRepository.findByPlan_PlanIdAndConfirmIdNotAndReportStatus(PLAN_ID, null, ReportStatus.REPORTED))
                 .thenReturn(List.of(sibling));
@@ -112,5 +130,150 @@ class DeathReportServiceTest {
 
         assertThat(reporting.getReportStatus()).isEqualTo(ReportStatus.MATCHED);
         assertThat(sibling.getReportStatus()).isEqualTo(ReportStatus.MATCHED);
+    }
+
+    // 정책 변경 회귀 테스트 - 한쪽만 사망일을 모르는 경우 더 이상 자동 일치로 처리하지 않는다
+    @Test
+    void report_whenOnlyOneConfirmerKnowsDeathDate_marksBothMismatchedWithoutCreatingCase() {
+        Plan plan = mock(Plan.class);
+        when(plan.getPlanId()).thenReturn(PLAN_ID);
+
+        Confirmer reporting = confirmerAcceptedOn(plan, "A", "a@test.com");
+        SecurityToken reportDeathToken = mock(SecurityToken.class);
+        when(reportDeathToken.getConfirmer()).thenReturn(reporting);
+        when(securityTokenService.resolve(eq("token-a"), eq(SecurityTokenPurpose.REPORT_DEATH))).thenReturn(reportDeathToken);
+
+        Confirmer sibling = confirmerAcceptedOn(plan, "B", "b@test.com");
+        sibling.report(LocalDate.of(2026, 8, 15)); // 날짜를 알고 먼저 신고
+        when(confirmerRepository.findByPlan_PlanIdAndConfirmIdNotAndReportStatus(PLAN_ID, null, ReportStatus.REPORTED))
+                .thenReturn(List.of(sibling));
+
+        deathReportService.report("token-a", new DeathReportRequest(null), null); // 사망일을 모른 채 신고
+
+        assertThat(reporting.getReportStatus()).isEqualTo(ReportStatus.MISMATCHED);
+        assertThat(sibling.getReportStatus()).isEqualTo(ReportStatus.MISMATCHED);
+        verify(releaseCaseRepository, never()).saveAndFlush(any());
+    }
+
+    // 정책 변경 회귀 테스트 - 둘 다 사망일을 모르는 경우도 더 이상 자동 일치로 처리하지 않는다
+    @Test
+    void report_whenBothConfirmersDoNotKnowDeathDate_marksBothMismatchedWithoutCreatingCase() {
+        Plan plan = mock(Plan.class);
+        when(plan.getPlanId()).thenReturn(PLAN_ID);
+
+        Confirmer reporting = confirmerAcceptedOn(plan, "A", "a@test.com");
+        SecurityToken reportDeathToken = mock(SecurityToken.class);
+        when(reportDeathToken.getConfirmer()).thenReturn(reporting);
+        when(securityTokenService.resolve(eq("token-a"), eq(SecurityTokenPurpose.REPORT_DEATH))).thenReturn(reportDeathToken);
+
+        Confirmer sibling = confirmerAcceptedOn(plan, "B", "b@test.com");
+        sibling.report(null); // 사망일을 모른 채 먼저 신고
+        when(confirmerRepository.findByPlan_PlanIdAndConfirmIdNotAndReportStatus(PLAN_ID, null, ReportStatus.REPORTED))
+                .thenReturn(List.of(sibling));
+
+        deathReportService.report("token-a", new DeathReportRequest(null), null);
+
+        assertThat(reporting.getReportStatus()).isEqualTo(ReportStatus.MISMATCHED);
+        assertThat(sibling.getReportStatus()).isEqualTo(ReportStatus.MISMATCHED);
+        verify(releaseCaseRepository, never()).saveAndFlush(any());
+    }
+
+    // 둘 다 사망일을 명시했지만 서로 다른 고전적 불일치 케이스
+    @Test
+    void report_whenConfirmersReportDifferentDeathDates_marksBothMismatchedWithoutCreatingCase() {
+        Plan plan = mock(Plan.class);
+        when(plan.getPlanId()).thenReturn(PLAN_ID);
+
+        Confirmer reporting = confirmerAcceptedOn(plan, "A", "a@test.com");
+        SecurityToken reportDeathToken = mock(SecurityToken.class);
+        when(reportDeathToken.getConfirmer()).thenReturn(reporting);
+        when(securityTokenService.resolve(eq("token-a"), eq(SecurityTokenPurpose.REPORT_DEATH))).thenReturn(reportDeathToken);
+
+        Confirmer sibling = confirmerAcceptedOn(plan, "B", "b@test.com");
+        sibling.report(LocalDate.of(2026, 8, 15));
+        when(confirmerRepository.findByPlan_PlanIdAndConfirmIdNotAndReportStatus(PLAN_ID, null, ReportStatus.REPORTED))
+                .thenReturn(List.of(sibling));
+
+        deathReportService.report("token-a", new DeathReportRequest(LocalDate.of(2026, 8, 16)), null);
+
+        assertThat(reporting.getReportStatus()).isEqualTo(ReportStatus.MISMATCHED);
+        assertThat(sibling.getReportStatus()).isEqualTo(ReportStatus.MISMATCHED);
+        verify(releaseCaseRepository, never()).saveAndFlush(any());
+    }
+
+    // 준비도 검증 실패 시 두 신고가 일치하더라도 사건이 생성되지 않아야 한다
+    @Test
+    void report_whenPlanNotReady_propagatesExceptionWithoutCreatingCase() {
+        Plan plan = mock(Plan.class);
+        when(plan.getPlanId()).thenReturn(PLAN_ID);
+
+        Confirmer reporting = confirmerAcceptedOn(plan, "A", "a@test.com");
+        SecurityToken reportDeathToken = mock(SecurityToken.class);
+        when(reportDeathToken.getConfirmer()).thenReturn(reporting);
+        when(securityTokenService.resolve(eq("token-a"), eq(SecurityTokenPurpose.REPORT_DEATH))).thenReturn(reportDeathToken);
+
+        Confirmer sibling = confirmerAcceptedOn(plan, "B", "b@test.com");
+        sibling.report(LocalDate.of(2026, 8, 15));
+        when(confirmerRepository.findByPlan_PlanIdAndConfirmIdNotAndReportStatus(PLAN_ID, null, ReportStatus.REPORTED))
+                .thenReturn(List.of(sibling));
+
+        when(releaseCaseRepository.findFirstByPlan_PlanIdOrderByCaseIdDesc(PLAN_ID)).thenReturn(Optional.empty());
+        doThrow(new CustomException(ErrorCode.PLAN_NOT_READY)).when(planReadinessValidator).validate(plan);
+
+        assertThatThrownBy(() ->
+                deathReportService.report("token-a", new DeathReportRequest(LocalDate.of(2026, 8, 15)), null))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.PLAN_NOT_READY);
+
+        verify(releaseCaseRepository, never()).saveAndFlush(any());
+    }
+
+    // 검증기를 목이 아닌 실제 구현으로 붙여, "정규화 이메일 기준 서로 다른 확인자 2명 미만"이라는
+    // INSUFFICIENT_CONFIRMERS 경로가 report() 레벨에서 실제로 사건 생성을 막는지 직접 재현한다.
+    @Test
+    void report_whenFewerThanTwoDistinctAcceptedConfirmers_throwsInsufficientConfirmersWithoutCreatingCase() {
+        ConfirmerRepository readinessConfirmerRepository = mock(ConfirmerRepository.class);
+        ItemRepository itemRepository = mock(ItemRepository.class);
+        DisputeContactRepository disputeContactRepository = mock(DisputeContactRepository.class);
+        PlanReadinessValidator realValidator =
+                new PlanReadinessValidator(readinessConfirmerRepository, itemRepository, disputeContactRepository);
+        deathReportService = new DeathReportService(
+                confirmerRepository, releaseCaseRepository, planVersionRepository,
+                planSnapshotService, idempotencyGuard, securityTokenService, emailOutboxService, appProperties,
+                realValidator);
+
+        Plan plan = mock(Plan.class);
+        when(plan.getPlanId()).thenReturn(PLAN_ID);
+        when(plan.getStatus()).thenReturn(PlanStatus.SEALED);
+        when(plan.getWaitingDays()).thenReturn(14);
+        when(plan.getSelfWarningEmailVerified()).thenReturn(true);
+        when(plan.getOrderConfirmedAt()).thenReturn(LocalDateTime.now());
+
+        Confirmer reporting = confirmerAcceptedOn(plan, "A", "same@test.com");
+        SecurityToken reportDeathToken = mock(SecurityToken.class);
+        when(reportDeathToken.getConfirmer()).thenReturn(reporting);
+        when(securityTokenService.resolve(eq("token-a"), eq(SecurityTokenPurpose.REPORT_DEATH))).thenReturn(reportDeathToken);
+
+        Confirmer sibling = confirmerAcceptedOn(plan, "B", "SAME@test.com"); // 정규화하면 reporting과 같은 이메일
+        sibling.report(LocalDate.of(2026, 8, 15));
+        when(confirmerRepository.findByPlan_PlanIdAndConfirmIdNotAndReportStatus(PLAN_ID, null, ReportStatus.REPORTED))
+                .thenReturn(List.of(sibling));
+
+        when(releaseCaseRepository.findFirstByPlan_PlanIdOrderByCaseIdDesc(PLAN_ID)).thenReturn(Optional.empty());
+        DisputeContact verifiedContact = DisputeContact.builder().plan(mock(Plan.class)).email("dispute@test.com").name("이의").build();
+        verifiedContact.verify();
+        when(disputeContactRepository.findFirstByPlan_PlanIdOrderByContactIdDesc(PLAN_ID)).thenReturn(Optional.of(verifiedContact));
+        when(itemRepository.findByLifeArea_Plan_PlanIdOrderBySortOrderAscItemIdAsc(PLAN_ID)).thenReturn(List.of());
+        // "정규화하면 같은 이메일"인 두 확인자만 존재 - distinct 기준으로는 1명뿐이라 INSUFFICIENT_CONFIRMERS여야 한다
+        when(readinessConfirmerRepository.findByPlan_PlanIdOrderByConfirmIdAsc(PLAN_ID)).thenReturn(List.of(reporting, sibling));
+
+        assertThatThrownBy(() ->
+                deathReportService.report("token-a", new DeathReportRequest(LocalDate.of(2026, 8, 15)), null))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INSUFFICIENT_CONFIRMERS);
+
+        verify(releaseCaseRepository, never()).saveAndFlush(any());
     }
 }

--- a/src/test/java/com/mamoki/ieojuda/domain/plan/service/PlanReadinessValidatorTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/plan/service/PlanReadinessValidatorTest.java
@@ -1,0 +1,216 @@
+package com.mamoki.ieojuda.domain.plan.service;
+
+import com.mamoki.ieojuda.domain.confirmer.entity.Confirmer;
+import com.mamoki.ieojuda.domain.confirmer.entity.DisputeContact;
+import com.mamoki.ieojuda.domain.confirmer.entity.Relationship;
+import com.mamoki.ieojuda.domain.confirmer.repository.ConfirmerRepository;
+import com.mamoki.ieojuda.domain.confirmer.repository.DisputeContactRepository;
+import com.mamoki.ieojuda.domain.plan.entity.Item;
+import com.mamoki.ieojuda.domain.plan.entity.LifeArea;
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.plan.entity.PlanStatus;
+import com.mamoki.ieojuda.domain.plan.repository.ItemRepository;
+import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+// 사건 생성 직전 계획 준비도 검증 - 각 조건이 단독으로 막는지, 모두 충족하면 통과하는지 확인한다.
+class PlanReadinessValidatorTest {
+
+    private static final UUID PLAN_ID = UUID.randomUUID();
+
+    private ConfirmerRepository confirmerRepository;
+    private ItemRepository itemRepository;
+    private DisputeContactRepository disputeContactRepository;
+    private PlanReadinessValidator validator;
+
+    @BeforeEach
+    void setUp() {
+        confirmerRepository = mock(ConfirmerRepository.class);
+        itemRepository = mock(ItemRepository.class);
+        disputeContactRepository = mock(DisputeContactRepository.class);
+        validator = new PlanReadinessValidator(confirmerRepository, itemRepository, disputeContactRepository);
+    }
+
+    private Plan readyPlan() {
+        Plan plan = mock(Plan.class);
+        when(plan.getPlanId()).thenReturn(PLAN_ID);
+        when(plan.getStatus()).thenReturn(PlanStatus.SEALED);
+        when(plan.getWaitingDays()).thenReturn(14);
+        when(plan.getSelfWarningEmailVerified()).thenReturn(true);
+        when(plan.getOrderConfirmedAt()).thenReturn(LocalDateTime.now());
+        return plan;
+    }
+
+    private void stubVerifiedDisputeContact() {
+        DisputeContact contact = DisputeContact.builder().plan(mock(Plan.class)).email("dispute@test.com").name("이의").build();
+        contact.verify();
+        when(disputeContactRepository.findFirstByPlan_PlanIdOrderByContactIdDesc(PLAN_ID)).thenReturn(Optional.of(contact));
+    }
+
+    private void stubAssignedItems() {
+        Item item = Item.builder().lifeArea(mock(LifeArea.class)).build();
+        item.assignRecipient(mock(Recipient.class));
+        when(itemRepository.findByLifeArea_Plan_PlanIdOrderBySortOrderAscItemIdAsc(PLAN_ID)).thenReturn(List.of(item));
+    }
+
+    private void stubTwoDistinctAcceptedConfirmers() {
+        Confirmer a = Confirmer.builder().plan(mock(Plan.class)).name("A").relationship(Relationship.FRIEND).email("a@test.com").build();
+        a.accept(null);
+        Confirmer b = Confirmer.builder().plan(mock(Plan.class)).name("B").relationship(Relationship.FRIEND).email("b@test.com").build();
+        b.accept(null);
+        when(confirmerRepository.findByPlan_PlanIdOrderByConfirmIdAsc(PLAN_ID)).thenReturn(List.of(a, b));
+    }
+
+    private void stubAllConditionsExceptUnderTest() {
+        stubVerifiedDisputeContact();
+        stubAssignedItems();
+        stubTwoDistinctAcceptedConfirmers();
+    }
+
+    @Test
+    void validate_whenAllConditionsMet_doesNotThrow() {
+        Plan plan = readyPlan();
+        stubAllConditionsExceptUnderTest();
+
+        assertThatCode(() -> validator.validate(plan)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void validate_whenPlanIsDraft_throwsPlanNotReady() {
+        Plan plan = readyPlan();
+        when(plan.getStatus()).thenReturn(PlanStatus.DRAFT);
+
+        assertThatThrownBy(() -> validator.validate(plan))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.PLAN_NOT_READY);
+    }
+
+    @Test
+    void validate_whenPlanIsDeactivated_throwsPlanNotReady() {
+        Plan plan = readyPlan();
+        when(plan.getStatus()).thenReturn(PlanStatus.DEACTIVATED);
+
+        assertThatThrownBy(() -> validator.validate(plan))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.PLAN_NOT_READY);
+    }
+
+    @Test
+    void validate_whenWaitingDaysNotSet_throwsWaitingPeriodNotSet() {
+        Plan plan = readyPlan();
+        when(plan.getWaitingDays()).thenReturn(null);
+
+        assertThatThrownBy(() -> validator.validate(plan))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.WAITING_PERIOD_NOT_SET);
+    }
+
+    @Test
+    void validate_whenSelfWarningEmailNotVerified_throwsSelfWarningEmailNotVerified() {
+        Plan plan = readyPlan();
+        when(plan.getSelfWarningEmailVerified()).thenReturn(false);
+
+        assertThatThrownBy(() -> validator.validate(plan))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.SELF_WARNING_EMAIL_NOT_VERIFIED);
+    }
+
+    @Test
+    void validate_whenNoDisputeContactRegistered_throwsDisputeContactNotVerified() {
+        Plan plan = readyPlan();
+        when(disputeContactRepository.findFirstByPlan_PlanIdOrderByContactIdDesc(PLAN_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> validator.validate(plan))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.DISPUTE_CONTACT_NOT_VERIFIED);
+    }
+
+    @Test
+    void validate_whenDisputeContactNotVerified_throwsDisputeContactNotVerified() {
+        Plan plan = readyPlan();
+        DisputeContact unverified = DisputeContact.builder().plan(mock(Plan.class)).email("dispute@test.com").name("이의").build();
+        when(disputeContactRepository.findFirstByPlan_PlanIdOrderByContactIdDesc(PLAN_ID)).thenReturn(Optional.of(unverified));
+
+        assertThatThrownBy(() -> validator.validate(plan))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.DISPUTE_CONTACT_NOT_VERIFIED);
+    }
+
+    @Test
+    void validate_whenItemHasNoAssignee_throwsItemAssigneeMissing() {
+        Plan plan = readyPlan();
+        stubVerifiedDisputeContact();
+        Item unassigned = Item.builder().lifeArea(mock(LifeArea.class)).build();
+        when(itemRepository.findByLifeArea_Plan_PlanIdOrderBySortOrderAscItemIdAsc(PLAN_ID)).thenReturn(List.of(unassigned));
+
+        assertThatThrownBy(() -> validator.validate(plan))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.ITEM_ASSIGNEE_MISSING);
+    }
+
+    @Test
+    void validate_whenOrderNotConfirmed_throwsOrderNotConfirmed() {
+        Plan plan = readyPlan();
+        when(plan.getOrderConfirmedAt()).thenReturn(null);
+        stubVerifiedDisputeContact();
+        stubAssignedItems();
+
+        assertThatThrownBy(() -> validator.validate(plan))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.ORDER_NOT_CONFIRMED);
+    }
+
+    @Test
+    void validate_whenFewerThanTwoAcceptedConfirmers_throwsInsufficientConfirmers() {
+        Plan plan = readyPlan();
+        stubVerifiedDisputeContact();
+        stubAssignedItems();
+        Confirmer onlyOne = Confirmer.builder().plan(mock(Plan.class)).name("A").relationship(Relationship.FRIEND).email("a@test.com").build();
+        onlyOne.accept(null);
+        when(confirmerRepository.findByPlan_PlanIdOrderByConfirmIdAsc(PLAN_ID)).thenReturn(List.of(onlyOne));
+
+        assertThatThrownBy(() -> validator.validate(plan))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INSUFFICIENT_CONFIRMERS);
+    }
+
+    // 정규화(trim + lowercase) 후 같은 이메일이면 서로 다른 확인자로 세지 않는다
+    @Test
+    void validate_whenAcceptedConfirmersShareNormalizedEmail_throwsInsufficientConfirmers() {
+        Plan plan = readyPlan();
+        stubVerifiedDisputeContact();
+        stubAssignedItems();
+        Confirmer a = Confirmer.builder().plan(mock(Plan.class)).name("A").relationship(Relationship.FRIEND).email(" Same@Test.com ".trim()).build();
+        a.accept(null);
+        Confirmer b = Confirmer.builder().plan(mock(Plan.class)).name("B").relationship(Relationship.FRIEND).email("same@test.com").build();
+        b.accept(null);
+        when(confirmerRepository.findByPlan_PlanIdOrderByConfirmIdAsc(PLAN_ID)).thenReturn(List.of(a, b));
+
+        assertThatThrownBy(() -> validator.validate(plan))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INSUFFICIENT_CONFIRMERS);
+    }
+}


### PR DESCRIPTION
## 연관 Issue

- Closes #46

## 요약

사망 신고 매칭 시점에 계획 준비도(봉인 상태·필수 설정)를 강제로 재검증하고, 서로 다른 확인자 2명의 독립 신고가 실제로 일치할 때만 사후 사건(ReleaseCase)이 열리도록 검증을 강화합니다.

## 변경 사항

- `PlanReadinessValidator` 신설 - 사건 생성 직전 계획 봉인 상태·대기기간·본인 경고 이메일 인증·이의 연락처 인증·항목 담당자 배정·실행 순서 확정·서로 다른 정규화 이메일의 ACCEPTED 확인자 2명 이상을 순서대로 검증
- `DeathReportService.createReleaseCase()`에서 기존 `log.warn`만 남기던 미봉인 계획 처리를 하드 블록으로 교체
- `DeathReportService.datesAgree()` 정책 변경 - 사망일이 한쪽이라도 결측이면 더 이상 자동 일치로 보지 않고, 둘 다 명시하고 값이 같을 때만 일치 처리 (그 외는 기존 `MISMATCHED` 경로로 전환)
- 신규 에러코드 4종 추가: `PLAN_NOT_READY`, `WAITING_PERIOD_NOT_SET`, `SELF_WARNING_EMAIL_NOT_VERIFIED`, `ITEM_ASSIGNEE_MISSING`
- 테스트 정리용 `EmailOutboxRepository.deleteByEmailLog_LogId` 벌크 삭제 쿼리 추가(통합 테스트 FK 정리용)

## 범위

### 포함

- 계획 준비도(봉인/필수 설정) 검증기 구현 및 사건 생성 경로 연결
- 서로 다른 확인자 최소 2명(정규화 이메일 기준) 강제
- 사망일 결측 자동 일치 로직 제거

### 제외

- 증빙 파트너 심사 구현
- 사후 패키지 발송 구현
- `PlanPackageService.seal()`(작성자 측 봉인 액션)의 기존 검사 로직 변경

## 테스트 해본것

- `PlanReadinessValidatorTest` (신규, 단위 11개) - 조건별 단독 차단/전체 충족 통과 검증
- `DeathReportServiceTest` (수정, 6개) - 매칭/부분결측/전체결측/명시적 불일치/준비도 실패/확인자 부족 시나리오
- `DeathReportReadinessIntegrationTest` (신규, `@SpringBootTest` 실 DB 9개) - 실제 리포지토리 쿼리 및 `DeathReportService.report()` end-to-end로 미봉인·비활성·설정누락 계획 차단, 전체 충족 시 정상 사건 생성 확인
- 전체 테스트 스위트(325개) 실행 - 이번 변경과 무관한 기존 실패 2건(동시성 타이밍 테스트, 로컬 환경변수 이슈) 외 회귀 없음