### PR TITLE
[Fix/#52]: AI 입력 자격증명 차단 및 요청 제한

### DIFF
--- a/src/main/java/com/mamoki/ieojuda/domain/plan/dto/LifeAreaMessageRequest.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/dto/LifeAreaMessageRequest.java
@@ -2,9 +2,12 @@ package com.mamoki.ieojuda.domain.plan.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
+// issue #52 - 대화 1회 발화 길이 상한(4,000자). OpenAI로 무제한 길이의 입력이 전달되는 것을 막는다
 public record LifeAreaMessageRequest(
         @Schema(description = "사용자가 입력한 자연어 발화", example = "아내에게 가족사진 위치를 알려주고 싶어요.")
-        @NotBlank(message = "내용을 입력해 주세요.") String content
+        @NotBlank(message = "내용을 입력해 주세요.")
+        @Size(max = 4000, message = "한 번에 입력할 수 있는 내용은 4,000자 이하여야 합니다.") String content
 ) {
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/service/ConversationService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/service/ConversationService.java
@@ -51,6 +51,10 @@ import java.util.Map;
 @Transactional(readOnly = true)
 public class ConversationService {
 
+    // issue #52 - 대화 세션 하나가 무한히 길어져 OpenAI 요청이 비대해지는 것을 막는 상한.
+    // 한 번의 발화 상한(4,000자)은 LifeAreaMessageRequest에서 검증한다.
+    private static final int MAX_HISTORY_LENGTH = 12_000;
+
     private final PlanOwnershipReader planOwnershipReader;
     private final ConversationRepository conversationRepository;
     private final LifeAreaMessageRepository lifeAreaMessageRepository;
@@ -96,6 +100,13 @@ public class ConversationService {
         // step 1. 이 세션 안에서 지금까지의 대화 이력 로드
         List<LifeAreaMessage> history = lifeAreaMessageRepository
                 .findByConversation_ConversationIdOrderByMessageIdAsc(conversation.getConversationId());
+
+        // issue #52 - 전체 이력 길이 상한. 이번 메세지를 저장하기 전에 확인해야
+        // "거절된 입력은 저장하지 않는다"는 원칙을 지킬 수 있다.
+        int historyLength = history.stream().mapToInt(message -> message.getContent().length()).sum();
+        if (historyLength + userContent.length() > MAX_HISTORY_LENGTH) {
+            throw new CustomException(ErrorCode.CONVERSATION_HISTORY_TOO_LONG);
+        }
 
         // step 2. 이번 사용자 메세지 저장
         LifeAreaMessage userMessage = lifeAreaMessageRepository.save(
@@ -222,12 +233,30 @@ public class ConversationService {
         };
     }
 
+    // issue #52 - "응답 JSON 구조를 서버에서 엄격히 검증". JSON 파싱 자체가 실패하는 경우뿐 아니라,
+    // 파싱은 됐지만 type이 QUESTION/RESULT가 아니거나 그에 맞는 필드(question/items)가 비어 있는 경우도
+    // AI_RESPONSE_INVALID로 통일해서 처리한다 - 이전에는 후자가 걸러지지 않고 question=null인 애매한
+    // 응답으로 그냥 통과했다.
     private AiTurnResult parseAiTurnResult(String rawContent) {
+        AiTurnResult turnResult;
         try {
-            return objectMapper.readValue(rawContent, AiTurnResult.class);
+            turnResult = objectMapper.readValue(rawContent, AiTurnResult.class);
         } catch (Exception e) {
-            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+            throw new CustomException(ErrorCode.AI_RESPONSE_INVALID);
         }
+
+        if ("QUESTION".equalsIgnoreCase(turnResult.type())) {
+            if (turnResult.question() == null || turnResult.question().isBlank()) {
+                throw new CustomException(ErrorCode.AI_RESPONSE_INVALID);
+            }
+        } else if ("RESULT".equalsIgnoreCase(turnResult.type())) {
+            if (turnResult.items() == null || turnResult.items().isEmpty()) {
+                throw new CustomException(ErrorCode.AI_RESPONSE_INVALID);
+            }
+        } else {
+            throw new CustomException(ErrorCode.AI_RESPONSE_INVALID);
+        }
+        return turnResult;
     }
 
     private String toOpenAiRole(MessageRole role) {

--- a/src/main/java/com/mamoki/ieojuda/global/exception/ErrorCode.java
+++ b/src/main/java/com/mamoki/ieojuda/global/exception/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
     INVALID_WAITING_PERIOD(HttpStatus.BAD_REQUEST, "INVALID_WAITING_PERIOD", "대기 기간은 7일 이상 30일 이하여야 합니다."),
     CONSENT_REQUIRED(HttpStatus.BAD_REQUEST, "CONSENT_REQUIRED", "사후 인계 조건과 안전 범위를 확인해 주세요."),
     SUSPECTED_CREDENTIAL_INPUT(HttpStatus.BAD_REQUEST, "SUSPECTED_CREDENTIAL_INPUT", "비밀번호·PIN·OTP·복구 코드로 보이는 내용은 저장할 수 없습니다. 위치 유형만 적어 주세요."),
+    CONVERSATION_HISTORY_TOO_LONG(HttpStatus.BAD_REQUEST, "CONVERSATION_HISTORY_TOO_LONG", "대화 이력이 너무 깁니다. 새 대화 세션을 시작해 주세요."),
     UNGROUNDED_ITEM_NOT_APPROVABLE(HttpStatus.BAD_REQUEST, "UNGROUNDED_ITEM_NOT_APPROVABLE", "원문 근거가 없는 항목은 승인할 수 없습니다."),
     ITEM_NOT_APPROVED(HttpStatus.BAD_REQUEST, "ITEM_NOT_APPROVED", "승인되지 않은 항목에는 담당자를 등록할 수 없습니다."),
     PROHIBITED_ACTION_DETECTED(HttpStatus.BAD_REQUEST, "PROHIBITED_ACTION_DETECTED", "AI가 처리할 수 없는 금지 행동이 포함되어 있습니다."),
@@ -40,6 +41,10 @@ public enum ErrorCode {
 
     // 암호화 증빙 저장소 관련 예외 (500)
     EVIDENCE_STORAGE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "EVIDENCE_STORAGE_FAILED", "증빙 저장소 처리 중 오류가 발생했습니다."),
+
+    // OpenAI 연동 관련 예외 (502/503) - issue #52
+    AI_RESPONSE_INVALID(HttpStatus.BAD_GATEWAY, "AI_RESPONSE_INVALID", "AI 응답을 처리할 수 없습니다. 다시 시도해 주세요."),
+    AI_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "AI_SERVICE_UNAVAILABLE", "AI 서비스 응답이 지연되고 있습니다. 잠시 후 다시 시도해 주세요."),
 
     // 공통 이메일 발송 모듈 관련 예외 (500)
     EMAIL_CONTENT_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "EMAIL_CONTENT_GENERATION_FAILED", "이메일 본문 생성에 실패했습니다."),

--- a/src/main/java/com/mamoki/ieojuda/global/openai/component/OpenAIClient.java
+++ b/src/main/java/com/mamoki/ieojuda/global/openai/component/OpenAIClient.java
@@ -6,14 +6,17 @@ import com.mamoki.ieojuda.global.openai.dto.OpenAIMessageDto;
 import com.mamoki.ieojuda.global.openai.dto.OpenAIRequest;
 import com.mamoki.ieojuda.global.openai.dto.OpenAIResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.ArrayList;
 import java.util.List;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class OpenAIClient {
@@ -35,8 +38,10 @@ public class OpenAIClient {
                     "action에는 원문을 바탕으로 무엇을 어떻게 해야 하는지 전체를 자연스러운 문장으로 서술하세요. " +
                     "title은 대상이 되는 구체적인 채널·계정·서비스 이름을 짧게 쓰세요(예: '인스타그램', '트위터', '문자 메세지', '카카오톡'). " +
                     "content에는 그 채널에 대해 실제로 해야 할 일을 짧게 쓰세요(예: '탈퇴 처리', '비공개 전환'). " +
-                    "(예: 원문이 '인스타그램 아이디 비밀번호 이건데 친구 땡땡한테 처리 줘'라면 " +
-                    "action은 '인스타그램 아이디와 비밀번호를 전달해서 계정을 정리해줘', title은 '인스타그램', content는 '탈퇴 처리'). " +
+                    // issue #52 - 이전 예시가 "인스타그램 아이디 비밀번호 이건데"처럼 자격증명 입력을 정상 예시로 들고 있어,
+                    // AI가 이런 입력을 정상적인 발화로 학습할 위험이 있었다. 같은 title/content/action 구분을 자격증명 없이 가르친다.
+                    "(예: 원문이 '인스타그램 계정은 친구 땡땡한테 넘겨서 정리해달라고 하고 싶어요'라면 " +
+                    "action은 '인스타그램 계정 접근 권한을 넘겨줘서 정리해달라고 부탁해줘', title은 '인스타그램', content는 '탈퇴 처리'). " +
                     "한 발화에 여러 채널이 섞여 있으면(예: '인스타그램이랑 트위터 둘 다 계정 지워줘') 채널마다 별도 항목으로 나누세요. " +
                     "같은 채널·계정이라도 서로 성격이 다른 행동이 함께 있으면(예: '클라우드 사진을 아내한테 전달하고 그 계정은 삭제해줘'처럼 " +
                     "자료를 전달·공개하는 행동과 그 계정·자료 자체를 삭제·정리하는 행동이 함께 있으면) 절대 하나로 합치지 말고, " +
@@ -80,6 +85,8 @@ public class OpenAIClient {
     private static final String JSON_RESPONSE_FORMAT_TYPE = "json_object";
     // 창의성이 필요 없는 구조화 작업이라 낮게 고정해서 같은 입력에 최대한 일관된 결과(특히 sortOrder)가 나오게 함
     private static final double COMPILE_TEMPERATURE = 0.0;
+    // issue #52 - 무제한 응답 대기를 막기 위한 상한. 이 서비스의 응답은 항목 목록 JSON이라 2000토큰이면 충분하다
+    private static final int MAX_RESPONSE_TOKENS = 2000;
 
     private final RestTemplate restTemplate;
 
@@ -107,16 +114,21 @@ public class OpenAIClient {
      */
     private OpenAIResponse callOpenAI(List<OpenAIMessageDto> messages) {
         OpenAIRequest openAiRequest = new OpenAIRequest(
-                model, messages, new OpenAIRequest.ResponseFormat(JSON_RESPONSE_FORMAT_TYPE), COMPILE_TEMPERATURE);
+                model, messages, new OpenAIRequest.ResponseFormat(JSON_RESPONSE_FORMAT_TYPE),
+                COMPILE_TEMPERATURE, MAX_RESPONSE_TOKENS);
 
-        ResponseEntity<OpenAIResponse> chatResponse = restTemplate.postForEntity(
-                apiUrl,
-                openAiRequest,
-                OpenAIResponse.class
-        );
+        ResponseEntity<OpenAIResponse> chatResponse;
+        try {
+            // issue #52 - RestTemplate에 연결·읽기 타임아웃이 설정돼 있어(OpenAIConfig), 응답이 없으면
+            // 여기서 RestClientException으로 실패하며 무한정 대기하지 않는다.
+            chatResponse = restTemplate.postForEntity(apiUrl, openAiRequest, OpenAIResponse.class);
+        } catch (RestClientException e) {
+            log.warn("[OpenAI 호출 실패] {}: {}", e.getClass().getSimpleName(), e.getMessage());
+            throw new CustomException(ErrorCode.AI_SERVICE_UNAVAILABLE);
+        }
 
         if (!chatResponse.getStatusCode().is2xxSuccessful() || chatResponse.getBody() == null) {
-            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+            throw new CustomException(ErrorCode.AI_SERVICE_UNAVAILABLE);
         }
 
         return chatResponse.getBody();

--- a/src/main/java/com/mamoki/ieojuda/global/openai/config/OpenAIConfig.java
+++ b/src/main/java/com/mamoki/ieojuda/global/openai/config/OpenAIConfig.java
@@ -6,8 +6,15 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
 
+import java.time.Duration;
+
 @Configuration
 public class OpenAIConfig {
+
+    // issue #52 - 이 RestTemplate은 OpenAI 호출 전용이라, 여기서 건 타임아웃이 다른 외부 연동에 영향을 주지 않는다.
+    // 연결 5초·응답 15초를 넘기면 RestClientException으로 실패해 OpenAIClient가 AI_SERVICE_UNAVAILABLE로 변환한다.
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(5);
+    private static final Duration READ_TIMEOUT = Duration.ofSeconds(15);
 
     @Value("${openai.api-key}")
     private String apiKey;
@@ -15,6 +22,8 @@ public class OpenAIConfig {
     @Bean
     public RestTemplate restTemplate(RestTemplateBuilder restTemplateBuilder) {
         return restTemplateBuilder
+                .connectTimeout(CONNECT_TIMEOUT)
+                .readTimeout(READ_TIMEOUT)
                 .additionalInterceptors((request, body, execution) -> {
                     request.getHeaders().set("Authorization", "Bearer " + apiKey);
                     return execution.execute(request, body);

--- a/src/main/java/com/mamoki/ieojuda/global/openai/dto/OpenAIRequest.java
+++ b/src/main/java/com/mamoki/ieojuda/global/openai/dto/OpenAIRequest.java
@@ -8,7 +8,9 @@ public record OpenAIRequest(
         String model,
         List<OpenAIMessageDto> messages,
         @JsonProperty("response_format") ResponseFormat responseFormat,
-        Double temperature
+        Double temperature,
+        // issue #52 - 응답 길이 상한. OpenAI 쪽 무제한 응답 대기를 막는다
+        @JsonProperty("max_tokens") Integer maxTokens
 ) {
     // OpenAI에게 응답을 항상 유효한 JSON으로만 달라고 강제하는 옵션 (예: new ResponseFormat("json_object"))
     public record ResponseFormat(String type) {

--- a/src/test/java/com/mamoki/ieojuda/domain/plan/service/ConversationServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/plan/service/ConversationServiceTest.java
@@ -130,4 +130,75 @@ class ConversationServiceTest {
         verify(lifeAreaMessageRepository, times(2)).save(any());
         verify(openAIClient).getChatCompletion(any());
     }
+
+    // issue #52 완료 조건 - "입력 상한 초과는 명확한 400... 으로 처리된다" (전체 이력 12,000자 상한)
+    @Test
+    void sendMessage_whenHistoryPlusNewMessageExceedsTwelveThousandChars_throwsWithoutSavingOrCallingOpenAI() {
+        LifeAreaMessage longPastMessage = LifeAreaMessage.builder()
+                .conversation(conversation).role(MessageRole.USER).content("x".repeat(11_990)).build();
+        when(lifeAreaMessageRepository.findByConversation_ConversationIdOrderByMessageIdAsc(CONVERSATION_ID))
+                .thenReturn(List.of(longPastMessage));
+
+        assertThatThrownBy(() -> conversationService.sendMessage(
+                USER_ID, PLAN_ID, CONVERSATION_ID, "x".repeat(11)))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.CONVERSATION_HISTORY_TOO_LONG));
+
+        verify(lifeAreaMessageRepository, never()).save(any());
+        verify(openAIClient, never()).getChatCompletion(any());
+    }
+
+    @Test
+    void sendMessage_whenHistoryPlusNewMessageIsExactlyTwelveThousandChars_proceeds() {
+        LifeAreaMessage longPastMessage = LifeAreaMessage.builder()
+                .conversation(conversation).role(MessageRole.USER).content("x".repeat(11_990)).build();
+        when(lifeAreaMessageRepository.findByConversation_ConversationIdOrderByMessageIdAsc(CONVERSATION_ID))
+                .thenReturn(List.of(longPastMessage));
+        OpenAIResponse response = new OpenAIResponse(List.of(
+                new OpenAIResponse.Choice(new OpenAIMessageDto("assistant",
+                        "{\"type\":\"QUESTION\",\"question\":\"어떤 계정인가요?\"}"))));
+        when(openAIClient.getChatCompletion(any())).thenReturn(response);
+
+        conversationService.sendMessage(USER_ID, PLAN_ID, CONVERSATION_ID, "x".repeat(10));
+
+        verify(openAIClient).getChatCompletion(any());
+    }
+
+    // issue #52 - "응답 JSON 구조를 서버에서 엄격히 검증". type이 QUESTION/RESULT가 아니면
+    // 예전처럼 question=null인 애매한 응답으로 통과시키지 않고 명확히 실패해야 한다.
+    @Test
+    void sendMessage_whenAiResponseTypeIsUnrecognized_throwsAiResponseInvalid() {
+        OpenAIResponse response = new OpenAIResponse(List.of(
+                new OpenAIResponse.Choice(new OpenAIMessageDto("assistant", "{\"type\":\"UNKNOWN\"}"))));
+        when(openAIClient.getChatCompletion(any())).thenReturn(response);
+
+        assertThatThrownBy(() -> conversationService.sendMessage(
+                USER_ID, PLAN_ID, CONVERSATION_ID, "인스타그램 계정을 정리해줘"))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.AI_RESPONSE_INVALID));
+    }
+
+    @Test
+    void sendMessage_whenAiResponseTypeResultHasNoItems_throwsAiResponseInvalid() {
+        OpenAIResponse response = new OpenAIResponse(List.of(
+                new OpenAIResponse.Choice(new OpenAIMessageDto("assistant", "{\"type\":\"RESULT\",\"items\":[]}"))));
+        when(openAIClient.getChatCompletion(any())).thenReturn(response);
+
+        assertThatThrownBy(() -> conversationService.sendMessage(
+                USER_ID, PLAN_ID, CONVERSATION_ID, "인스타그램 계정을 정리해줘"))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.AI_RESPONSE_INVALID));
+    }
+
+    @Test
+    void sendMessage_whenAiResponseIsNotValidJson_throwsAiResponseInvalid() {
+        OpenAIResponse response = new OpenAIResponse(List.of(
+                new OpenAIResponse.Choice(new OpenAIMessageDto("assistant", "이건 JSON이 아닙니다"))));
+        when(openAIClient.getChatCompletion(any())).thenReturn(response);
+
+        assertThatThrownBy(() -> conversationService.sendMessage(
+                USER_ID, PLAN_ID, CONVERSATION_ID, "인스타그램 계정을 정리해줘"))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.AI_RESPONSE_INVALID));
+    }
 }

--- a/src/test/java/com/mamoki/ieojuda/global/openai/component/OpenAIClientTest.java
+++ b/src/test/java/com/mamoki/ieojuda/global/openai/component/OpenAIClientTest.java
@@ -1,0 +1,87 @@
+package com.mamoki.ieojuda.global.openai.component;
+
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import com.mamoki.ieojuda.global.openai.dto.OpenAIMessageDto;
+import com.mamoki.ieojuda.global.openai.dto.OpenAIRequest;
+import com.mamoki.ieojuda.global.openai.dto.OpenAIResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+// issue #52 완료 조건 - "OpenAI 응답이 2,000토큰으로 제한된다" / "외부 API 무응답 시 설정된 제한 시간 안에
+// 실패 처리된다"를 검증한다. 실제 타임아웃 대기(OpenAIConfig의 5초/15초)는 여기서 재현하지 않고,
+// RestTemplate이 타임아웃 시 던지는 예외(ResourceAccessException)를 흉내내 변환 로직만 확인한다.
+class OpenAIClientTest {
+
+    private RestTemplate restTemplate;
+    private OpenAIClient openAIClient;
+
+    @BeforeEach
+    void setUp() {
+        restTemplate = mock(RestTemplate.class);
+        openAIClient = new OpenAIClient(restTemplate);
+        ReflectionTestUtils.setField(openAIClient, "apiUrl", "http://openai.test/chat");
+        ReflectionTestUtils.setField(openAIClient, "model", "test-model");
+    }
+
+    @Test
+    void getChatCompletion_sendsRequestWithTwoThousandMaxTokens() {
+        OpenAIResponse response = new OpenAIResponse(
+                List.of(new OpenAIResponse.Choice(new OpenAIMessageDto("assistant", "{\"type\":\"QUESTION\"}"))));
+        when(restTemplate.postForEntity(eq("http://openai.test/chat"), any(OpenAIRequest.class), eq(OpenAIResponse.class)))
+                .thenAnswer(invocation -> {
+                    OpenAIRequest request = invocation.getArgument(1);
+                    assertThat(request.maxTokens()).isEqualTo(2000);
+                    return ResponseEntity.ok(response);
+                });
+
+        OpenAIResponse result = openAIClient.getChatCompletion(List.of(new OpenAIMessageDto("user", "안녕")));
+
+        assertThat(result).isEqualTo(response);
+    }
+
+    // issue #52 완료 조건 - "외부 API 무응답 시 설정된 제한 시간 안에 실패 처리된다"
+    @Test
+    void getChatCompletion_whenRestTemplateTimesOut_throwsAiServiceUnavailable() {
+        when(restTemplate.postForEntity(any(String.class), any(OpenAIRequest.class), eq(OpenAIResponse.class)))
+                .thenThrow(new ResourceAccessException("Read timed out"));
+
+        assertThatThrownBy(() -> openAIClient.getChatCompletion(List.of(new OpenAIMessageDto("user", "안녕"))))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.AI_SERVICE_UNAVAILABLE));
+    }
+
+    @Test
+    void getChatCompletion_whenResponseIsNotSuccessful_throwsAiServiceUnavailable() {
+        when(restTemplate.postForEntity(any(String.class), any(OpenAIRequest.class), eq(OpenAIResponse.class)))
+                .thenReturn(ResponseEntity.status(HttpStatus.BAD_GATEWAY).build());
+
+        assertThatThrownBy(() -> openAIClient.getChatCompletion(List.of(new OpenAIMessageDto("user", "안녕"))))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.AI_SERVICE_UNAVAILABLE));
+    }
+
+    @Test
+    void getChatCompletion_whenResponseBodyIsNull_throwsAiServiceUnavailable() {
+        when(restTemplate.postForEntity(any(String.class), any(OpenAIRequest.class), eq(OpenAIResponse.class)))
+                .thenReturn(ResponseEntity.ok(null));
+
+        assertThatThrownBy(() -> openAIClient.getChatCompletion(List.of(new OpenAIMessageDto("user", "안녕"))))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.AI_SERVICE_UNAVAILABLE));
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/global/validation/InputSizeConstraintTest.java
+++ b/src/test/java/com/mamoki/ieojuda/global/validation/InputSizeConstraintTest.java
@@ -13,6 +13,7 @@ import com.mamoki.ieojuda.domain.evidence.entity.Evidence;
 import com.mamoki.ieojuda.domain.evidence.service.EvidenceSubmitService;
 import com.mamoki.ieojuda.domain.partner.dto.PartnerReviewDecisionRequest;
 import com.mamoki.ieojuda.domain.plan.dto.ItemUpdateRequest;
+import com.mamoki.ieojuda.domain.plan.dto.LifeAreaMessageRequest;
 import com.mamoki.ieojuda.domain.plan.dto.SelfWarningEmailRequest;
 import com.mamoki.ieojuda.domain.plan.entity.Item;
 import com.mamoki.ieojuda.domain.recipient.dto.BackupRegisterRequest;
@@ -160,6 +161,16 @@ class InputSizeConstraintTest {
         assertThat(validator.validate(upperBound)).isEmpty();
         assertThat(validator.validate(belowRange)).hasSize(1);
         assertThat(validator.validate(aboveRange)).hasSize(1);
+    }
+
+    // issue #52 - 대화 1회 발화 4,000자 제한. LifeAreaMessage.content는 TEXT 컬럼(길이 제약 없음)이라
+    // EXPECTED_COLUMN_LENGTHS 방식(DTO ↔ DB length 대조)이 아니라 DTO 상한 자체를 직접 검증한다.
+    @Test
+    void lifeAreaMessageRequestAcceptsUpToFourThousandCharsAndRejectsOverflow() {
+        Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+        assertThat(validator.validate(new LifeAreaMessageRequest("x".repeat(4000)))).isEmpty();
+        assertThat(validator.validate(new LifeAreaMessageRequest("x".repeat(4001)))).hasSize(1);
     }
 
     // issue #93 - 피그마 회원가입 화면은 이메일/비밀번호/비밀번호 확인 3개만 입력받으므로 이름 없이도 가입이 성공해야 한다


### PR DESCRIPTION
## 연관 Issue
- Closes #52

## 요약
AI 대화 흐름의 무제한 입력·응답 대기와, 시스템 프롬프트가 자격증명 입력을 정상 예시로 학습시키던 문제를 수정합니다. 자격증명 탐지·차단 자체(패턴 탐지, 저장/전송 전 거절)는 `#91`에서 이미 구현·연결되어 있어 이번 범위에서는 제외했습니다.

## 변경 사항
- `OpenAIClient` 시스템 프롬프트 예시에서 `'인스타그램 아이디 비밀번호 이건데...'`처럼 자격증명을 정상 입력으로 쓰던 부분을 비밀번호 없는 예시로 교체
- `LifeAreaMessageRequest.content`에 `@Size(max = 4000)` 추가 — 컬럼이 `TEXT`라 길이 제한이 전혀 없었음. 기존 `@Valid` 400 처리를 재사용
- `ConversationService.sendMessage()`에 전체 대화 이력 12,000자 상한 추가 — 메세지를 저장하기 **전에** 검사해 초과 시 저장하지 않음 (`CONVERSATION_HISTORY_TOO_LONG`)
- `OpenAIRequest`에 `max_tokens` 필드 추가, `OpenAIClient`가 2000 고정값 전달
- `OpenAIConfig`의 RestTemplate(OpenAI 호출 전용)에 연결 5초·읽기 15초 타임아웃 설정, `OpenAIClient`가 `RestClientException`(타임아웃 포함)을 `AI_SERVICE_UNAVAILABLE`로 변환
- `ConversationService.parseAiTurnResult()` — JSON 파싱 실패뿐 아니라 `type`이 `QUESTION`/`RESULT`가 아니거나 필수 필드(`question`/`items`)가 비어있는 경우도 `AI_RESPONSE_INVALID`로 명확히 실패 처리 (기존엔 원인불명 500이거나 `question=null`인 애매한 응답으로 그냥 통과했음)

## 범위

### 포함
- 자격증명 패턴 탐지 후 요청 거절 (기존 `#91` 구현 재확인, 신규 작업 없음)
- 거절된 입력의 미저장·외부 미전송 (동일)
- 대화 1회 4,000자·전체 이력 12,000자 제한
- OpenAI 응답 최대 2,000토큰 제한
- OpenAI 연결 5초·응답 15초 타임아웃
- 응답 스키마 검증

### 제외
- AI 모델 변경
- 일반 이메일·S3 복원력 구현

## 신규 ErrorCode
| 코드 | 상태 | 용도 |
|---|---|---|
| `CONVERSATION_HISTORY_TOO_LONG` | 400 | 대화 전체 이력 12,000자 초과 |
| `AI_RESPONSE_INVALID` | 502 | AI 응답 JSON 파싱 실패 또는 스키마(type/question/items) 불일치 |
| `AI_SERVICE_UNAVAILABLE` | 503 | OpenAI 연결/응답 타임아웃, 비정상 응답 |

## 테스트 내역
- `OpenAIClientTest` 신규 작성 (4건: max_tokens 전달 확인, 타임아웃→503, 비정상 응답→503, null body→503)
- `ConversationServiceTest`에 5건 추가 (이력 상한 차단/경계값 통과, 응답 스키마 검증 3종)
- `InputSizeConstraintTest`에 `LifeAreaMessageRequest` 4,000자 경계값 검증 추가
- 완료 조건 4개 전부 테스트로 직접 검증
- 전체 스위트 352개 중 6개 실패 — 전부 이 PR과 무관한 사전 존재 문제(로컬 Postgres 스키마 drift, 대용량 멀티파트 소켓 테스트 환경 이슈)
