### PR TITLE
[Fix/#129]: 파트너 증빙 검토 목록 응답을 reviews 키로 감싸도록 수정

### DIFF
--- a/src/main/java/com/mamoki/ieojuda/domain/partner/controller/PartnerReviewListController.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/partner/controller/PartnerReviewListController.java
@@ -1,10 +1,9 @@
 package com.mamoki.ieojuda.domain.partner.controller;
 
-import java.util.List;
 import java.util.UUID;
 
 import com.mamoki.ieojuda.domain.evidence.entity.EvidenceReviewStatus;
-import com.mamoki.ieojuda.domain.partner.dto.PartnerReviewListItemResponse;
+import com.mamoki.ieojuda.domain.partner.dto.PartnerReviewListResponse;
 import com.mamoki.ieojuda.domain.partner.service.PartnerReviewService;
 import com.mamoki.ieojuda.global.rsdata.RsData;
 import io.swagger.v3.oas.annotations.Operation;
@@ -30,7 +29,7 @@ public class PartnerReviewListController {
 
     @Operation(summary = "검토 목록 조회", description = "EVIDENCE_REVIEW 권한을 가진 검토자가 전체 검토 대상을 상태별로 조회합니다. 역할별 패키지는 포함하지 않습니다.")
     @GetMapping
-    public ResponseEntity<RsData<List<PartnerReviewListItemResponse>>> getReviews(
+    public ResponseEntity<RsData<PartnerReviewListResponse>> getReviews(
             @AuthenticationPrincipal UUID userId,
             @Parameter(description = "검토 상태 필터") @RequestParam(required = false) EvidenceReviewStatus status
     ) {

--- a/src/main/java/com/mamoki/ieojuda/domain/partner/dto/PartnerReviewListResponse.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/partner/dto/PartnerReviewListResponse.java
@@ -1,0 +1,10 @@
+package com.mamoki.ieojuda.domain.partner.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record PartnerReviewListResponse(
+        @Schema(description = "검토 목록") List<PartnerReviewListItemResponse> reviews
+) {
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/partner/service/PartnerReviewService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/partner/service/PartnerReviewService.java
@@ -17,6 +17,7 @@ import com.mamoki.ieojuda.domain.evidence.repository.EvidenceRepository;
 import com.mamoki.ieojuda.domain.partner.dto.EvidenceDownloadLinkResponse;
 import com.mamoki.ieojuda.domain.partner.dto.PartnerReviewDecisionRequest;
 import com.mamoki.ieojuda.domain.partner.dto.PartnerReviewListItemResponse;
+import com.mamoki.ieojuda.domain.partner.dto.PartnerReviewListResponse;
 import com.mamoki.ieojuda.domain.partner.dto.PartnerReviewResponse;
 import com.mamoki.ieojuda.domain.partner.entity.PartnerReviewer;
 import com.mamoki.ieojuda.domain.partner.repository.PartnerReviewerRepository;
@@ -69,12 +70,13 @@ public class PartnerReviewService {
     }
 
     // issue #87 - EVIDENCE_REVIEW 권한만 있으면 전체를 조회한다.
-    public List<PartnerReviewListItemResponse> getReviews(UUID userId, EvidenceReviewStatus status) {
+    public PartnerReviewListResponse getReviews(UUID userId, EvidenceReviewStatus status) {
         permissionGuard.require(userId, AdminPermission.EVIDENCE_REVIEW);
-        return evidenceRepository.findAllByReviewStatus(status)
+        List<PartnerReviewListItemResponse> reviews = evidenceRepository.findAllByReviewStatus(status)
                 .stream()
                 .map(PartnerReviewListItemResponse::from)
                 .toList();
+        return new PartnerReviewListResponse(reviews);
     }
 
     // issue #43 - 원본을 직접 스트리밍하지 않고, 먼저 짧은 수명의 1회성 다운로드 토큰을 발급한다.

--- a/src/test/java/com/mamoki/ieojuda/domain/partner/service/PartnerReviewServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/partner/service/PartnerReviewServiceTest.java
@@ -14,7 +14,7 @@ import com.mamoki.ieojuda.domain.evidence.repository.EvidenceDownloadTokenReposi
 import com.mamoki.ieojuda.domain.evidence.repository.EvidenceRepository;
 import com.mamoki.ieojuda.domain.partner.dto.EvidenceDownloadLinkResponse;
 import com.mamoki.ieojuda.domain.partner.dto.PartnerReviewDecisionRequest;
-import com.mamoki.ieojuda.domain.partner.dto.PartnerReviewListItemResponse;
+import com.mamoki.ieojuda.domain.partner.dto.PartnerReviewListResponse;
 import com.mamoki.ieojuda.domain.partner.entity.PartnerReviewer;
 import com.mamoki.ieojuda.domain.partner.repository.PartnerReviewerRepository;
 import com.mamoki.ieojuda.domain.plan.entity.Plan;
@@ -354,10 +354,10 @@ class PartnerReviewServiceTest {
         when(evidenceRepository.findAllByReviewStatus(EvidenceReviewStatus.PENDING))
                 .thenReturn(List.of(evidence));
 
-        List<PartnerReviewListItemResponse> result = partnerReviewService.getReviews(USER_ID, EvidenceReviewStatus.PENDING);
+        PartnerReviewListResponse result = partnerReviewService.getReviews(USER_ID, EvidenceReviewStatus.PENDING);
 
-        assertThat(result).hasSize(1);
-        assertThat(result.get(0).reviewId()).isEqualTo(REVIEW_ID);
+        assertThat(result.reviews()).hasSize(1);
+        assertThat(result.reviews().get(0).reviewId()).isEqualTo(REVIEW_ID);
     }
 
     @Test


### PR DESCRIPTION
**연관 Issue**
- Closes #129

**요약**
GET /api/partner/reviews 응답이 스펙과 다르게 배열을 그대로 반환하던 문제를 reviews 키로 감싸서 수정합니다.

**변경 사항**
- PartnerReviewListResponse 래퍼 DTO 추가 (reviews 필드)
- PartnerReviewService.getReviews()가 래퍼를 반환하도록 수정
- PartnerReviewListController 반환 타입 수정
- 관련 테스트(PartnerReviewServiceTest) 수정

**범위**

*포함*
- PartnerReviewListResponse 래퍼 추가 및 관련 서비스/컨트롤러/테스트 수정

*제외*
- getReview(단건), decide, requestDownloadLink 등 다른 엔드포인트 (이미 스펙대로 동작)

**스크린샷 / 미리 보기**
- 수정 후 응답: `{"success":true,"data":{"reviews":[...]}}` (실제 HTTP 통합 테스트로 확인 완료)