### PR TITLE
[Feat/#49]: 사건 생성·대기 시작 전 취소·이의 제기 경고 이메일 발송 및 실패 시 진행 보류

### DIFF
--- a/src/main/java/com/mamoki/ieojuda/domain/audit/controller/EmailAuditController.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/audit/controller/EmailAuditController.java
@@ -61,4 +61,26 @@ public class EmailAuditController {
         emailAuditService.freeze(userId, caseId, request.password());
         return ResponseEntity.ok(RsData.success(null));
     }
+
+    @Operation(summary = "사건 동결 해제하기", description = "동결을 해제합니다. 막혀 있던 경고 발송·상태 전이를 다시 시도하려면 '경고 발송 재시도'를 별도로 호출해야 합니다.")
+    @PostMapping("/unfreeze")
+    public ResponseEntity<RsData<Void>> unfreeze(
+            @AuthenticationPrincipal UUID userId,
+            @Parameter(description = "사건 ID") @PathVariable UUID caseId,
+            @Valid @RequestBody ReauthRequest request
+    ) {
+        emailAuditService.unfreeze(userId, caseId, request.password());
+        return ResponseEntity.ok(RsData.success(null));
+    }
+
+    @Operation(summary = "경고 발송 재시도", description = "취소·이의 제기 경고 메일 발송 실패로 동결된 사건에서, 막혀 있던 발송과 그 발송이 게이트하던 상태 전이를 다시 시도합니다.")
+    @PostMapping("/retry-warning")
+    public ResponseEntity<RsData<Void>> retryWarning(
+            @AuthenticationPrincipal UUID userId,
+            @Parameter(description = "사건 ID") @PathVariable UUID caseId,
+            @Valid @RequestBody ReauthRequest request
+    ) {
+        emailAuditService.retryWarning(userId, caseId, request.password());
+        return ResponseEntity.ok(RsData.success(null));
+    }
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/audit/entity/AdminActionType.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/audit/entity/AdminActionType.java
@@ -3,6 +3,8 @@ package com.mamoki.ieojuda.domain.audit.entity;
 // issue #59 - 감사 대상 고위험 관리자/파트너 조작
 public enum AdminActionType {
     CASE_FREEZE,          // 사건 동결
+    CASE_UNFREEZE,        // 사건 동결 해제
+    CASE_WARNING_RETRY,   // 취소·이의 제기 경고 발송 재시도
     EVIDENCE_DECISION,    // 증빙 승인/반려/추가자료요청
     EVIDENCE_DELETE,      // 증빙 원본 삭제(수동 재처리 또는 자동 스케줄러)
     EVIDENCE_DOWNLOAD,    // issue #43 - 증빙 원본 다운로드(1회성 링크 발급 및 소비)

--- a/src/main/java/com/mamoki/ieojuda/domain/audit/entity/EmailType.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/audit/entity/EmailType.java
@@ -8,6 +8,7 @@ public enum EmailType {
     EVIDENCE_SUBMISSION_REQUEST,  // 증빙 제출 안내
     WAITING_PERIOD_WARNING,       // 대기 기간 경고
     OBJECTION_WINDOW_NOTICE,      // 이의 제기 가능 기간 안내 (issue #41 - RAISE_OBJECTION 토큰 발급 시 발송)
+    CASE_CANCEL_WARNING,          // 사건 생성 시 작성자에게 보내는 취소 링크 경고
     POSTHUMOUS_HANDOFF_LINK,      // 사후 인계 링크
     OTP,                          // OTP 코드
     HANDOFF_CHECK

--- a/src/main/java/com/mamoki/ieojuda/domain/audit/service/EmailAuditService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/audit/service/EmailAuditService.java
@@ -6,9 +6,15 @@ import com.mamoki.ieojuda.domain.audit.dto.EmailDeliveryResponse;
 import com.mamoki.ieojuda.domain.audit.entity.AdminActionType;
 import com.mamoki.ieojuda.domain.audit.entity.EmailLog;
 import com.mamoki.ieojuda.domain.audit.repository.EmailLogRepository;
+import com.mamoki.ieojuda.domain.confirmer.entity.ReportStatus;
+import com.mamoki.ieojuda.domain.confirmer.repository.ConfirmerRepository;
+import com.mamoki.ieojuda.domain.evidence.entity.EvidenceReviewStatus;
+import com.mamoki.ieojuda.domain.evidence.repository.EvidenceRepository;
 import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
 import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCase;
+import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCaseStatus;
 import com.mamoki.ieojuda.domain.releasecase.repository.ReleaseCaseRepository;
+import com.mamoki.ieojuda.domain.releasecase.service.ReleaseCaseWarningService;
 import com.mamoki.ieojuda.domain.securitytoken.entity.SecurityTokenPurpose;
 import com.mamoki.ieojuda.domain.securitytoken.service.SecurityTokenService;
 import com.mamoki.ieojuda.domain.stage.entity.HandoverStage;
@@ -44,6 +50,9 @@ public class EmailAuditService {
     private final ReauthGuard reauthGuard;
     private final AdminActionAuditService adminActionAuditService;
     private final SecurityTokenService securityTokenService;
+    private final ReleaseCaseWarningService releaseCaseWarningService;
+    private final EvidenceRepository evidenceRepository;
+    private final ConfirmerRepository confirmerRepository;
 
     public List<EmailDeliveryResponse> getDeliveries(UUID userId, UUID caseId) {
         permissionGuard.require(userId, AdminPermission.CASE_SUPERVISE);
@@ -101,6 +110,61 @@ public class EmailAuditService {
 
         findCase(caseId).freeze();
         adminActionAuditService.record(actor, AdminActionType.CASE_FREEZE, caseId, true, null);
+    }
+
+    // "사건 동결 해제하기" - freeze()와 대칭되는 순수 플래그 해제. 동결 사유(발송 실패로 인한 자동 동결이든,
+    // 운영자가 임의로 건 동결이든)와 무관하게 항상 사용할 수 있다 - 막혀 있던 경고 발송·상태 전이를 실제로
+    // 재개하려면 retryWarning()을 따로 호출해야 한다(이 메서드는 그 재시도를 하지 않는다).
+    @Transactional
+    public void unfreeze(UUID userId, UUID caseId, String password) {
+        User actor = permissionGuard.require(userId, AdminPermission.CASE_SUPERVISE);
+        try {
+            reauthGuard.verify(actor, password);
+        } catch (CustomException e) {
+            adminActionAuditService.record(actor, AdminActionType.CASE_UNFREEZE, caseId, false, "재인증 실패");
+            throw e;
+        }
+
+        findCase(caseId).unfreeze();
+        adminActionAuditService.record(actor, AdminActionType.CASE_UNFREEZE, caseId, true, null);
+    }
+
+    // "경고 발송 재시도" - 사건 생성/증빙 승인 시점에 경고 메일 발송이 실패해 동결된 사건을 대상으로,
+    // 막혀 있던 경고 발송과 그것이 게이트하던 상태 전이(WAITING 진입)를 다시 시도한다. 증빙이 전부
+    // 승인됐는지를 그때와 동일한 기준으로 재계산해 어느 경고가 막혀 있었는지 판단한다 - 이미 WAITING
+    // 이후 단계로 넘어간 사건은 재시도 대상이 아니다.
+    @Transactional
+    public void retryWarning(UUID userId, UUID caseId, String password) {
+        User actor = permissionGuard.require(userId, AdminPermission.CASE_SUPERVISE);
+        try {
+            reauthGuard.verify(actor, password);
+        } catch (CustomException e) {
+            adminActionAuditService.record(actor, AdminActionType.CASE_WARNING_RETRY, caseId, false, "재인증 실패");
+            throw e;
+        }
+
+        ReleaseCase releaseCase = findCase(caseId);
+        if (releaseCase.getStatus() == ReleaseCaseStatus.WAITING
+                || releaseCase.getStatus() == ReleaseCaseStatus.RELEASING
+                || releaseCase.getStatus() == ReleaseCaseStatus.COMPLETED
+                || releaseCase.getStatus() == ReleaseCaseStatus.CANCELED
+                || releaseCase.getStatus() == ReleaseCaseStatus.DISPUTED) {
+            adminActionAuditService.record(actor, AdminActionType.CASE_WARNING_RETRY, caseId, false, "재시도 대상 아님");
+            throw new CustomException(ErrorCode.INVALID_INPUT);
+        }
+
+        long approvedCount = evidenceRepository.countByReleaseCase_CaseIdAndReviewStatus(caseId, EvidenceReviewStatus.APPROVED);
+        long requiredCount = confirmerRepository.findByPlan_PlanIdAndReportStatus(
+                releaseCase.getPlan().getPlanId(), ReportStatus.MATCHED).size();
+
+        boolean sent = (requiredCount > 0 && approvedCount >= requiredCount)
+                ? releaseCaseWarningService.sendDisputeWarningsAndStartWaiting(releaseCase, releaseCase.getPlan().getWaitingDays())
+                : releaseCaseWarningService.sendAuthorCancelWarningOrFreeze(releaseCase);
+
+        if (sent) {
+            releaseCase.unfreeze();
+        }
+        adminActionAuditService.record(actor, AdminActionType.CASE_WARNING_RETRY, caseId, sent, sent ? null : "발송 재시도 실패");
     }
 
     private ReleaseCase findCase(UUID caseId) {

--- a/src/main/java/com/mamoki/ieojuda/domain/confirmer/service/DeathReportService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/confirmer/service/DeathReportService.java
@@ -15,6 +15,7 @@ import com.mamoki.ieojuda.domain.plan.service.PlanSnapshotService;
 import com.mamoki.ieojuda.domain.recipient.entity.AcceptanceStatus;
 import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCase;
 import com.mamoki.ieojuda.domain.releasecase.repository.ReleaseCaseRepository;
+import com.mamoki.ieojuda.domain.releasecase.service.ReleaseCaseWarningService;
 import com.mamoki.ieojuda.domain.securitytoken.entity.SecurityToken;
 import com.mamoki.ieojuda.domain.securitytoken.entity.SecurityTokenPurpose;
 import com.mamoki.ieojuda.domain.securitytoken.service.SecurityTokenService;
@@ -55,6 +56,7 @@ public class DeathReportService {
     private final EmailOutboxService emailOutboxService;
     private final AppProperties appProperties;
     private final PlanReadinessValidator planReadinessValidator;
+    private final ReleaseCaseWarningService releaseCaseWarningService;
 
     @Transactional
     public DeathReportResponse report(String plainToken, DeathReportRequest request, String idempotencyKey) {
@@ -147,6 +149,9 @@ public class DeathReportService {
         }
         releaseCase.confirmReport();
         releaseCase.awaitEvidence();
+        // 사건이 대기 없이 바로 증빙 단계로 넘어가기 전에, 작성자에게 취소 링크를 반드시 먼저 보낸다.
+        // 발송이 실패하면 사건은 이미 만들어졌으므로 되돌리지 않고 동결해 운영 검토로 넘긴다.
+        releaseCaseWarningService.sendAuthorCancelWarningOrFreeze(releaseCase);
         return releaseCase;
     }
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/partner/service/PartnerReviewService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/partner/service/PartnerReviewService.java
@@ -9,7 +9,6 @@ import com.mamoki.ieojuda.domain.audit.entity.AdminActionType;
 import com.mamoki.ieojuda.domain.audit.service.AdminActionAuditService;
 import com.mamoki.ieojuda.domain.confirmer.entity.ReportStatus;
 import com.mamoki.ieojuda.domain.confirmer.repository.ConfirmerRepository;
-import com.mamoki.ieojuda.domain.confirmer.service.DisputeContactService;
 import com.mamoki.ieojuda.domain.evidence.entity.Evidence;
 import com.mamoki.ieojuda.domain.evidence.entity.EvidenceDownloadToken;
 import com.mamoki.ieojuda.domain.evidence.entity.EvidenceReviewStatus;
@@ -22,6 +21,7 @@ import com.mamoki.ieojuda.domain.partner.dto.PartnerReviewResponse;
 import com.mamoki.ieojuda.domain.partner.entity.PartnerReviewer;
 import com.mamoki.ieojuda.domain.partner.repository.PartnerReviewerRepository;
 import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCase;
+import com.mamoki.ieojuda.domain.releasecase.service.ReleaseCaseWarningService;
 import com.mamoki.ieojuda.domain.securitytoken.entity.SecurityTokenPurpose;
 import com.mamoki.ieojuda.domain.securitytoken.service.SecurityTokenService;
 import com.mamoki.ieojuda.global.email.token.TokenProvider;
@@ -59,7 +59,7 @@ public class PartnerReviewService {
     private final AdminActionAuditService adminActionAuditService;
     private final IdempotencyGuard idempotencyGuard;
     private final SecurityTokenService securityTokenService;
-    private final DisputeContactService disputeContactService;
+    private final ReleaseCaseWarningService releaseCaseWarningService;
 
     public PartnerReviewResponse getReview(UUID userId, UUID reviewId) {
         permissionGuard.require(userId, AdminPermission.EVIDENCE_REVIEW);
@@ -162,10 +162,9 @@ public class PartnerReviewService {
                         releaseCase.getPlan().getPlanId(), ReportStatus.MATCHED).size();
 
                 if (alreadyApprovedCount + 1 >= requiredCount) {
-                    releaseCase.approveEvidenceAndStartWaiting(evidence.getPlan().getWaitingDays());
-                    // issue #41 - 증빙 제출 단계가 끝났으므로 UPLOAD_EVIDENCE 토큰은 더 이상 필요 없다
-                    securityTokenService.revokeAllForCase(releaseCase, SecurityTokenPurpose.UPLOAD_EVIDENCE);
-                    disputeContactService.notifyVerifiedContactsOfObjectionWindow(releaseCase);
+                    // 이의 제기 연락처 전원에게 경고를 보내 발송이 확인된 뒤에만 WAITING으로 전이한다
+                    // (UPLOAD_EVIDENCE 토큰 폐기도 이 메서드 안에서 함께 처리됨) - 발송 실패 시 전이하지 않고 동결한다.
+                    releaseCaseWarningService.sendDisputeWarningsAndStartWaiting(releaseCase, evidence.getPlan().getWaitingDays());
                 } else {
                     releaseCase.markEvidencePartiallyApproved();
                 }

--- a/src/main/java/com/mamoki/ieojuda/domain/releasecase/controller/CaseCancellationController.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/releasecase/controller/CaseCancellationController.java
@@ -1,0 +1,38 @@
+package com.mamoki.ieojuda.domain.releasecase.controller;
+
+import java.util.UUID;
+
+import com.mamoki.ieojuda.domain.releasecase.dto.CaseCancellationRequest;
+import com.mamoki.ieojuda.domain.releasecase.dto.ReleaseStatusResponse;
+import com.mamoki.ieojuda.domain.releasecase.service.CaseCancellationService;
+import com.mamoki.ieojuda.global.rsdata.RsData;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+// 명세서 "사후 인계" 화면 - 경고 메일의 취소 링크로 접수 (로그인 불필요, 초대 토큰이 곧 인증)
+@Tag(name = "CaseCancellation", description = "경고 메일 취소 링크 접수")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/release-cases/{caseId}/cancellations")
+public class CaseCancellationController {
+
+    private final CaseCancellationService caseCancellationService;
+
+    @Operation(summary = "취소 링크로 취소하기", description = "사건 생성 시 발송된 경고 메일의 취소 링크로 진행 중인 절차 전체를 즉시 취소합니다.")
+    @PostMapping
+    public ResponseEntity<RsData<ReleaseStatusResponse>> cancel(
+            @Parameter(description = "사건 ID") @PathVariable UUID caseId,
+            @Valid @RequestBody CaseCancellationRequest request
+    ) {
+        return ResponseEntity.ok(RsData.success(caseCancellationService.cancel(caseId, request.token())));
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/releasecase/dto/CaseCancellationRequest.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/releasecase/dto/CaseCancellationRequest.java
@@ -1,0 +1,11 @@
+package com.mamoki.ieojuda.domain.releasecase.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+// 이메일 속 취소 링크 클릭 - 작성자 본인 확인용 토큰
+public record CaseCancellationRequest(
+        @Schema(description = "취소 링크 토큰")
+        @NotBlank(message = "토큰을 입력해 주세요.") String token
+) {
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/releasecase/service/CaseCancellationService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/releasecase/service/CaseCancellationService.java
@@ -1,0 +1,43 @@
+package com.mamoki.ieojuda.domain.releasecase.service;
+
+import java.util.UUID;
+
+import com.mamoki.ieojuda.domain.releasecase.dto.ReleaseStatusResponse;
+import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCase;
+import com.mamoki.ieojuda.domain.securitytoken.entity.SecurityToken;
+import com.mamoki.ieojuda.domain.securitytoken.entity.SecurityTokenPurpose;
+import com.mamoki.ieojuda.domain.securitytoken.service.SecurityTokenService;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+// 명세서 "사후 인계" 화면 - 사건 생성 시 발송된 경고 메일의 취소 링크로 접수 (로그인 불필요, CANCEL_CASE 토큰이 곧 인증)
+// ReleaseStatusService.cancel()(로그인 필요)과 같은 취소 동작을 수행하되, 인증 수단만 다르다.
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CaseCancellationService {
+
+    private final SecurityTokenService securityTokenService;
+
+    @Transactional
+    public ReleaseStatusResponse cancel(UUID caseId, String plainToken) {
+        SecurityToken token = securityTokenService.resolve(plainToken, SecurityTokenPurpose.CANCEL_CASE);
+
+        // URL의 caseId가 토큰 발급 시 묶인 사건과 실제로 같은지 검증 - ObjectionService.raise()와 동일 패턴
+        if (token.getReleaseCase() == null || !token.getReleaseCase().getCaseId().equals(caseId)) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
+        ReleaseCase releaseCase = token.getReleaseCase();
+
+        releaseCase.cancel();
+        securityTokenService.consume(token);
+        // issue #41 - 사건 종료(취소) 시 이 사건에 묶인 미사용 토큰을 전부 폐기한다 (ReleaseStatusService.cancel()과 동일)
+        securityTokenService.revokeAllForCase(releaseCase, SecurityTokenPurpose.UPLOAD_EVIDENCE);
+        securityTokenService.revokeAllForCase(releaseCase, SecurityTokenPurpose.RAISE_OBJECTION);
+
+        return ReleaseStatusResponse.of(releaseCase);
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/releasecase/service/ReleaseCaseWarningService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/releasecase/service/ReleaseCaseWarningService.java
@@ -1,0 +1,109 @@
+package com.mamoki.ieojuda.domain.releasecase.service;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+
+import com.mamoki.ieojuda.domain.audit.entity.EmailType;
+import com.mamoki.ieojuda.domain.confirmer.entity.DisputeContact;
+import com.mamoki.ieojuda.domain.confirmer.repository.DisputeContactRepository;
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCase;
+import com.mamoki.ieojuda.domain.securitytoken.entity.SecurityTokenPurpose;
+import com.mamoki.ieojuda.domain.securitytoken.service.SecurityTokenService;
+import com.mamoki.ieojuda.global.config.AppProperties;
+import com.mamoki.ieojuda.global.email.contract.EmailContent;
+import com.mamoki.ieojuda.global.email.outbox.CriticalEmailSender;
+import com.mamoki.ieojuda.global.email.template.EmailBuilder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+// 이 작업의 핵심 - "공개 절차가 시작되기 전에 취소·이의 제기 경고가 실제로 전달된다"를 보장하기 위한
+// 게이트. EmailOutbox(완전 비동기)와 달리 여기 두 메서드는 CriticalEmailSender로 발송 성공을 그 자리에서
+// 확인한 뒤에만 사건 상태 전이를 수행한다 - 실패하면 전이를 하지 않고 releaseCase.freeze()로 진행을
+// 멈춘다("이메일 발송 감사" 화면의 동결 메커니즘 재사용). 두 트리거(사건 생성, 증빙 승인)와 운영자
+// 재시도 액션이 이 서비스를 공유한다.
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReleaseCaseWarningService {
+
+    private static final int DEFAULT_WAITING_DAYS = 7;
+    // "단기" 취소 토큰 - DeathReportService.EVIDENCE_TOKEN_TTL_DAYS와 동일 수준. appProperties의
+    // activeTokenTtlDays(10년, 장기 보안 토큰용)를 재사용하면 사실상 무기한이 되어 "단기 토큰 발급"이라는
+    // 완료 조건과 어긋나므로 별도 상수로 둔다.
+    private static final long CANCEL_TOKEN_TTL_DAYS = 30;
+
+    private final DisputeContactRepository disputeContactRepository;
+    private final SecurityTokenService securityTokenService;
+    private final CriticalEmailSender criticalEmailSender;
+    private final AppProperties appProperties;
+
+    // 사건 생성 직후 - 작성자(본인 경고 이메일, 이미 검증됨)에게 취소 링크를 보낸다.
+    // 실패하면 사건을 동결해 운영 검토로 넘긴다(사건 자체는 이미 만들어져 있어야 하므로 생성을 되돌리지 않는다).
+    @Transactional
+    public boolean sendAuthorCancelWarningOrFreeze(ReleaseCase releaseCase) {
+        Plan plan = releaseCase.getPlan();
+        LocalDateTime expiresAt = LocalDateTime.now().plusDays(CANCEL_TOKEN_TTL_DAYS);
+        String plainToken = securityTokenService.issueForCase(SecurityTokenPurpose.CANCEL_CASE, releaseCase, expiresAt);
+
+        String secureLink = appProperties.getBaseUrl() + "/release-cases/" + releaseCase.getCaseId() + "/cancellations/" + plainToken;
+        EmailContent content = EmailBuilder.build(
+                "사후 절차 시작 및 취소 안내",
+                "본인이 아니거나 절차를 멈추고 싶다면 링크를 눌러 즉시 취소해 주세요.",
+                expiresAt.atZone(ZoneId.systemDefault()),
+                secureLink,
+                appProperties.getContactEmail()
+        );
+
+        boolean sent = criticalEmailSender.sendOrFail(plan, EmailType.CASE_CANCEL_WARNING, plan.getSelfWarningEmail(), content);
+        if (!sent) {
+            releaseCase.freeze();
+        }
+        return sent;
+    }
+
+    // 증빙이 전부 승인된 시점 - 검증된 이의 제기 연락처 전원에게 이의 제기 링크를 보낸 뒤에만 WAITING으로
+    // 전이한다. 하나라도 발송에 실패하면(나머지 연락처에도 계속 시도는 하되) 전이를 하지 않고 동결한다.
+    // waitingEndsAt을 먼저 확정해 WAITING에 들어간 뒤 발송 실패를 알면, 나중에 동결이 풀렸을 때 이미 지난
+    // waitingEndsAt 때문에 경고가 도착하자마자 발송 단계로 넘어가는 문제가 생기므로 순서를 반드시 지킨다.
+    @Transactional
+    public boolean sendDisputeWarningsAndStartWaiting(ReleaseCase releaseCase, Integer waitingDays) {
+        LocalDateTime intendedWaitingEndsAt = LocalDateTime.now().plusDays(waitingDays != null ? waitingDays : DEFAULT_WAITING_DAYS);
+
+        List<DisputeContact> contacts = disputeContactRepository.findByPlan_PlanId(releaseCase.getPlan().getPlanId());
+        boolean allSent = true;
+        for (DisputeContact contact : contacts) {
+            if (!Boolean.TRUE.equals(contact.getIsVerified())) {
+                continue;
+            }
+            if (!sendObjectionWindowWarning(releaseCase, contact, intendedWaitingEndsAt)) {
+                allSent = false;
+            }
+        }
+
+        if (allSent) {
+            releaseCase.approveEvidenceAndStartWaiting(waitingDays);
+            securityTokenService.revokeAllForCase(releaseCase, SecurityTokenPurpose.UPLOAD_EVIDENCE);
+        } else {
+            releaseCase.freeze();
+        }
+        return allSent;
+    }
+
+    private boolean sendObjectionWindowWarning(ReleaseCase releaseCase, DisputeContact contact, LocalDateTime expiresAt) {
+        String plainToken = securityTokenService.issueForDisputeContact(
+                SecurityTokenPurpose.RAISE_OBJECTION, contact, releaseCase, expiresAt);
+
+        String secureLink = appProperties.getBaseUrl() + "/release-cases/" + releaseCase.getCaseId() + "/disputes/" + plainToken;
+        EmailContent content = EmailBuilder.build(
+                "이의 제기 가능 기간 안내",
+                "잘못된 점이 있다면 링크로 들어가 이의를 제기해 주세요.",
+                expiresAt.atZone(ZoneId.systemDefault()),
+                secureLink,
+                appProperties.getContactEmail()
+        );
+        return criticalEmailSender.sendOrFail(contact.getPlan(), EmailType.OBJECTION_WINDOW_NOTICE, contact.getEmail(), content);
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/securitytoken/entity/SecurityTokenPurpose.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/securitytoken/entity/SecurityTokenPurpose.java
@@ -6,5 +6,6 @@ public enum SecurityTokenPurpose {
     ACCEPT_ROLE,      // 역할 담당자·지정 확인자 수락/거절
     REPORT_DEATH,     // 지정 확인자의 사망 신고
     UPLOAD_EVIDENCE,  // 지정 확인자의 공식 증빙 제출
-    RAISE_OBJECTION   // 이의 제기 연락처의 이의 제기
+    RAISE_OBJECTION,  // 이의 제기 연락처의 이의 제기
+    CANCEL_CASE       // 작성자 본인의 취소 (사건 바인딩만으로 특정 - 계획당 작성자 1명)
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/securitytoken/service/SecurityTokenService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/securitytoken/service/SecurityTokenService.java
@@ -66,6 +66,19 @@ public class SecurityTokenService {
         return plainToken;
     }
 
+    // 작성자는 계획당 1명이라 별도 대상 필드 없이 releaseCase 바인딩만으로 충분히 특정된다 (예: CANCEL_CASE)
+    @Transactional
+    public String issueForCase(SecurityTokenPurpose purpose, ReleaseCase releaseCase, LocalDateTime expiresAt) {
+        String plainToken = TokenProvider.generatePlainToken();
+        securityTokenRepository.save(SecurityToken.builder()
+                .tokenHash(TokenProvider.hashToken(plainToken))
+                .purpose(purpose)
+                .releaseCase(releaseCase)
+                .expiresAt(expiresAt)
+                .build());
+        return plainToken;
+    }
+
     // 조회 + 만료·사용·폐기·목적 불일치 검증 (아직 소비하지 않음 - 실제 처리가 성공한 뒤 consume()을 별도 호출)
     public SecurityToken resolve(String plainToken, SecurityTokenPurpose expectedPurpose) {
         SecurityToken token = tokenLookupGuard.resolve(plainToken,

--- a/src/main/java/com/mamoki/ieojuda/global/config/SecurityConfig.java
+++ b/src/main/java/com/mamoki/ieojuda/global/config/SecurityConfig.java
@@ -41,6 +41,7 @@ public class SecurityConfig {
             "/api/self-warning-email/**",
             "/api/dispute-contacts/*/verify",
             "/api/release-cases/*/disputes", // 이의 제기 접수 (초대 토큰이 곧 인증)
+            "/api/release-cases/*/cancellations", // 경고 메일 취소 링크 접수 (CANCEL_CASE 토큰이 곧 인증)
             "/api/release-cases/*/evidence/**", // 증빙 제출 (초대 토큰이 곧 인증)
             "/api/recipient-acceptances/**",// 역할 담당자 수락
             "/api/confirmer-acceptances/**", // 지정확인자 수락 / 사망 신고
@@ -87,6 +88,7 @@ public class SecurityConfig {
                 new RateLimitRule("death-report", "/api/confirmer-acceptances/*/death-report", "POST", 10, Duration.ofHours(1)),
                 new RateLimitRule("evidence-submit", "/api/release-cases/*/evidence/submit", "POST", 10, Duration.ofHours(1)),
                 new RateLimitRule("objection", "/api/release-cases/*/disputes", "POST", 10, Duration.ofHours(1)),
+                new RateLimitRule("case-cancellation", "/api/release-cases/*/cancellations", "POST", 10, Duration.ofHours(1)),
                 new RateLimitRule("dispute-verify", "/api/dispute-contacts/*/verify", null, 20, Duration.ofHours(1)),
                 new RateLimitRule("dispute-contact-resend", "/api/dispute-contacts/*/verification-email", "POST", 5, Duration.ofHours(1)),
                 new RateLimitRule("self-warning-email", "/api/self-warning-email/**", null, 20, Duration.ofHours(1)),

--- a/src/main/java/com/mamoki/ieojuda/global/email/outbox/CriticalEmailSender.java
+++ b/src/main/java/com/mamoki/ieojuda/global/email/outbox/CriticalEmailSender.java
@@ -1,0 +1,44 @@
+package com.mamoki.ieojuda.global.email.outbox;
+
+import com.mamoki.ieojuda.domain.audit.entity.EmailLog;
+import com.mamoki.ieojuda.domain.audit.entity.EmailType;
+import com.mamoki.ieojuda.domain.audit.repository.EmailLogRepository;
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.global.email.contract.EmailContent;
+import com.mamoki.ieojuda.global.email.contract.EmailSendResult;
+import com.mamoki.ieojuda.global.email.sender.EmailSender;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+// 사건 생성·대기 시작처럼 "발송 성공을 확인해야만 다음 상태 전이를 허용"해야 하는 경고 메일 전용 발송 경로.
+// EmailOutboxService는 "네트워크 호출 없이 DB 저장만 한다"는 게 명시된 불변식이라(EmailOutboxScheduler가
+// 10분 주기로 비동기 발송) 재사용하지 않고, 이 컴포넌트가 EmailSender를 직접 동기 호출해 그 자리에서
+// 성공/실패를 확정한다. 실패해도 EmailLog에는 FAILED로 정확히 기록되어 "발송 실패가 성공으로 기록되지
+// 않는다"를 보장한다.
+@Component
+@RequiredArgsConstructor
+public class CriticalEmailSender {
+
+    private final EmailLogRepository emailLogRepository;
+    private final EmailSender emailSender;
+
+    @Transactional
+    public boolean sendOrFail(Plan plan, EmailType emailType, String recipientEmail, EmailContent content) {
+        EmailLog log = emailLogRepository.save(EmailLog.builder()
+                .plan(plan)
+                .handoverStage(null)
+                .emailType(emailType)
+                .recipientEmail(recipientEmail)
+                .build());
+
+        EmailSendResult result = emailSender.send(recipientEmail, content);
+        if (result.success()) {
+            log.markSent(result.messageId());
+            return true;
+        }
+
+        log.markFailed(result.bounceType() + ":" + result.emailFaill());
+        return false;
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/domain/audit/service/EmailAuditServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/audit/service/EmailAuditServiceTest.java
@@ -1,0 +1,157 @@
+package com.mamoki.ieojuda.domain.audit.service;
+
+import com.mamoki.ieojuda.domain.account.entity.AdminPermission;
+import com.mamoki.ieojuda.domain.account.entity.User;
+import com.mamoki.ieojuda.domain.audit.entity.AdminActionType;
+import com.mamoki.ieojuda.domain.audit.repository.EmailLogRepository;
+import com.mamoki.ieojuda.domain.confirmer.entity.ReportStatus;
+import com.mamoki.ieojuda.domain.confirmer.repository.ConfirmerRepository;
+import com.mamoki.ieojuda.domain.evidence.entity.EvidenceReviewStatus;
+import com.mamoki.ieojuda.domain.evidence.repository.EvidenceRepository;
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCase;
+import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCaseStatus;
+import com.mamoki.ieojuda.domain.releasecase.repository.ReleaseCaseRepository;
+import com.mamoki.ieojuda.domain.releasecase.service.ReleaseCaseWarningService;
+import com.mamoki.ieojuda.domain.securitytoken.service.SecurityTokenService;
+import com.mamoki.ieojuda.global.config.AppProperties;
+import com.mamoki.ieojuda.global.email.outbox.EmailOutboxService;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import com.mamoki.ieojuda.global.security.PermissionGuard;
+import com.mamoki.ieojuda.global.security.ReauthGuard;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+// "경고 발송 재시도"가 재인증 없이는 실행되지 않고, 이미 WAITING 이후로 넘어간 사건은 재시도 대상에서
+// 제외되며, 재시도 성공 시에만 동결이 풀리는지 검증한다.
+class EmailAuditServiceTest {
+
+    private static final UUID USER_ID = UUID.randomUUID();
+    private static final UUID CASE_ID = UUID.randomUUID();
+    private static final UUID PLAN_ID = UUID.randomUUID();
+
+    private ReleaseCaseRepository releaseCaseRepository;
+    private EmailLogRepository emailLogRepository;
+    private EmailOutboxService emailOutboxService;
+    private AppProperties appProperties;
+    private PermissionGuard permissionGuard;
+    private ReauthGuard reauthGuard;
+    private AdminActionAuditService adminActionAuditService;
+    private SecurityTokenService securityTokenService;
+    private ReleaseCaseWarningService releaseCaseWarningService;
+    private EvidenceRepository evidenceRepository;
+    private ConfirmerRepository confirmerRepository;
+    private EmailAuditService emailAuditService;
+
+    private User actor;
+    private ReleaseCase releaseCase;
+    private Plan plan;
+
+    @BeforeEach
+    void setUp() {
+        releaseCaseRepository = mock(ReleaseCaseRepository.class);
+        emailLogRepository = mock(EmailLogRepository.class);
+        emailOutboxService = mock(EmailOutboxService.class);
+        appProperties = mock(AppProperties.class);
+        permissionGuard = mock(PermissionGuard.class);
+        reauthGuard = mock(ReauthGuard.class);
+        adminActionAuditService = mock(AdminActionAuditService.class);
+        securityTokenService = mock(SecurityTokenService.class);
+        releaseCaseWarningService = mock(ReleaseCaseWarningService.class);
+        evidenceRepository = mock(EvidenceRepository.class);
+        confirmerRepository = mock(ConfirmerRepository.class);
+        emailAuditService = new EmailAuditService(
+                releaseCaseRepository, emailLogRepository, emailOutboxService, appProperties, permissionGuard,
+                reauthGuard, adminActionAuditService, securityTokenService, releaseCaseWarningService,
+                evidenceRepository, confirmerRepository);
+
+        actor = mock(User.class);
+        when(permissionGuard.require(USER_ID, AdminPermission.CASE_SUPERVISE)).thenReturn(actor);
+
+        plan = mock(Plan.class);
+        when(plan.getPlanId()).thenReturn(PLAN_ID);
+        when(plan.getWaitingDays()).thenReturn(7);
+        releaseCase = mock(ReleaseCase.class);
+        when(releaseCase.getPlan()).thenReturn(plan);
+        when(releaseCaseRepository.findById(CASE_ID)).thenReturn(Optional.of(releaseCase));
+    }
+
+    @Test
+    void retryWarning_whenReauthFails_doesNotAttemptRetry() {
+        doThrow(new CustomException(ErrorCode.REAUTH_FAILED)).when(reauthGuard).verify(actor, "wrong-pw");
+
+        assertThatThrownBy(() -> emailAuditService.retryWarning(USER_ID, CASE_ID, "wrong-pw"))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.REAUTH_FAILED));
+
+        verify(releaseCaseWarningService, never()).sendAuthorCancelWarningOrFreeze(any());
+        verify(releaseCaseWarningService, never()).sendDisputeWarningsAndStartWaiting(any(), any());
+    }
+
+    @Test
+    void retryWarning_whenCaseAlreadyWaiting_isRejected() {
+        when(releaseCase.getStatus()).thenReturn(ReleaseCaseStatus.WAITING);
+
+        assertThatThrownBy(() -> emailAuditService.retryWarning(USER_ID, CASE_ID, "pw"))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.INVALID_INPUT));
+
+        verify(releaseCaseWarningService, never()).sendAuthorCancelWarningOrFreeze(any());
+        verify(releaseCaseWarningService, never()).sendDisputeWarningsAndStartWaiting(any(), any());
+    }
+
+    // 증빙이 아직 전부 승인되지 않은 사건 - 사건 생성 시점의 작성자 경고가 막혀 있던 경우
+    @Test
+    void retryWarning_whenEvidenceNotFullyApproved_retriesAuthorWarningAndUnfreezesOnSuccess() {
+        when(releaseCase.getStatus()).thenReturn(ReleaseCaseStatus.EVIDENCE_PENDING);
+        when(evidenceRepository.countByReleaseCase_CaseIdAndReviewStatus(CASE_ID, EvidenceReviewStatus.APPROVED)).thenReturn(0L);
+        when(confirmerRepository.findByPlan_PlanIdAndReportStatus(PLAN_ID, ReportStatus.MATCHED)).thenReturn(List.of());
+        when(releaseCaseWarningService.sendAuthorCancelWarningOrFreeze(releaseCase)).thenReturn(true);
+
+        emailAuditService.retryWarning(USER_ID, CASE_ID, "pw");
+
+        verify(releaseCaseWarningService).sendAuthorCancelWarningOrFreeze(releaseCase);
+        verify(releaseCaseWarningService, never()).sendDisputeWarningsAndStartWaiting(any(), any());
+        verify(releaseCase).unfreeze();
+        verify(adminActionAuditService).record(actor, AdminActionType.CASE_WARNING_RETRY, CASE_ID, true, null);
+    }
+
+    // 증빙이 전부 승인된 사건 - 대기 시작 시점의 이의 연락처 경고가 막혀 있던 경우
+    @Test
+    void retryWarning_whenEvidenceFullyApproved_retriesDisputeWarningAndStaysFrozenOnFailure() {
+        when(releaseCase.getStatus()).thenReturn(ReleaseCaseStatus.EVIDENCE_APPROVED);
+        when(evidenceRepository.countByReleaseCase_CaseIdAndReviewStatus(CASE_ID, EvidenceReviewStatus.APPROVED)).thenReturn(2L);
+        when(confirmerRepository.findByPlan_PlanIdAndReportStatus(PLAN_ID, ReportStatus.MATCHED))
+                .thenReturn(List.of(mock(com.mamoki.ieojuda.domain.confirmer.entity.Confirmer.class),
+                        mock(com.mamoki.ieojuda.domain.confirmer.entity.Confirmer.class)));
+        when(releaseCaseWarningService.sendDisputeWarningsAndStartWaiting(releaseCase, 7)).thenReturn(false);
+
+        emailAuditService.retryWarning(USER_ID, CASE_ID, "pw");
+
+        verify(releaseCaseWarningService).sendDisputeWarningsAndStartWaiting(releaseCase, 7);
+        verify(releaseCase, never()).unfreeze();
+        verify(adminActionAuditService).record(actor, AdminActionType.CASE_WARNING_RETRY, CASE_ID, false, "발송 재시도 실패");
+    }
+
+    @Test
+    void unfreeze_whenReauthSucceeds_clearsFrozenFlag() {
+        emailAuditService.unfreeze(USER_ID, CASE_ID, "pw");
+
+        verify(releaseCase).unfreeze();
+        verify(adminActionAuditService).record(actor, AdminActionType.CASE_UNFREEZE, CASE_ID, true, null);
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/domain/confirmer/service/AuthorCancelWarningIntegrationTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/confirmer/service/AuthorCancelWarningIntegrationTest.java
@@ -1,0 +1,230 @@
+package com.mamoki.ieojuda.domain.confirmer.service;
+
+import com.mamoki.ieojuda.domain.account.entity.User;
+import com.mamoki.ieojuda.domain.account.repository.UserRepository;
+import com.mamoki.ieojuda.domain.audit.entity.EmailDeliveryStatus;
+import com.mamoki.ieojuda.domain.audit.entity.EmailLog;
+import com.mamoki.ieojuda.domain.audit.entity.EmailType;
+import com.mamoki.ieojuda.domain.audit.repository.EmailLogRepository;
+import com.mamoki.ieojuda.domain.confirmer.dto.DeathReportRequest;
+import com.mamoki.ieojuda.domain.confirmer.entity.Confirmer;
+import com.mamoki.ieojuda.domain.confirmer.entity.DisputeContact;
+import com.mamoki.ieojuda.domain.confirmer.entity.Relationship;
+import com.mamoki.ieojuda.domain.confirmer.repository.ConfirmerRepository;
+import com.mamoki.ieojuda.domain.confirmer.repository.DisputeContactRepository;
+import com.mamoki.ieojuda.domain.plan.entity.Conversation;
+import com.mamoki.ieojuda.domain.plan.entity.DisclosureScope;
+import com.mamoki.ieojuda.domain.plan.entity.Item;
+import com.mamoki.ieojuda.domain.plan.entity.ItemActionType;
+import com.mamoki.ieojuda.domain.plan.entity.LifeArea;
+import com.mamoki.ieojuda.domain.plan.entity.LifeAreaCategory;
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.plan.repository.ConversationRepository;
+import com.mamoki.ieojuda.domain.plan.repository.ItemRepository;
+import com.mamoki.ieojuda.domain.plan.repository.LifeAreaRepository;
+import com.mamoki.ieojuda.domain.plan.repository.PlanRepository;
+import com.mamoki.ieojuda.domain.plan.repository.PlanVersionRepository;
+import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
+import com.mamoki.ieojuda.domain.recipient.entity.RoleType;
+import com.mamoki.ieojuda.domain.recipient.repository.RecipientRepository;
+import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCase;
+import com.mamoki.ieojuda.domain.releasecase.repository.ReleaseCaseRepository;
+import com.mamoki.ieojuda.domain.securitytoken.entity.SecurityTokenPurpose;
+import com.mamoki.ieojuda.domain.securitytoken.repository.SecurityTokenRepository;
+import com.mamoki.ieojuda.domain.securitytoken.service.SecurityTokenService;
+import com.mamoki.ieojuda.global.email.contract.BounceType;
+import com.mamoki.ieojuda.global.email.contract.EmailFaill;
+import com.mamoki.ieojuda.global.email.contract.EmailSendResult;
+import com.mamoki.ieojuda.global.email.outbox.EmailOutboxRepository;
+import com.mamoki.ieojuda.global.email.sender.EmailSender;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+// 완료 조건 통합 검증 - "사건 생성 시 검증된 작성자 경고 이메일 발송 연결"과 "발송 실패가 성공으로
+// 기록되지 않는다"를 실제 스프링 컨텍스트·DB로 검증한다. SMTP만 @MockitoBean으로 격리하고(실제 이메일을
+// 보내지 않기 위함 - PartnerReviewAccessHttpIntegrationTest가 EvidenceStorageClient를 격리하는 것과
+// 동일한 패턴), 그 외 트랜잭션·리포지토리·엔티티 상태 전이는 전부 실제 경로를 그대로 탄다.
+@SpringBootTest
+class AuthorCancelWarningIntegrationTest {
+
+    private static final LocalDate REPORTED_DEATH_DATE = LocalDate.of(2026, 8, 15);
+
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private PlanRepository planRepository;
+    @Autowired
+    private ConversationRepository conversationRepository;
+    @Autowired
+    private LifeAreaRepository lifeAreaRepository;
+    @Autowired
+    private RecipientRepository recipientRepository;
+    @Autowired
+    private ItemRepository itemRepository;
+    @Autowired
+    private ConfirmerRepository confirmerRepository;
+    @Autowired
+    private DisputeContactRepository disputeContactRepository;
+    @Autowired
+    private ReleaseCaseRepository releaseCaseRepository;
+    @Autowired
+    private PlanVersionRepository planVersionRepository;
+    @Autowired
+    private SecurityTokenRepository securityTokenRepository;
+    @Autowired
+    private SecurityTokenService securityTokenService;
+    @Autowired
+    private EmailLogRepository emailLogRepository;
+    @Autowired
+    private EmailOutboxRepository emailOutboxRepository;
+    @Autowired
+    private DeathReportService deathReportService;
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    @MockitoBean
+    private EmailSender emailSender;
+
+    private User user;
+    private Plan plan;
+    private Conversation conversation;
+    private LifeArea lifeArea;
+    private Recipient recipient;
+    private Item item;
+    private Confirmer confirmerA;
+    private Confirmer confirmerB;
+    private DisputeContact disputeContact;
+
+    // DeathReportReadinessIntegrationTest.createFixture()와 동일한 조건(이의 연락처 인증·대기 기간·
+    // 본인 경고 이메일 인증·실행 순서 확정·수락 확인자 2명·봉인)을 갖춘 계획을 만든다 - PlanReadinessValidator를
+    // 통과해야 사건 생성까지 도달할 수 있다.
+    @BeforeEach
+    void setUp() {
+        user = userRepository.saveAndFlush(User.builder()
+                .email("author-warning-" + UUID.randomUUID() + "@test.com").password("hash").name("김철수").build());
+        plan = planRepository.saveAndFlush(Plan.builder().user(user).build());
+        conversation = conversationRepository.saveAndFlush(Conversation.builder().plan(plan).build());
+        lifeArea = lifeAreaRepository.saveAndFlush(
+                LifeArea.builder().plan(plan).conversation(conversation).category(LifeAreaCategory.RELATIONSHIP_CLEANUP).build());
+        recipient = recipientRepository.saveAndFlush(Recipient.builder()
+                .plan(plan).lifeArea(lifeArea).name("이지수").email("recipient-" + UUID.randomUUID() + "@test.com")
+                .roleType(RoleType.RELATIONSHIP_MANAGER).isBackup(false)
+                .disclosureScope(DisclosureScope.RELATIONSHIP).maxWaitHours(168).backupFor(null).build());
+        item = Item.builder()
+                .lifeArea(lifeArea).targetName("이지수").locationType("인스타그램").action("정리해줘")
+                .title("SNS 정리").content("비공개로 전환").precondition("")
+                .disclosureScope(DisclosureScope.RELATIONSHIP).sourceExcerpt("근거 발췌")
+                .sortOrder(0).actionType(ItemActionType.DELETE).build();
+        item.assignRecipient(recipient);
+        item = itemRepository.saveAndFlush(item);
+
+        confirmerA = Confirmer.builder().plan(plan).name("A").relationship(Relationship.FRIEND)
+                .email("confirmer-a-" + UUID.randomUUID() + "@test.com").build();
+        confirmerA.accept(null);
+        confirmerA = confirmerRepository.saveAndFlush(confirmerA);
+        confirmerB = Confirmer.builder().plan(plan).name("B").relationship(Relationship.FRIEND)
+                .email("confirmer-b-" + UUID.randomUUID() + "@test.com").build();
+        confirmerB.accept(null);
+        confirmerB = confirmerRepository.saveAndFlush(confirmerB);
+
+        disputeContact = DisputeContact.builder().plan(plan)
+                .email("dispute-" + UUID.randomUUID() + "@test.com").name("이의연락처").build();
+        disputeContact.verify();
+        disputeContact = disputeContactRepository.saveAndFlush(disputeContact);
+
+        plan.updateWaitingDays(14);
+        plan.requestSelfWarningEmailVerification("warn-" + UUID.randomUUID() + "@test.com", "hash", LocalDateTime.now().plusDays(1));
+        plan.verifySelfWarningEmail();
+        plan.confirmOrder();
+        plan.seal();
+        plan = planRepository.saveAndFlush(plan);
+    }
+
+    @AfterEach
+    void tearDown() {
+        releaseCaseRepository.findByPlan_PlanId(plan.getPlanId()).forEach(releaseCase -> {
+            new TransactionTemplate(transactionManager).executeWithoutResult(
+                    status -> securityTokenRepository.deleteByReleaseCase_CaseId(releaseCase.getCaseId()));
+            releaseCaseRepository.delete(releaseCase);
+        });
+        planVersionRepository.findByPlan_PlanId(plan.getPlanId()).forEach(planVersionRepository::delete);
+        new TransactionTemplate(transactionManager).executeWithoutResult(status -> {
+            securityTokenRepository.deleteByConfirmer_ConfirmId(confirmerA.getConfirmId());
+            securityTokenRepository.deleteByConfirmer_ConfirmId(confirmerB.getConfirmId());
+        });
+        confirmerRepository.delete(confirmerA);
+        confirmerRepository.delete(confirmerB);
+        disputeContactRepository.delete(disputeContact);
+        for (EmailLog emailLog : emailLogRepository.findByPlan_PlanIdOrderByRequestedAtDesc(plan.getPlanId())) {
+            new TransactionTemplate(transactionManager).executeWithoutResult(
+                    status -> emailOutboxRepository.deleteByEmailLog_LogId(emailLog.getLogId()));
+            emailLogRepository.delete(emailLog);
+        }
+        itemRepository.delete(item);
+        recipientRepository.delete(recipient);
+        lifeAreaRepository.delete(lifeArea);
+        conversationRepository.delete(conversation);
+        planRepository.delete(plan);
+        userRepository.delete(user);
+    }
+
+    private void matchBothConfirmers() {
+        String tokenA = securityTokenService.issueForConfirmer(
+                SecurityTokenPurpose.REPORT_DEATH, confirmerA, null, LocalDateTime.now().plusDays(1));
+        String tokenB = securityTokenService.issueForConfirmer(
+                SecurityTokenPurpose.REPORT_DEATH, confirmerB, null, LocalDateTime.now().plusDays(1));
+        deathReportService.report(tokenA, new DeathReportRequest(REPORTED_DEATH_DATE), null);
+        deathReportService.report(tokenB, new DeathReportRequest(REPORTED_DEATH_DATE), null);
+    }
+
+    private EmailLog findCancelWarningLog() {
+        return emailLogRepository.findByPlan_PlanIdOrderByRequestedAtDesc(plan.getPlanId()).stream()
+                .filter(log -> log.getEmailType() == EmailType.CASE_CANCEL_WARNING)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("CASE_CANCEL_WARNING 로그가 기록되지 않았습니다"));
+    }
+
+    @Test
+    void report_whenAuthorWarningSendSucceeds_caseNotFrozenAndLoggedAsSent() {
+        when(emailSender.send(eq(plan.getSelfWarningEmail()), any())).thenReturn(EmailSendResult.success("msg-1"));
+
+        matchBothConfirmers();
+
+        ReleaseCase releaseCase = releaseCaseRepository.findFirstByPlan_PlanIdOrderByCaseIdDesc(plan.getPlanId()).orElseThrow();
+        assertThat(releaseCase.getFrozen()).isFalse();
+
+        EmailLog log = findCancelWarningLog();
+        assertThat(log.getStatus()).isEqualTo(EmailDeliveryStatus.SENT);
+        assertThat(log.getRecipientEmail()).isEqualTo(plan.getSelfWarningEmail());
+    }
+
+    // 핵심 완료 조건 - 발송 실패가 성공으로 기록되지 않고, 사건은 진행을 멈춘다(동결)
+    @Test
+    void report_whenAuthorWarningSendFails_freezesCaseAndLogsFailure() {
+        when(emailSender.send(eq(plan.getSelfWarningEmail()), any()))
+                .thenReturn(EmailSendResult.failure(BounceType.PERMANENT, EmailFaill.INVALID_ADDRESS_FORMAT));
+
+        matchBothConfirmers();
+
+        ReleaseCase releaseCase = releaseCaseRepository.findFirstByPlan_PlanIdOrderByCaseIdDesc(plan.getPlanId()).orElseThrow();
+        assertThat(releaseCase.getFrozen()).isTrue();
+
+        EmailLog log = findCancelWarningLog();
+        assertThat(log.getStatus()).isEqualTo(EmailDeliveryStatus.FAILED);
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/domain/confirmer/service/DeathReportServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/confirmer/service/DeathReportServiceTest.java
@@ -16,6 +16,7 @@ import com.mamoki.ieojuda.domain.plan.repository.PlanVersionRepository;
 import com.mamoki.ieojuda.domain.plan.service.PlanReadinessValidator;
 import com.mamoki.ieojuda.domain.plan.service.PlanSnapshotService;
 import com.mamoki.ieojuda.domain.releasecase.repository.ReleaseCaseRepository;
+import com.mamoki.ieojuda.domain.releasecase.service.ReleaseCaseWarningService;
 import com.mamoki.ieojuda.domain.securitytoken.entity.SecurityToken;
 import com.mamoki.ieojuda.domain.securitytoken.entity.SecurityTokenPurpose;
 import com.mamoki.ieojuda.domain.securitytoken.service.SecurityTokenService;
@@ -59,6 +60,7 @@ class DeathReportServiceTest {
     private EmailOutboxService emailOutboxService;
     private AppProperties appProperties;
     private PlanReadinessValidator planReadinessValidator;
+    private ReleaseCaseWarningService releaseCaseWarningService;
     private DeathReportService deathReportService;
 
     @BeforeEach
@@ -72,10 +74,11 @@ class DeathReportServiceTest {
         emailOutboxService = mock(EmailOutboxService.class);
         appProperties = mock(AppProperties.class);
         planReadinessValidator = mock(PlanReadinessValidator.class);
+        releaseCaseWarningService = mock(ReleaseCaseWarningService.class);
         deathReportService = new DeathReportService(
                 confirmerRepository, releaseCaseRepository, planVersionRepository,
                 planSnapshotService, idempotencyGuard, securityTokenService, emailOutboxService, appProperties,
-                planReadinessValidator);
+                planReadinessValidator, releaseCaseWarningService);
 
         when(appProperties.getBaseUrl()).thenReturn("https://ieoduda.example.com");
         when(appProperties.getContactEmail()).thenReturn("support@ieoduda.example.com");
@@ -130,6 +133,43 @@ class DeathReportServiceTest {
 
         assertThat(reporting.getReportStatus()).isEqualTo(ReportStatus.MATCHED);
         assertThat(sibling.getReportStatus()).isEqualTo(ReportStatus.MATCHED);
+        // 사건 생성 직후 작성자에게 취소 경고 메일 발송을 시도했는지 확인
+        verify(releaseCaseWarningService).sendAuthorCancelWarningOrFreeze(any());
+    }
+
+    // 작성자 경고 메일 발송이 실패해도(운영 검토로 동결될 뿐) report() 자체는 정상 응답해야 한다 -
+    // 이미 성사된 두 확인자의 신고 매칭까지 되돌릴 이유가 없다.
+    @Test
+    void report_whenAuthorWarningSendFails_stillReturnsSuccessResponse() {
+        Plan plan = mock(Plan.class);
+        when(plan.getPlanId()).thenReturn(PLAN_ID);
+
+        Confirmer reporting = confirmerAcceptedOn(plan, "A", "a@test.com");
+        SecurityToken reportDeathToken = mock(SecurityToken.class);
+        when(reportDeathToken.getConfirmer()).thenReturn(reporting);
+        when(securityTokenService.resolve(eq("token-a"), eq(SecurityTokenPurpose.REPORT_DEATH))).thenReturn(reportDeathToken);
+        when(securityTokenService.issueForConfirmer(eq(SecurityTokenPurpose.UPLOAD_EVIDENCE), any(), any(), any()))
+                .thenReturn("evidence-token");
+        when(releaseCaseWarningService.sendAuthorCancelWarningOrFreeze(any())).thenReturn(false);
+
+        Confirmer sibling = confirmerAcceptedOn(plan, "B", "b@test.com");
+        sibling.report(LocalDate.of(2026, 8, 15));
+        when(confirmerRepository.findByPlan_PlanIdAndConfirmIdNotAndReportStatus(PLAN_ID, null, ReportStatus.REPORTED))
+                .thenReturn(List.of(sibling));
+
+        when(releaseCaseRepository.findFirstByPlan_PlanIdOrderByCaseIdDesc(PLAN_ID)).thenReturn(Optional.empty());
+        when(planVersionRepository.countByPlan_PlanId(PLAN_ID)).thenReturn(0L);
+        PlanSnapshotDto snapshot = new PlanSnapshotDto(PLAN_ID, 7, List.of(), List.of());
+        when(planSnapshotService.buildSnapshot(plan)).thenReturn(snapshot);
+        when(planSnapshotService.serialize(snapshot)).thenReturn("{}");
+        when(planSnapshotService.hash("{}")).thenReturn("hash");
+        when(planVersionRepository.save(any(PlanVersion.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(releaseCaseRepository.saveAndFlush(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        var response = deathReportService.report("token-a", new DeathReportRequest(LocalDate.of(2026, 8, 15)), null);
+
+        assertThat(response).isNotNull();
+        verify(releaseCaseWarningService).sendAuthorCancelWarningOrFreeze(any());
     }
 
     // 정책 변경 회귀 테스트 - 한쪽만 사망일을 모르는 경우 더 이상 자동 일치로 처리하지 않는다
@@ -241,7 +281,7 @@ class DeathReportServiceTest {
         deathReportService = new DeathReportService(
                 confirmerRepository, releaseCaseRepository, planVersionRepository,
                 planSnapshotService, idempotencyGuard, securityTokenService, emailOutboxService, appProperties,
-                realValidator);
+                realValidator, releaseCaseWarningService);
 
         Plan plan = mock(Plan.class);
         when(plan.getPlanId()).thenReturn(PLAN_ID);

--- a/src/test/java/com/mamoki/ieojuda/domain/partner/service/PartnerReviewServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/partner/service/PartnerReviewServiceTest.java
@@ -6,7 +6,6 @@ import com.mamoki.ieojuda.domain.audit.entity.AdminActionType;
 import com.mamoki.ieojuda.domain.audit.service.AdminActionAuditService;
 import com.mamoki.ieojuda.domain.confirmer.entity.Confirmer;
 import com.mamoki.ieojuda.domain.confirmer.repository.ConfirmerRepository;
-import com.mamoki.ieojuda.domain.confirmer.service.DisputeContactService;
 import com.mamoki.ieojuda.domain.evidence.entity.Evidence;
 import com.mamoki.ieojuda.domain.evidence.entity.EvidenceDownloadToken;
 import com.mamoki.ieojuda.domain.evidence.entity.EvidenceReviewStatus;
@@ -20,6 +19,7 @@ import com.mamoki.ieojuda.domain.partner.entity.PartnerReviewer;
 import com.mamoki.ieojuda.domain.partner.repository.PartnerReviewerRepository;
 import com.mamoki.ieojuda.domain.plan.entity.Plan;
 import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCase;
+import com.mamoki.ieojuda.domain.releasecase.service.ReleaseCaseWarningService;
 import com.mamoki.ieojuda.domain.securitytoken.service.SecurityTokenService;
 import com.mamoki.ieojuda.global.exception.CustomException;
 import com.mamoki.ieojuda.global.exception.ErrorCode;
@@ -63,7 +63,7 @@ class PartnerReviewServiceTest {
     private AdminActionAuditService adminActionAuditService;
     private IdempotencyGuard idempotencyGuard;
     private SecurityTokenService securityTokenService;
-    private DisputeContactService disputeContactService;
+    private ReleaseCaseWarningService releaseCaseWarningService;
     private PartnerReviewService partnerReviewService;
 
     private User actor;
@@ -83,11 +83,11 @@ class PartnerReviewServiceTest {
         adminActionAuditService = mock(AdminActionAuditService.class);
         idempotencyGuard = mock(IdempotencyGuard.class);
         securityTokenService = mock(SecurityTokenService.class);
-        disputeContactService = mock(DisputeContactService.class);
+        releaseCaseWarningService = mock(ReleaseCaseWarningService.class);
         partnerReviewService = new PartnerReviewService(
                 evidenceRepository, confirmerRepository, partnerReviewerRepository, evidenceDownloadTokenRepository,
                 evidenceStorageClient, permissionGuard, reauthGuard, adminActionAuditService, idempotencyGuard,
-                securityTokenService, disputeContactService);
+                securityTokenService, releaseCaseWarningService);
 
         actor = mock(User.class);
         when(permissionGuard.require(USER_ID, AdminPermission.EVIDENCE_REVIEW)).thenReturn(actor);
@@ -133,7 +133,8 @@ class PartnerReviewServiceTest {
         partnerReviewService.decide(REVIEW_ID, USER_ID, request, null);
 
         verify(evidence).approve();
-        verify(releaseCase).approveEvidenceAndStartWaiting(any());
+        // WAITING 전이는 이제 ReleaseCaseWarningService가 경고 발송 성공을 확인한 뒤에만 수행한다
+        verify(releaseCaseWarningService).sendDisputeWarningsAndStartWaiting(releaseCase, 7);
         verify(adminActionAuditService).record(actor, AdminActionType.EVIDENCE_DECISION, REVIEW_ID, true, "APPROVE");
         // issue #43 - 개별 사전 배정은 없지만, 실제로 판정한 사람은 표시·감사용으로 기록해둔다
         verify(evidence).assignReviewer(reviewer);
@@ -153,7 +154,7 @@ class PartnerReviewServiceTest {
 
         verify(evidence).approve();
         verify(releaseCase).markEvidencePartiallyApproved();
-        verify(releaseCase, never()).approveEvidenceAndStartWaiting(any());
+        verify(releaseCaseWarningService, never()).sendDisputeWarningsAndStartWaiting(any(), any());
     }
 
     // 매칭된 두 확인자 중 이미 한 명이 승인된 상태에서 나머지 한 명의 증빙까지 승인되면
@@ -169,7 +170,7 @@ class PartnerReviewServiceTest {
         partnerReviewService.decide(REVIEW_ID, USER_ID, request, null);
 
         verify(evidence).approve();
-        verify(releaseCase).approveEvidenceAndStartWaiting(any());
+        verify(releaseCaseWarningService).sendDisputeWarningsAndStartWaiting(releaseCase, 7);
         verify(releaseCase, never()).markEvidencePartiallyApproved();
     }
 

--- a/src/test/java/com/mamoki/ieojuda/domain/partner/service/PartnerReviewWarningIntegrationTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/partner/service/PartnerReviewWarningIntegrationTest.java
@@ -1,0 +1,222 @@
+package com.mamoki.ieojuda.domain.partner.service;
+
+import com.mamoki.ieojuda.domain.account.entity.AdminPermission;
+import com.mamoki.ieojuda.domain.account.entity.User;
+import com.mamoki.ieojuda.domain.account.entity.UserRole;
+import com.mamoki.ieojuda.domain.account.repository.UserRepository;
+import com.mamoki.ieojuda.domain.audit.entity.EmailDeliveryStatus;
+import com.mamoki.ieojuda.domain.audit.entity.EmailLog;
+import com.mamoki.ieojuda.domain.audit.entity.EmailType;
+import com.mamoki.ieojuda.domain.audit.repository.EmailLogRepository;
+import com.mamoki.ieojuda.domain.confirmer.entity.Confirmer;
+import com.mamoki.ieojuda.domain.confirmer.entity.DisputeContact;
+import com.mamoki.ieojuda.domain.confirmer.entity.Relationship;
+import com.mamoki.ieojuda.domain.confirmer.repository.ConfirmerRepository;
+import com.mamoki.ieojuda.domain.confirmer.repository.DisputeContactRepository;
+import com.mamoki.ieojuda.domain.evidence.entity.Evidence;
+import com.mamoki.ieojuda.domain.evidence.entity.EvidenceType;
+import com.mamoki.ieojuda.domain.evidence.repository.EvidenceRepository;
+import com.mamoki.ieojuda.domain.partner.dto.PartnerReviewDecisionRequest;
+import com.mamoki.ieojuda.domain.partner.entity.PartnerReviewer;
+import com.mamoki.ieojuda.domain.partner.repository.PartnerReviewerRepository;
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.plan.entity.PlanVersion;
+import com.mamoki.ieojuda.domain.plan.repository.PlanRepository;
+import com.mamoki.ieojuda.domain.plan.repository.PlanVersionRepository;
+import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCase;
+import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCaseStatus;
+import com.mamoki.ieojuda.domain.releasecase.repository.ReleaseCaseRepository;
+import com.mamoki.ieojuda.domain.securitytoken.repository.SecurityTokenRepository;
+import com.mamoki.ieojuda.global.email.contract.BounceType;
+import com.mamoki.ieojuda.global.email.contract.EmailFaill;
+import com.mamoki.ieojuda.global.email.contract.EmailSendResult;
+import com.mamoki.ieojuda.global.email.sender.EmailSender;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.LocalDate;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+// 완료 조건 통합 검증 - "증빙 승인 및 대기 시작 시 이의 연락처 경고 발송 연결"과 "대기 시작 전에 경고가
+// 전송된다"를 실제 스프링 컨텍스트·DB로 검증한다. PartnerReviewAccessHttpIntegrationTest와 동일하게
+// SMTP만 @MockitoBean으로 격리한다.
+@SpringBootTest
+class PartnerReviewWarningIntegrationTest {
+
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private PlanRepository planRepository;
+    @Autowired
+    private PlanVersionRepository planVersionRepository;
+    @Autowired
+    private ReleaseCaseRepository releaseCaseRepository;
+    @Autowired
+    private PartnerReviewerRepository partnerReviewerRepository;
+    @Autowired
+    private EvidenceRepository evidenceRepository;
+    @Autowired
+    private ConfirmerRepository confirmerRepository;
+    @Autowired
+    private DisputeContactRepository disputeContactRepository;
+    @Autowired
+    private EmailLogRepository emailLogRepository;
+    @Autowired
+    private PartnerReviewService partnerReviewService;
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+    @Autowired
+    private SecurityTokenRepository securityTokenRepository;
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    @MockitoBean
+    private EmailSender emailSender;
+
+    private User owner;
+    private Plan plan;
+    private PlanVersion planVersion;
+    private ReleaseCase releaseCase;
+    private Confirmer confirmerA;
+    private Confirmer confirmerB;
+    private Evidence evidenceA;
+    private Evidence evidenceB;
+    private DisputeContact disputeContact;
+    private User reviewerUser;
+
+    @BeforeEach
+    void setUp() {
+        owner = userRepository.saveAndFlush(User.builder()
+                .email("owner-" + UUID.randomUUID() + "@test.com").password("hash").name("작성자").build());
+        plan = planRepository.saveAndFlush(Plan.builder().user(owner).build());
+        plan.updateWaitingDays(7);
+        plan = planRepository.saveAndFlush(plan);
+        planVersion = planVersionRepository.saveAndFlush(
+                PlanVersion.builder().plan(plan).versionNum(1).snapshotData("{}").build());
+        releaseCase = releaseCaseRepository.saveAndFlush(ReleaseCase.builder().plan(plan).planVersion(planVersion).build());
+        releaseCase.confirmReport();
+        releaseCase.awaitEvidence();
+        releaseCase.startEvidenceReview();
+        releaseCase = releaseCaseRepository.saveAndFlush(releaseCase);
+
+        // 매칭된 확인자 2명 - PartnerReviewService가 요구 승인 건수를 이 값으로 계산한다
+        confirmerA = confirmerRepository.saveAndFlush(buildMatchedConfirmer("A"));
+        confirmerB = confirmerRepository.saveAndFlush(buildMatchedConfirmer("B"));
+
+        evidenceA = evidenceRepository.saveAndFlush(Evidence.builder()
+                .confirmer(confirmerA).plan(plan).releaseCase(releaseCase)
+                .storageKey("evidence/warning-test/a").fileName("a.pdf").mimeType("application/pdf")
+                .integrityHash("hash-a").evidenceType(EvidenceType.DEATH_CERTIFICATE).build());
+        evidenceB = evidenceRepository.saveAndFlush(Evidence.builder()
+                .confirmer(confirmerB).plan(plan).releaseCase(releaseCase)
+                .storageKey("evidence/warning-test/b").fileName("b.pdf").mimeType("application/pdf")
+                .integrityHash("hash-b").evidenceType(EvidenceType.DEATH_CERTIFICATE).build());
+
+        disputeContact = DisputeContact.builder().plan(plan)
+                .email("dispute-" + UUID.randomUUID() + "@test.com").name("이의연락처").build();
+        disputeContact.verify();
+        disputeContact = disputeContactRepository.saveAndFlush(disputeContact);
+
+        reviewerUser = User.builder().email("reviewer-" + UUID.randomUUID() + "@test.com")
+                .password(passwordEncoder.encode("hash")).name("검토자").build();
+        ReflectionTestUtils.setField(reviewerUser, "role", UserRole.EXTERNAL);
+        ReflectionTestUtils.setField(reviewerUser, "permissions", Set.of(AdminPermission.EVIDENCE_REVIEW));
+        reviewerUser = userRepository.saveAndFlush(reviewerUser);
+        partnerReviewerRepository.saveAndFlush(PartnerReviewer.builder()
+                .user(reviewerUser).name("검토자").email(reviewerUser.getEmail()).build());
+    }
+
+    private Confirmer buildMatchedConfirmer(String name) {
+        Confirmer confirmer = Confirmer.builder().plan(plan).name(name).relationship(Relationship.FRIEND)
+                .email("confirmer-warning-" + UUID.randomUUID() + "@test.com").build();
+        confirmer.accept(null);
+        confirmer.report(LocalDate.of(2026, 8, 15));
+        confirmer.markMatched();
+        return confirmer;
+    }
+
+    @AfterEach
+    void tearDown() {
+        // 이 사건에 묶인 RAISE_OBJECTION 토큰(이의 연락처 FK 참조)을 먼저 지워야 dispute_contacts/
+        // release_cases 삭제 시 FK 위반이 나지 않는다 (DeathReportReadinessIntegrationTest와 동일 패턴).
+        new TransactionTemplate(transactionManager).executeWithoutResult(
+                status -> securityTokenRepository.deleteByReleaseCase_CaseId(releaseCase.getCaseId()));
+        // decide() 호출로 evidence/releaseCase의 버전이 바뀌었으므로, setUp() 시점의 stale 참조로
+        // delete(entity)를 호출하면 낙관적 잠금 예외가 난다 - id 기반 삭제로 매번 새로 조회하게 한다.
+        evidenceRepository.deleteById(evidenceA.getEvidenceId());
+        evidenceRepository.deleteById(evidenceB.getEvidenceId());
+        confirmerRepository.deleteById(confirmerA.getConfirmId());
+        confirmerRepository.deleteById(confirmerB.getConfirmId());
+        disputeContactRepository.deleteById(disputeContact.getContactId());
+        partnerReviewerRepository.deleteAll(partnerReviewerRepository.findAll().stream()
+                .filter(r -> r.getUser().getUserId().equals(reviewerUser.getUserId()))
+                .toList());
+        for (EmailLog log : emailLogRepository.findByPlan_PlanIdOrderByRequestedAtDesc(plan.getPlanId())) {
+            emailLogRepository.deleteById(log.getLogId());
+        }
+        releaseCaseRepository.deleteById(releaseCase.getCaseId());
+        planVersionRepository.deleteById(planVersion.getVersionId());
+        planRepository.deleteById(plan.getPlanId());
+        userRepository.deleteById(owner.getUserId());
+        userRepository.deleteById(reviewerUser.getUserId());
+    }
+
+    private void approve(Evidence evidence) {
+        partnerReviewService.decide(evidence.getEvidenceId(), reviewerUser.getUserId(),
+                new PartnerReviewDecisionRequest(PartnerReviewDecisionRequest.PartnerReviewDecision.APPROVE, null, "hash"), null);
+    }
+
+    private EmailLog findObjectionWindowLog() {
+        return emailLogRepository.findByPlan_PlanIdOrderByRequestedAtDesc(plan.getPlanId()).stream()
+                .filter(log -> log.getEmailType() == EmailType.OBJECTION_WINDOW_NOTICE)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("OBJECTION_WINDOW_NOTICE 로그가 기록되지 않았습니다"));
+    }
+
+    @Test
+    void decide_whenLastEvidenceApprovedAndWarningSendSucceeds_startsWaiting() {
+        when(emailSender.send(eq(disputeContact.getEmail()), any())).thenReturn(EmailSendResult.success("msg-1"));
+
+        approve(evidenceA);
+        approve(evidenceB); // 매칭된 확인자 2명 전원 승인 - 대기 시작 트리거
+
+        ReleaseCase updated = releaseCaseRepository.findById(releaseCase.getCaseId()).orElseThrow();
+        assertThat(updated.getStatus()).isEqualTo(ReleaseCaseStatus.WAITING);
+        assertThat(updated.getFrozen()).isFalse();
+
+        EmailLog log = findObjectionWindowLog();
+        assertThat(log.getStatus()).isEqualTo(EmailDeliveryStatus.SENT);
+    }
+
+    // 핵심 완료 조건 - 이의 연락처 경고 발송이 실패하면 WAITING으로 전이하지 않고, 실패가 성공으로
+    // 기록되지도 않는다. 대신 사건이 동결되어 운영 검토로 전환된다.
+    @Test
+    void decide_whenLastEvidenceApprovedAndWarningSendFails_doesNotStartWaitingAndFreezesCase() {
+        when(emailSender.send(eq(disputeContact.getEmail()), any()))
+                .thenReturn(EmailSendResult.failure(BounceType.PERMANENT, EmailFaill.INVALID_ADDRESS_FORMAT));
+
+        approve(evidenceA);
+        approve(evidenceB);
+
+        ReleaseCase updated = releaseCaseRepository.findById(releaseCase.getCaseId()).orElseThrow();
+        assertThat(updated.getStatus()).isNotEqualTo(ReleaseCaseStatus.WAITING);
+        assertThat(updated.getFrozen()).isTrue();
+
+        EmailLog log = findObjectionWindowLog();
+        assertThat(log.getStatus()).isEqualTo(EmailDeliveryStatus.FAILED);
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/domain/releasecase/service/CaseCancellationServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/releasecase/service/CaseCancellationServiceTest.java
@@ -1,0 +1,101 @@
+package com.mamoki.ieojuda.domain.releasecase.service;
+
+import com.mamoki.ieojuda.domain.releasecase.dto.ReleaseStatusResponse;
+import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCase;
+import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCaseStatus;
+import com.mamoki.ieojuda.domain.securitytoken.entity.SecurityToken;
+import com.mamoki.ieojuda.domain.securitytoken.entity.SecurityTokenPurpose;
+import com.mamoki.ieojuda.domain.securitytoken.service.SecurityTokenService;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+// 완료 조건 - "만료·사용된 경고 링크는 재사용할 수 없다"는 SecurityTokenService.resolve()/consume()이
+// 이미 검증하므로(만료·사용·폐기·목적 불일치), 여기서는 CANCEL_CASE 토큰이 그 검증을 실제로 거치는지와
+// URL의 caseId가 토큰이 가리키는 사건과 다를 때 거절되는지를 확인한다 (ObjectionServiceTest와 동일 패턴).
+class CaseCancellationServiceTest {
+
+    private static final UUID CASE_ID = UUID.randomUUID();
+    private static final UUID OTHER_CASE_ID = UUID.randomUUID();
+
+    private SecurityTokenService securityTokenService;
+    private CaseCancellationService caseCancellationService;
+
+    private ReleaseCase releaseCase;
+
+    @BeforeEach
+    void setUp() {
+        securityTokenService = mock(SecurityTokenService.class);
+        caseCancellationService = new CaseCancellationService(securityTokenService);
+
+        releaseCase = mock(ReleaseCase.class);
+        when(releaseCase.getCaseId()).thenReturn(CASE_ID);
+    }
+
+    private SecurityToken tokenFor(ReleaseCase releaseCase) {
+        SecurityToken token = mock(SecurityToken.class);
+        when(token.getReleaseCase()).thenReturn(releaseCase);
+        return token;
+    }
+
+    @Test
+    void cancel_whenTokenBoundToDifferentCase_throwsForbiddenWithoutCanceling() {
+        SecurityToken token = tokenFor(releaseCase);
+        when(securityTokenService.resolve(eq("token"), eq(SecurityTokenPurpose.CANCEL_CASE))).thenReturn(token);
+
+        assertThatThrownBy(() -> caseCancellationService.cancel(OTHER_CASE_ID, "token"))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.FORBIDDEN));
+        verify(releaseCase, never()).cancel();
+        verify(securityTokenService, never()).consume(token);
+    }
+
+    @Test
+    void cancel_whenTokenMatchesCase_cancelsAndConsumesTokenAndRevokesRemainingTokens() {
+        SecurityToken token = tokenFor(releaseCase);
+        when(securityTokenService.resolve(eq("token"), eq(SecurityTokenPurpose.CANCEL_CASE))).thenReturn(token);
+        when(releaseCase.getStatus()).thenReturn(ReleaseCaseStatus.CANCELED);
+
+        ReleaseStatusResponse response = caseCancellationService.cancel(CASE_ID, "token");
+
+        assertThat(response).isNotNull();
+        verify(releaseCase).cancel();
+        verify(securityTokenService).consume(token);
+        verify(securityTokenService).revokeAllForCase(releaseCase, SecurityTokenPurpose.UPLOAD_EVIDENCE);
+        verify(securityTokenService).revokeAllForCase(releaseCase, SecurityTokenPurpose.RAISE_OBJECTION);
+    }
+
+    // 만료·사용된 토큰은 SecurityTokenService.resolve()가 먼저 예외를 던지므로 취소가 실행되지 않는다
+    @Test
+    void cancel_whenTokenExpired_propagatesExceptionWithoutCanceling() {
+        when(securityTokenService.resolve(eq("token"), eq(SecurityTokenPurpose.CANCEL_CASE)))
+                .thenThrow(new CustomException(ErrorCode.ACCESS_LINK_EXPIRED));
+
+        assertThatThrownBy(() -> caseCancellationService.cancel(CASE_ID, "token"))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.ACCESS_LINK_EXPIRED));
+        verify(releaseCase, never()).cancel();
+    }
+
+    @Test
+    void cancel_whenTokenAlreadyUsed_propagatesExceptionWithoutCanceling() {
+        when(securityTokenService.resolve(eq("token"), eq(SecurityTokenPurpose.CANCEL_CASE)))
+                .thenThrow(new CustomException(ErrorCode.ACCESS_LINK_ALREADY_USED));
+
+        assertThatThrownBy(() -> caseCancellationService.cancel(CASE_ID, "token"))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.ACCESS_LINK_ALREADY_USED));
+        verify(releaseCase, never()).cancel();
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/domain/releasecase/service/ReleaseCaseWarningServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/releasecase/service/ReleaseCaseWarningServiceTest.java
@@ -1,0 +1,144 @@
+package com.mamoki.ieojuda.domain.releasecase.service;
+
+import com.mamoki.ieojuda.domain.audit.entity.EmailType;
+import com.mamoki.ieojuda.domain.confirmer.entity.DisputeContact;
+import com.mamoki.ieojuda.domain.confirmer.repository.DisputeContactRepository;
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCase;
+import com.mamoki.ieojuda.domain.securitytoken.entity.SecurityTokenPurpose;
+import com.mamoki.ieojuda.domain.securitytoken.service.SecurityTokenService;
+import com.mamoki.ieojuda.global.config.AppProperties;
+import com.mamoki.ieojuda.global.email.contract.EmailContent;
+import com.mamoki.ieojuda.global.email.outbox.CriticalEmailSender;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+// 이 작업의 핵심 회귀 테스트 - "대기 시작 전에 경고가 전송된다"와 "발송 실패가 성공으로 기록되지 않는다"를
+// 코드 레벨에서 보장한다: 경고 발송이 실패하면 WAITING 전이가 절대 일어나지 않고 사건이 동결되어야 한다.
+class ReleaseCaseWarningServiceTest {
+
+    private static final UUID CASE_ID = UUID.randomUUID();
+    private static final UUID PLAN_ID = UUID.randomUUID();
+
+    private DisputeContactRepository disputeContactRepository;
+    private SecurityTokenService securityTokenService;
+    private CriticalEmailSender criticalEmailSender;
+    private AppProperties appProperties;
+    private ReleaseCaseWarningService releaseCaseWarningService;
+
+    private ReleaseCase releaseCase;
+    private Plan plan;
+
+    @BeforeEach
+    void setUp() {
+        disputeContactRepository = mock(DisputeContactRepository.class);
+        securityTokenService = mock(SecurityTokenService.class);
+        criticalEmailSender = mock(CriticalEmailSender.class);
+        appProperties = mock(AppProperties.class);
+        releaseCaseWarningService = new ReleaseCaseWarningService(
+                disputeContactRepository, securityTokenService, criticalEmailSender, appProperties);
+
+        plan = mock(Plan.class);
+        when(plan.getPlanId()).thenReturn(PLAN_ID);
+        when(plan.getSelfWarningEmail()).thenReturn("author@test.com");
+        releaseCase = mock(ReleaseCase.class);
+        when(releaseCase.getCaseId()).thenReturn(CASE_ID);
+        when(releaseCase.getPlan()).thenReturn(plan);
+
+        when(appProperties.getBaseUrl()).thenReturn("https://ieoduda.example.com");
+        when(appProperties.getContactEmail()).thenReturn("support@ieoduda.example.com");
+        when(securityTokenService.issueForCase(any(), any(), any())).thenReturn("cancel-token");
+        when(securityTokenService.issueForDisputeContact(any(), any(), any(), any())).thenReturn("dispute-token");
+    }
+
+    @Test
+    void sendAuthorCancelWarningOrFreeze_whenSendSucceeds_doesNotFreeze() {
+        when(criticalEmailSender.sendOrFail(eq(plan), eq(EmailType.CASE_CANCEL_WARNING), eq("author@test.com"), any()))
+                .thenReturn(true);
+
+        boolean result = releaseCaseWarningService.sendAuthorCancelWarningOrFreeze(releaseCase);
+
+        assertThat(result).isTrue();
+        verify(releaseCase, never()).freeze();
+    }
+
+    @Test
+    void sendAuthorCancelWarningOrFreeze_whenSendFails_freezesCase() {
+        when(criticalEmailSender.sendOrFail(eq(plan), eq(EmailType.CASE_CANCEL_WARNING), eq("author@test.com"), any()))
+                .thenReturn(false);
+
+        boolean result = releaseCaseWarningService.sendAuthorCancelWarningOrFreeze(releaseCase);
+
+        assertThat(result).isFalse();
+        verify(releaseCase).freeze();
+    }
+
+    @Test
+    void sendDisputeWarningsAndStartWaiting_whenAllVerifiedContactsSucceed_startsWaiting() {
+        DisputeContact verified = mock(DisputeContact.class);
+        when(verified.getIsVerified()).thenReturn(true);
+        when(verified.getPlan()).thenReturn(plan);
+        when(verified.getEmail()).thenReturn("dispute@test.com");
+        when(disputeContactRepository.findByPlan_PlanId(PLAN_ID)).thenReturn(List.of(verified));
+        when(criticalEmailSender.sendOrFail(eq(plan), eq(EmailType.OBJECTION_WINDOW_NOTICE), eq("dispute@test.com"), any()))
+                .thenReturn(true);
+
+        boolean result = releaseCaseWarningService.sendDisputeWarningsAndStartWaiting(releaseCase, 7);
+
+        assertThat(result).isTrue();
+        verify(releaseCase).approveEvidenceAndStartWaiting(7);
+        verify(securityTokenService).revokeAllForCase(releaseCase, SecurityTokenPurpose.UPLOAD_EVIDENCE);
+        verify(releaseCase, never()).freeze();
+    }
+
+    // 핵심 회귀 - 이의 연락처 중 한 명이라도 발송에 실패하면 WAITING 전이가 절대 일어나서는 안 된다
+    @Test
+    void sendDisputeWarningsAndStartWaiting_whenAnyVerifiedContactFails_doesNotStartWaitingAndFreezes() {
+        DisputeContact ok = mock(DisputeContact.class);
+        when(ok.getIsVerified()).thenReturn(true);
+        when(ok.getPlan()).thenReturn(plan);
+        when(ok.getEmail()).thenReturn("ok@test.com");
+        DisputeContact failing = mock(DisputeContact.class);
+        when(failing.getIsVerified()).thenReturn(true);
+        when(failing.getPlan()).thenReturn(plan);
+        when(failing.getEmail()).thenReturn("bad@test.com");
+        when(disputeContactRepository.findByPlan_PlanId(PLAN_ID)).thenReturn(List.of(ok, failing));
+        when(criticalEmailSender.sendOrFail(eq(plan), eq(EmailType.OBJECTION_WINDOW_NOTICE), eq("ok@test.com"), any()))
+                .thenReturn(true);
+        when(criticalEmailSender.sendOrFail(eq(plan), eq(EmailType.OBJECTION_WINDOW_NOTICE), eq("bad@test.com"), any()))
+                .thenReturn(false);
+
+        boolean result = releaseCaseWarningService.sendDisputeWarningsAndStartWaiting(releaseCase, 7);
+
+        assertThat(result).isFalse();
+        verify(releaseCase, never()).approveEvidenceAndStartWaiting(any());
+        verify(releaseCase).freeze();
+        // 성공한 연락처에게는 계속 시도해 실제로 발송한다 - 한 명 실패했다고 나머지까지 건너뛰지 않는다
+        verify(criticalEmailSender).sendOrFail(eq(plan), eq(EmailType.OBJECTION_WINDOW_NOTICE), eq("ok@test.com"), any());
+    }
+
+    @Test
+    void sendDisputeWarningsAndStartWaiting_ignoresUnverifiedContacts() {
+        DisputeContact unverified = mock(DisputeContact.class);
+        when(unverified.getIsVerified()).thenReturn(false);
+        when(disputeContactRepository.findByPlan_PlanId(PLAN_ID)).thenReturn(List.of(unverified));
+
+        boolean result = releaseCaseWarningService.sendDisputeWarningsAndStartWaiting(releaseCase, 7);
+
+        assertThat(result).isTrue();
+        verify(releaseCase).approveEvidenceAndStartWaiting(7);
+        verify(criticalEmailSender, never()).sendOrFail(any(), any(), anyString(), any());
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/global/validation/InputSizeConstraintTest.java
+++ b/src/test/java/com/mamoki/ieojuda/global/validation/InputSizeConstraintTest.java
@@ -172,17 +172,30 @@ class InputSizeConstraintTest {
         assertThat(validator.validate(withoutName)).isEmpty();
     }
 
+    // issue #54 이후 이 세 값은 하드코딩이 아니라 환경변수(MULTIPART_MAX_FILE_SIZE 등)로 외부화됐다.
+    // application.properties에는 "${MULTIPART_MAX_FILE_SIZE}" 같은 미해석 플레이스홀더만 있어 그 파일을
+    // 그대로 읽으면 항상 실패한다 - 대신 (1) application.properties가 올바른 환경변수 이름을 가리키는지,
+    // (2) 커밋된 기본값 문서인 .env.example이 여전히 50MB/55MB/60MB 계약을 명시하는지 두 가지로 검증한다.
     @Test
     void multipartLimitsAreFiftyAndFiftyFiveMegabytes() throws IOException {
-        Properties properties = new Properties();
+        Properties appProperties = new Properties();
         try (InputStream input = getClass().getResourceAsStream("/application.properties")) {
             assertThat(input).isNotNull();
-            properties.load(input);
+            appProperties.load(input);
         }
 
-        assertThat(properties.getProperty("spring.servlet.multipart.max-file-size")).isEqualTo("50MB");
-        assertThat(properties.getProperty("spring.servlet.multipart.max-request-size")).isEqualTo("55MB");
-        assertThat(properties.getProperty("server.tomcat.max-swallow-size")).isEqualTo("60MB");
+        assertThat(appProperties.getProperty("spring.servlet.multipart.max-file-size")).isEqualTo("${MULTIPART_MAX_FILE_SIZE}");
+        assertThat(appProperties.getProperty("spring.servlet.multipart.max-request-size")).isEqualTo("${MULTIPART_MAX_REQUEST_SIZE}");
+        assertThat(appProperties.getProperty("server.tomcat.max-swallow-size")).isEqualTo("${TOMCAT_MAX_SWALLOW_SIZE}");
+
+        Properties envExample = new Properties();
+        try (InputStream input = java.nio.file.Files.newInputStream(java.nio.file.Path.of(".env.example"))) {
+            envExample.load(input);
+        }
+
+        assertThat(envExample.getProperty("MULTIPART_MAX_FILE_SIZE")).isEqualTo("50MB");
+        assertThat(envExample.getProperty("MULTIPART_MAX_REQUEST_SIZE")).isEqualTo("55MB");
+        assertThat(envExample.getProperty("TOMCAT_MAX_SWALLOW_SIZE")).isEqualTo("60MB");
     }
 
     @Test


### PR DESCRIPTION
## 연관 Issue

- Closes #49

## 요약

사망 신고(사건 생성)와 증빙 승인(대기 시작) 시점에 작성자·이의 제기 연락처에게 취소·이의 제기 경고 메일이 실제로 전달됐는지 확인한 뒤에만 절차를 진행하도록 게이트를 추가합니다. 발송 실패 시 상태 전이를 막고 사건을 동결해 운영 검토로 전환합니다.

## 변경 사항

- 사건 생성 시 작성자(본인 경고 이메일, 검증됨)에게 목적 제한·30일 만료 취소 링크(`CANCEL_CASE` 토큰) 발송
- 증빙 전량 승인 시 검증된 이의 제기 연락처 전원에게 이의 제기 링크(`RAISE_OBJECTION` 토큰) 발송 — 전원 발송 성공을 확인한 뒤에만 `WAITING` 전이
- 경고 메일은 `CriticalEmailSender`로 동기 발송해 그 자리에서 성공/실패를 확정 (`EmailLog`에 정확히 SENT/FAILED로 기록, 실패가 성공으로 기록되지 않음)
- 발송 실패 시 `ReleaseCase.freeze()`로 진행 보류 — 운영자용 동결 해제(`unfreeze`)·경고 재시도(`retry-warning`) 엔드포인트 추가
- 로그인 없이 이메일 링크만으로 접수하는 취소 엔드포인트 신설: `POST /api/release-cases/{caseId}/cancellations`
- 성공/실패 경로 통합 테스트 추가 (`@SpringBootTest` + 실제 DB, SMTP만 `@MockitoBean`으로 격리)
- (부수 수정) `InputSizeConstraintTest`의 multipart 설정 assertion이 #54 환경변수 외부화 이후 깨져 있던 것을 함께 수정

## 범위

### 포함

- 사건 생성 및 대기 시작 전 경고 이메일 발송
- 목적 제한·만료형 취소 및 이의 제기 링크
- 발송 실패 시 진행 보류 또는 운영 검토 전환

### 제외

- `DisputeContactService.notifyVerifiedContactsOfObjectionWindow()` — 이번 변경으로 호출자가 없어져 고아 코드가 됐으나, 별도 요청 없이는 삭제하지 않음


## 테스트 내역

- `./gradlew test` — 357개 전체 통과