### PR TITLE
[Fix/#47]: 수락된 대체 담당자만 자동 전환

### DIFF
--- a/src/main/java/com/mamoki/ieojuda/domain/audit/entity/AdminActionType.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/audit/entity/AdminActionType.java
@@ -7,5 +7,6 @@ public enum AdminActionType {
     EVIDENCE_DELETE,      // 증빙 원본 삭제(수동 재처리 또는 자동 스케줄러)
     EVIDENCE_DOWNLOAD,    // issue #43 - 증빙 원본 다운로드(1회성 링크 발급 및 소비)
     EMAIL_OUTBOX_DISPATCH_FAILED, // issue #51 - 이메일 아웃박스 최대 재시도 초과(DEAD 전이)
-    EVIDENCE_ORPHAN_CLEANUP // issue #51 - 트랜잭션 롤백 후 S3 고아 객체 정리 실패
+    EVIDENCE_ORPHAN_CLEANUP, // issue #51 - 트랜잭션 롤백 후 S3 고아 객체 정리 실패
+    STAGE_FALLBACK // issue #47 - 대체 담당자 자동 전환(성공) 및 전환 불가로 인한 단계 차단(실패)
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/stage/service/HandoverStageService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/stage/service/HandoverStageService.java
@@ -1,11 +1,15 @@
 package com.mamoki.ieojuda.domain.stage.service;
 
 import com.mamoki.ieojuda.domain.account.entity.AdminPermission;
+import com.mamoki.ieojuda.domain.account.entity.User;
+import com.mamoki.ieojuda.domain.audit.entity.AdminActionType;
 import com.mamoki.ieojuda.domain.audit.entity.EmailType;
 import com.mamoki.ieojuda.domain.audit.repository.EmailLogRepository;
+import com.mamoki.ieojuda.domain.audit.service.AdminActionAuditService;
 import com.mamoki.ieojuda.domain.postaccess.entity.AccessToken;
 import com.mamoki.ieojuda.domain.postaccess.repository.AccessTokenRepository;
 import com.mamoki.ieojuda.domain.postaccess.repository.PackageActionCompletionRepository;
+import com.mamoki.ieojuda.domain.recipient.entity.AcceptanceStatus;
 import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
 import com.mamoki.ieojuda.domain.recipient.repository.RecipientRepository;
 import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCase;
@@ -50,6 +54,7 @@ public class HandoverStageService {
     private final PackageActionCompletionRepository packageActionCompletionRepository;
     private final AccessTokenRepository accessTokenRepository;
     private final SecurityTokenService securityTokenService;
+    private final AdminActionAuditService adminActionAuditService;
 
     public HandoverStageResponse getStage(UUID userId, UUID caseId, UUID stageId) {
         permissionGuard.require(userId, AdminPermission.CASE_SUPERVISE);
@@ -59,9 +64,12 @@ public class HandoverStageService {
     }
 
     // 무응답·영구반송·문제신고로 대체 담당자에게 전환. 대체 담당자가 없으면 사건을 차단 상태로 유지한다.
+    // issue #47 - "대체 담당자가 있다"는 backupFor 관계가 존재한다는 뜻일 뿐, 그 사람이 생전에 역할을
+    // 수락했다는 보장은 아니다. 거절·대기·만료 상태인 대체 담당자에게 민감한 사후 링크를 보내면 안 되므로,
+    // 관계 존재 여부가 아니라 "지금 전환해도 되는 대체 담당자인지"를 별도로 판정한다.
     @Transactional
     public HandoverStageResponse fallback(UUID userId, UUID caseId, UUID stageId) {
-        permissionGuard.require(userId, AdminPermission.CASE_SUPERVISE);
+        User actor = permissionGuard.require(userId, AdminPermission.CASE_SUPERVISE);
         ReleaseCase releaseCase = releaseCaseRepository.findById(caseId)
                 .orElseThrow(() -> new CustomException(ErrorCode.RELEASE_CASE_NOT_FOUND));
         if (Boolean.TRUE.equals(releaseCase.getFrozen())) {
@@ -70,18 +78,62 @@ public class HandoverStageService {
 
         HandoverStage stage = findStage(releaseCase, stageId);
         Recipient current = stage.getRecipient();
+        HandoverStageStatus stageStatusBeforeFallback = stage.getStatus();
 
         Recipient backup = recipientRepository.findByBackupFor_AssigneeId(current.getAssigneeId())
                 .orElse(null);
-        if (backup == null) {
+        ErrorCode rejectionReason = resolveFallbackRejection(backup, current);
+        if (rejectionReason != null) {
             stage.block();
-            throw new CustomException(ErrorCode.FALLBACK_RECIPIENT_MISSING);
+            adminActionAuditService.record(actor, AdminActionType.STAGE_FALLBACK, stageId, false,
+                    describeFallbackFailure(current, backup, stageStatusBeforeFallback, rejectionReason));
+            throw new CustomException(rejectionReason);
         }
 
         stage.fallbackTo(backup);
         sendHandoffInvite(stage, backup, InviteKind.FALLBACK);
+        adminActionAuditService.record(actor, AdminActionType.STAGE_FALLBACK, stageId, true,
+                describeFallbackSuccess(current, backup, stageStatusBeforeFallback));
 
         return HandoverStageResponse.from(stage);
+    }
+
+    // issue #47 완료 조건 - "ACCEPTED 상태의 대체 담당자만 전환 대상이 된다".
+    // 대체 담당자가 없거나 수락하지 않았으면 FALLBACK_RECIPIENT_MISSING/RECIPIENT_NOT_ACCEPTED를 반환하고,
+    // 문제가 없으면 null을 반환한다(정상 전환 가능).
+    // 공개 범주(disclosureScope) 일치는 대체 담당자 등록 시점(RecipientService.registerBackup)에 이미
+    // 주 담당자와 같은 값으로만 생성되도록 구조적으로 보장되지만, 다른 경로로 어긋난 데이터가 들어오는 상황까지
+    // 대비해 전환 직전에 한 번 더 확인한다(issue #45와 같은 이중 방어 원칙) - 이 경우도 "쓸 수 있는 대체
+    // 담당자가 없다"와 동일하게 취급해 FALLBACK_RECIPIENT_MISSING으로 응답한다.
+    private ErrorCode resolveFallbackRejection(Recipient backup, Recipient current) {
+        if (backup == null) {
+            return ErrorCode.FALLBACK_RECIPIENT_MISSING;
+        }
+        if (backup.getAcceptanceStatus() != AcceptanceStatus.ACCEPTED) {
+            return ErrorCode.RECIPIENT_NOT_ACCEPTED;
+        }
+        if (backup.getDisclosureScope() != current.getDisclosureScope()) {
+            return ErrorCode.FALLBACK_RECIPIENT_MISSING;
+        }
+        return null;
+    }
+
+    private String describeFallbackSuccess(Recipient current, Recipient backup, HandoverStageStatus stageStatusBeforeFallback) {
+        return "%s 상태로 인해 %s에서 %s로 전환됨".formatted(
+                stageStatusBeforeFallback, current.getAssigneeId(), backup.getAssigneeId());
+    }
+
+    private String describeFallbackFailure(Recipient current, Recipient backup, HandoverStageStatus stageStatusBeforeFallback,
+                                            ErrorCode rejectionReason) {
+        if (rejectionReason == ErrorCode.FALLBACK_RECIPIENT_MISSING && backup == null) {
+            return "%s 상태에서 %s의 대체 담당자가 등록되어 있지 않아 차단됨".formatted(stageStatusBeforeFallback, current.getAssigneeId());
+        }
+        if (rejectionReason == ErrorCode.RECIPIENT_NOT_ACCEPTED) {
+            return "%s 상태에서 대체 담당자 %s가 역할을 수락하지 않아(%s) 차단됨".formatted(
+                    stageStatusBeforeFallback, backup.getAssigneeId(), backup.getAcceptanceStatus());
+        }
+        return "%s 상태에서 대체 담당자 %s의 공개 범주가 주 담당자와 달라 차단됨".formatted(
+                stageStatusBeforeFallback, backup.getAssigneeId());
     }
 
     // 스케줄러 - 대기 기간 만료 시, 확정된 실행 순서대로 담당자 한 명당 단계 하나씩 만들고 1단계 담당자에게만 발송한다

--- a/src/test/java/com/mamoki/ieojuda/domain/stage/service/HandoverStageServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/stage/service/HandoverStageServiceTest.java
@@ -1,12 +1,17 @@
 package com.mamoki.ieojuda.domain.stage.service;
 
 import com.mamoki.ieojuda.domain.account.entity.AdminPermission;
+import com.mamoki.ieojuda.domain.account.entity.User;
+import com.mamoki.ieojuda.domain.audit.entity.AdminActionType;
 import com.mamoki.ieojuda.domain.audit.entity.EmailType;
+import com.mamoki.ieojuda.domain.audit.service.AdminActionAuditService;
+import com.mamoki.ieojuda.domain.plan.entity.DisclosureScope;
 import com.mamoki.ieojuda.domain.plan.entity.Plan;
 import com.mamoki.ieojuda.domain.plan.entity.PlanVersion;
 import com.mamoki.ieojuda.domain.postaccess.entity.AccessToken;
 import com.mamoki.ieojuda.domain.postaccess.repository.AccessTokenRepository;
 import com.mamoki.ieojuda.domain.postaccess.repository.PackageActionCompletionRepository;
+import com.mamoki.ieojuda.domain.recipient.entity.AcceptanceStatus;
 import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
 import com.mamoki.ieojuda.domain.recipient.entity.RoleType;
 import com.mamoki.ieojuda.domain.recipient.repository.RecipientRepository;
@@ -23,6 +28,8 @@ import com.mamoki.ieojuda.global.email.outbox.EmailOutboxService;
 import com.mamoki.ieojuda.global.email.contract.EmailSendResult;
 import com.mamoki.ieojuda.global.email.sender.EmailSender;
 import com.mamoki.ieojuda.global.email.token.TokenProvider;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
 import com.mamoki.ieojuda.global.security.PermissionGuard;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -35,6 +42,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -61,10 +69,12 @@ class HandoverStageServiceTest {
     private PackageActionCompletionRepository packageActionCompletionRepository;
     private AccessTokenRepository accessTokenRepository;
     private SecurityTokenService securityTokenService;
+    private AdminActionAuditService adminActionAuditService;
     private HandoverStageService handoverStageService;
 
     private ReleaseCase releaseCase;
     private HandoverStage currentStage;
+    private Recipient currentRecipient;
 
     @BeforeEach
     void setUp() {
@@ -77,10 +87,12 @@ class HandoverStageServiceTest {
         packageActionCompletionRepository = mock(PackageActionCompletionRepository.class);
         accessTokenRepository = mock(AccessTokenRepository.class);
         securityTokenService = mock(SecurityTokenService.class);
+        adminActionAuditService = mock(AdminActionAuditService.class);
         handoverStageService = new HandoverStageService(
                 releaseCaseRepository, handoverStageRepository, recipientRepository, emailOutboxService,
                 appProperties, permissionGuard, packageActionCompletionRepository, accessTokenRepository,
-                securityTokenService);
+                securityTokenService, adminActionAuditService);
+        when(permissionGuard.require(any(), eq(AdminPermission.CASE_SUPERVISE))).thenReturn(mock(User.class));
 
         when(appProperties.getContactEmail()).thenReturn("support@ieoduda.example");
         when(appProperties.getInviteTokenTtlHours()).thenReturn(72L);
@@ -100,9 +112,10 @@ class HandoverStageServiceTest {
         releaseCase.approveEvidenceAndStartWaiting(7);
         releaseCase.startReleasing();
 
-        Recipient recipient = mock(Recipient.class);
-        when(recipient.getEmail()).thenReturn("target@test.com");
-        currentStage = HandoverStage.builder().plan(plan).recipient(recipient).stageOrder(0).build();
+        currentRecipient = mock(Recipient.class);
+        when(currentRecipient.getEmail()).thenReturn("target@test.com");
+        when(currentRecipient.getDisclosureScope()).thenReturn(DisclosureScope.FAMILY);
+        currentStage = HandoverStage.builder().plan(plan).recipient(currentRecipient).stageOrder(0).build();
         currentStage.assignToCase(releaseCase);
         currentStage.send(); // 활성 발송 상태(SENT)에서 시작
 
@@ -261,13 +274,13 @@ class HandoverStageServiceTest {
     @Test
     void fallback_sendsFallbackWordingUnchangedButWithPosthumousAccessLink() {
         UUID userId = UUID.randomUUID(), caseId = UUID.randomUUID(), stageId = UUID.randomUUID();
-        when(permissionGuard.require(userId, AdminPermission.CASE_SUPERVISE)).thenReturn(null);
+        User actor = mock(User.class);
+        when(permissionGuard.require(userId, AdminPermission.CASE_SUPERVISE)).thenReturn(actor);
         when(releaseCaseRepository.findById(caseId)).thenReturn(Optional.of(releaseCase));
         currentStage.assignToCase(releaseCase);
         when(handoverStageRepository.findById(stageId)).thenReturn(Optional.of(currentStage));
 
-        Recipient backup = mock(Recipient.class);
-        when(backup.getEmail()).thenReturn("backup@test.com");
+        Recipient backup = acceptedBackup();
         when(recipientRepository.findByBackupFor_AssigneeId(any())).thenReturn(Optional.of(backup));
 
         handoverStageService.fallback(userId, caseId, stageId);
@@ -280,5 +293,92 @@ class HandoverStageServiceTest {
         assertThat(content.body()).contains("/posthumous-access/");
         assertThat(content.body()).doesNotContain("/recipient-acceptances/");
         assertLinkTokenWasIssuedAsAccessToken(content);
+        // issue #47 완료 조건 - "전환 대상과 사유를 감사 로그에서 확인할 수 있다"
+        verify(adminActionAuditService).record(eq(actor), eq(AdminActionType.STAGE_FALLBACK), eq(stageId), eq(true), anyString());
+    }
+
+    // 미리 ACCEPTED + 주 담당자와 같은 disclosureScope로 세팅된 "정상적으로 전환 가능한" 대체 담당자 mock.
+    // 개별 테스트에서 이 상태 중 하나만 어긋나게 덮어써서 각 차단 조건을 검증한다.
+    private Recipient acceptedBackup() {
+        Recipient backup = mock(Recipient.class);
+        when(backup.getAssigneeId()).thenReturn(UUID.randomUUID());
+        when(backup.getEmail()).thenReturn("backup@test.com");
+        when(backup.getAcceptanceStatus()).thenReturn(AcceptanceStatus.ACCEPTED);
+        when(backup.getDisclosureScope()).thenReturn(DisclosureScope.FAMILY);
+        return backup;
+    }
+
+    // issue #47 완료 조건 - "ACCEPTED 상태의 대체 담당자만 전환 대상이 된다"
+    @Test
+    void fallback_whenBackupNotAccepted_isBlockedAndBlocksStage() {
+        UUID userId = UUID.randomUUID(), caseId = UUID.randomUUID(), stageId = UUID.randomUUID();
+        when(releaseCaseRepository.findById(caseId)).thenReturn(Optional.of(releaseCase));
+        currentStage.assignToCase(releaseCase);
+        when(handoverStageRepository.findById(stageId)).thenReturn(Optional.of(currentStage));
+
+        Recipient backup = acceptedBackup();
+        when(backup.getAcceptanceStatus()).thenReturn(AcceptanceStatus.DECLINED);
+        when(recipientRepository.findByBackupFor_AssigneeId(any())).thenReturn(Optional.of(backup));
+
+        assertThatThrownBy(() -> handoverStageService.fallback(userId, caseId, stageId))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.RECIPIENT_NOT_ACCEPTED));
+
+        assertThat(currentStage.getStatus()).isEqualTo(HandoverStageStatus.BLOCKED);
+        verify(emailOutboxService, never()).enqueue(any(), any(), any(), anyString(), any());
+        verify(adminActionAuditService).record(any(), eq(AdminActionType.STAGE_FALLBACK), eq(stageId), eq(false), anyString());
+    }
+
+    // 대기 중(PENDING)·만료(EXPIRED) 상태도 같은 이유로 차단돼야 한다 (issue #47 - "거절·만료·대기 상태 담당자 전환 차단")
+    @Test
+    void fallback_whenBackupPendingOrExpired_isBlocked() {
+        UUID userId = UUID.randomUUID(), caseId = UUID.randomUUID(), stageId = UUID.randomUUID();
+        when(releaseCaseRepository.findById(caseId)).thenReturn(Optional.of(releaseCase));
+        currentStage.assignToCase(releaseCase);
+        when(handoverStageRepository.findById(stageId)).thenReturn(Optional.of(currentStage));
+
+        Recipient backup = acceptedBackup();
+        when(backup.getAcceptanceStatus()).thenReturn(AcceptanceStatus.PENDING);
+        when(recipientRepository.findByBackupFor_AssigneeId(any())).thenReturn(Optional.of(backup));
+
+        assertThatThrownBy(() -> handoverStageService.fallback(userId, caseId, stageId))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.RECIPIENT_NOT_ACCEPTED));
+    }
+
+    // issue #47 완료 조건 - "유효한 대체 담당자가 없으면 사건은 발송되지 않고 차단 상태를 유지한다"
+    @Test
+    void fallback_whenNoBackupRegistered_isBlockedWithMissingError() {
+        UUID userId = UUID.randomUUID(), caseId = UUID.randomUUID(), stageId = UUID.randomUUID();
+        when(releaseCaseRepository.findById(caseId)).thenReturn(Optional.of(releaseCase));
+        currentStage.assignToCase(releaseCase);
+        when(handoverStageRepository.findById(stageId)).thenReturn(Optional.of(currentStage));
+        when(recipientRepository.findByBackupFor_AssigneeId(any())).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> handoverStageService.fallback(userId, caseId, stageId))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.FALLBACK_RECIPIENT_MISSING));
+
+        assertThat(currentStage.getStatus()).isEqualTo(HandoverStageStatus.BLOCKED);
+        verify(adminActionAuditService).record(any(), eq(AdminActionType.STAGE_FALLBACK), eq(stageId), eq(false), anyString());
+    }
+
+    // 방어선 - 대체 담당자 등록 경로(RecipientService)는 항상 주 담당자와 같은 disclosureScope로만
+    // 만들지만, 다른 경로로 어긋난 데이터가 들어오는 상황까지 대비해 전환 직전에 한 번 더 막는다.
+    @Test
+    void fallback_whenBackupDisclosureScopeDiffersFromCurrent_isBlocked() {
+        UUID userId = UUID.randomUUID(), caseId = UUID.randomUUID(), stageId = UUID.randomUUID();
+        when(releaseCaseRepository.findById(caseId)).thenReturn(Optional.of(releaseCase));
+        currentStage.assignToCase(releaseCase);
+        when(handoverStageRepository.findById(stageId)).thenReturn(Optional.of(currentStage));
+
+        Recipient backup = acceptedBackup();
+        when(backup.getDisclosureScope()).thenReturn(DisclosureScope.WORK); // currentRecipient는 FAMILY
+        when(recipientRepository.findByBackupFor_AssigneeId(any())).thenReturn(Optional.of(backup));
+
+        assertThatThrownBy(() -> handoverStageService.fallback(userId, caseId, stageId))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.FALLBACK_RECIPIENT_MISSING));
+        assertThat(currentStage.getStatus()).isEqualTo(HandoverStageStatus.BLOCKED);
     }
 }


### PR DESCRIPTION
## 연관 Issue
- Closes #47

## 요약
대체 담당자가 `backupFor` 관계로 등록만 돼 있으면, 생전에 역할을 수락했는지와 무관하게 즉시 전환되어 민감한 사후 인계 링크를 받던 문제를 수정합니다. 이제 `AcceptanceStatus.ACCEPTED` 상태의 대체 담당자만 전환 대상이 되고, 그렇지 않으면(거절·대기·만료) 없는 것과 동일하게 취급해 단계를 차단 상태로 유지합니다. 전환 성공/실패와 사유는 감사 로그에 남습니다.

## 변경 사항
- `HandoverStageService.fallback()`: `backup == null` 단일 체크를 `resolveFallbackRejection()`으로 확장 — 대체 담당자 부재(`FALLBACK_RECIPIENT_MISSING`), 미수락(`RECIPIENT_NOT_ACCEPTED`, 기존에 정의만 있고 사용처 0곳이던 에러코드 연결), 공개 범주 불일치(`FALLBACK_RECIPIENT_MISSING`) 세 가지를 구분해 차단
- 공개 범주(`disclosureScope`) 일치 여부를 전환 직전에 방어적으로 재검증 — 등록 시점(`RecipientService.registerBackup`)에 주 담당자와 항상 같은 값으로 생성되도록 구조적으로 보장되지만, `#45`와 같은 이중 방어 원칙을 적용
- `AdminActionType.STAGE_FALLBACK` 신설 — 전환 대상(`전 담당자→대체 담당자`)과 사유(전환 전 단계 상태 / 차단 사유)를 `AdminActionAuditService`에 기록

## 범위

### 포함
- 대체 담당자 `AcceptanceStatus.ACCEPTED` 검증
- 공개 범주 검증 (단계 상태·호출자 권한 검증은 `#45`/기존 코드가 이미 보유)
- 대체 담당자 부재 시 안전한 차단 상태 유지
- 자동 전환 사유·결과 감사 기록
- 수락 상태별 전환 테스트

### 제외
- 담당자 초대 UI 변경
- OTP 인증 체계 구현

## 테스트 내역
- `HandoverStageServiceTest` 12개 전체 통과 (신규 4개: 미수락/대기·만료/부재/공개범주불일치, 기존 정상 전환 테스트에 감사 로그 검증 추가)
- `StageDispatchHttpIntegrationTest`, `ReleaseCaseTest` 회귀 없음 확인
- 전체 스위트 317개 중 5개 실패 — 전부 이 PR과 무관한 사전 존재 문제(로컬 Postgres 스키마 drift, 대용량 멀티파트 소켓 테스트 환경 이슈)
- 완료 조건 3개(ACCEPTED만 전환 대상 / 차단 상태 유지 / 감사 로그 확인 가능) 전부 테스트로 직접 검증
