### PR TITLE
[Refactor/#94]: 기능명세서 경로로 API 주소 정렬 (2건)

### DIFF
--- a/src/main/java/com/mamoki/ieojuda/domain/account/controller/ConsentController.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/account/controller/ConsentController.java
@@ -1,0 +1,33 @@
+package com.mamoki.ieojuda.domain.account.controller;
+
+import java.util.UUID;
+
+import com.mamoki.ieojuda.domain.account.dto.ConsentResponse;
+import com.mamoki.ieojuda.domain.account.service.UserService;
+import com.mamoki.ieojuda.global.rsdata.RsData;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+// 명세서 "서비스 안내 / 안전 동의" 화면 - 필수 동의 기록
+// issue #94 - 명세서 경로(POST /api/consents)와 실제 구현(POST /users/me/consent)이 어긋나 있던 것을
+// 명세서 경로로 정렬했다. 상태 조회(GET)는 명세서에 없는 API라 UserController(/users/me/consent)에 남아있다.
+@Tag(name = "Consent", description = "필수 동의 기록")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/consents")
+public class ConsentController {
+
+    private final UserService userService;
+
+    @Operation(summary = "필수 동의", description = "\"사후 인계 안내\" 화면의 필수 동의를 완료합니다. 동의 전에는 다른 API를 호출할 수 없습니다.")
+    @PostMapping
+    public ResponseEntity<RsData<ConsentResponse>> agree(@AuthenticationPrincipal UUID userId) {
+        return ResponseEntity.ok(RsData.success(userService.agree(userId)));
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/account/controller/UserController.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/account/controller/UserController.java
@@ -15,7 +15,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -51,11 +50,9 @@ public class UserController {
         return ResponseEntity.ok(RsData.success(userService.getConsentStatus(userId)));
     }
 
-    @Operation(summary = "필수 동의", description = "\"사후 인계 안내\" 화면의 필수 동의를 완료합니다. 동의 전에는 다른 API를 호출할 수 없습니다.")
-    @PostMapping("/consent")
-    public ResponseEntity<RsData<ConsentResponse>> agree(@AuthenticationPrincipal UUID userId) {
-        return ResponseEntity.ok(RsData.success(userService.agree(userId)));
-    }
+    // issue #94 - 동의 "제출"은 명세서 "서비스 안내 / 안전 동의" 페이지가 요구하는 대로
+    // POST /api/consents로 옮겼다 (ConsentController). 상태 "조회"는 명세서에 없는 추가 API라
+    // 여기 남겨둔다.
 
     @Operation(summary = "계정 삭제", description = "계정과 계획(대화·항목·담당자 등) 데이터를 영구 삭제합니다. 되돌릴 수 없습니다.")
     @DeleteMapping

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/controller/PlanController.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/controller/PlanController.java
@@ -38,8 +38,11 @@ public class PlanController {
     private final PlanService planService;
     private final PlanSummaryService planSummaryService;
 
+    // issue #94 - 명세서 "계획 홈" 경로(GET /api/plans/current/summary)와 실제 구현(GET /api/plans/me)이
+    // 어긋나 있던 것을 명세서 경로로 정렬했다. 명세서의 "GET /api/release-cases/current"(사후 사건 상태)는
+    // 별도 엔드포인트가 아니라 이 응답의 releaseCase 필드로 흡수되어 있다(issue #84).
     @Operation(summary = "내 계획 조회", description = "로그인한 사용자의 계획 홈 요약을 조회합니다. 계획은 회원가입 시 자동으로 1개 생성되므로, planId를 아직 모를 때(로그인 직후 등) 사용합니다.")
-    @GetMapping("/me")
+    @GetMapping("/current/summary")
     public ResponseEntity<RsData<PlanSummaryResponse>> getMyPlan(@AuthenticationPrincipal UUID userId) {
         return ResponseEntity.ok(RsData.success(planSummaryService.getMySummary(userId)));
     }

--- a/src/main/java/com/mamoki/ieojuda/global/consent/filter/ConsentCheckFilter.java
+++ b/src/main/java/com/mamoki/ieojuda/global/consent/filter/ConsentCheckFilter.java
@@ -32,7 +32,10 @@ public class ConsentCheckFilter extends OncePerRequestFilter {
             "/swagger-ui.html",
             "/api/self-warning-email/**",
             "/api/dispute-contacts/*/verify",
-            "/users/me/consent"
+            // issue #94 - 동의 제출은 /api/consents로 옮겨졌다 (ConsentController).
+            // /users/me/consent는 상태 조회(GET)만 남아있지만 계속 제외해야 조회 자체가 막히지 않는다.
+            "/users/me/consent",
+            "/api/consents"
     };
 
     private final UserRepository userRepository;


### PR DESCRIPTION
## 연관 Issue
- Related to #94

## 요약
기능명세서와 실제 구현의 경로가 어긋나 있던 항목 중, 순수 라우팅 변경만으로 정렬 가능한 2건을 명세서 경로로 옮깁니다. 비즈니스 로직은 전혀 변경하지 않았습니다 — 기존 핸들러의 URL 매핑만 이동했습니다.

**⚠️ Breaking change**: 프론트엔드가 기존 경로(`/users/me/consent` POST, `/api/plans/me`)로 이미 연동돼 있다면 프론트 쪽도 함께 수정해야 합니다.

## 변경 사항
- **필수 동의 제출**: `POST /users/me/consent` → `POST /api/consents`
  - 신규 `ConsentController` 추가, `UserController`의 `agree()` 메서드를 그대로 이동
  - 상태 조회(`GET /users/me/consent`)는 명세서에 없는 API라 `UserController`에 그대로 둠
  - `ConsentCheckFilter`의 동의 필터 제외 경로에 `/api/consents` 추가
- **계획 홈 요약**: `GET /api/plans/me` → `GET /api/plans/current/summary`
  - `PlanController`의 `@GetMapping` 경로만 변경, 메서드 본문 동일
  - 명세서의 `GET /api/release-cases/current`(사후 사건 상태)는 별도 엔드포인트가 아니라 이 응답의 `releaseCase` 필드로 이미 흡수되어 있음(issue #84)

## 범위

### 포함
- 위 2건의 경로 변경 (로직 변경 없음)

### 제외 (문서로만 정리, 코드 변경 없음)
아래 6건은 단순 이름 변경이 아니라 흐름 자체를 다시 만들어야 하거나, 팀이 이미 다른 방향으로 정책을 확정한 항목이라 **Notion 문서를 코드에 맞춰 갱신하는 쪽으로 처리**합니다 (이슈 #94의 원래 범위):
- 삶의 구역 작성 (statements+compile 2단계 → 대화형 1콜)
- AI 구조화 결과 검토 (compilations → items, compilation 개념 자체가 없음)
- 사망 신고 이메일 (신고+확인 2단계 → 1콜)
- 공식 증빙 제출 (upload-session+submit 2단계 → 1콜)
- 마이페이지 이메일 변경 (`PUT /users/me/email` → 이름과 통합된 `PUT /users/me`)
- 새 계획 만들기 (`POST /api/plans` → 가입 시 자동 생성으로 대체, 이미 팀 결정 완료)

## 테스트 내역
- `./gradlew compileJava compileTestJava` 성공
- 전체 테스트 스위트 352개 중 5개 실패 — 전부 이 PR과 무관한 사전 존재 문제(로컬 Postgres 스키마 drift, 대용량 멀티파트 소켓 테스트 환경 이슈), 새로 깨진 테스트 없음
- 두 경로 모두 코드베이스 내 하드코딩 참조(테스트 포함) 전수 검색 완료, 다른 곳에서 옛 경로를 참조하는 곳 없음 확인
