### PR TITLE
[Fix/#133]: 대체 담당자 부재를 순서 확정 차단 대신 경고로 전환

### DIFF
--- a/src/main/java/com/mamoki/ieojuda/domain/plan/controller/ItemOrderController.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/controller/ItemOrderController.java
@@ -31,7 +31,7 @@ public class ItemOrderController {
 
     private final ItemOrderService itemOrderService;
 
-    @Operation(summary = "실행 순서 점검 목록 조회", description = "담당자가 배정된 항목을 실행 순서대로 조회합니다. 삭제형 항목이 인계형 항목보다 먼저 오면 충돌로 표시됩니다.")
+    @Operation(summary = "실행 순서 점검 목록 조회", description = "담당자가 배정된 항목을 실행 순서대로 조회합니다. 삭제형 항목이 인계형 항목보다 먼저 오면 충돌(conflict)로 표시됩니다. 대체 담당자 부재처럼 확정을 막지는 않는 사유는 경고(warning)로 별도 표시됩니다.")
     @GetMapping
     public ResponseEntity<RsData<OrderCheckResponse>> getOrderCheck(
             @AuthenticationPrincipal UUID userId,
@@ -50,7 +50,7 @@ public class ItemOrderController {
         return ResponseEntity.ok(RsData.success(itemOrderService.reorder(userId, planId, request)));
     }
 
-    @Operation(summary = "순서 확정하기", description = "충돌이 하나라도 남아있으면 확정할 수 없습니다.")
+    @Operation(summary = "순서 확정하기", description = "conflict=true인 항목이 하나라도 남아있으면 확정할 수 없습니다. 대체 담당자 부재(warning)는 확정을 막지 않고 경고로만 표시됩니다.")
     @PostMapping("/confirm")
     public ResponseEntity<RsData<OrderConfirmResponse>> confirm(
             @AuthenticationPrincipal UUID userId,

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/dto/OrderCheckItemResponse.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/dto/OrderCheckItemResponse.java
@@ -15,7 +15,9 @@ public record OrderCheckItemResponse(
         @Schema(description = "담당자 이름") String recipientName,
         @Schema(description = "대기 기간(시간 단위)") Integer maxWaitHours,
         @Schema(description = "담당자 수락 상태", example = "PENDING", allowableValues = {"PENDING", "ACCEPTED", "DECLINED", "EXPIRED"}) String acceptanceStatus,
-        @Schema(description = "이 항목이 순서 충돌에 걸려 있는지 여부") boolean conflict,
-        @Schema(description = "충돌 사유 (충돌 없으면 null)") String conflictMessage
+        @Schema(description = "이 항목이 순서 충돌에 걸려 있는지 여부 (true면 확정 불가)") boolean conflict,
+        @Schema(description = "충돌 사유 (충돌 없으면 null)") String conflictMessage,
+        @Schema(description = "확정을 막지는 않지만 사용자에게 표시할 경고가 있는지 여부") boolean warning,
+        @Schema(description = "경고 사유 (없으면 null)") String warningMessage
 ) {
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/service/ItemOrderService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/service/ItemOrderService.java
@@ -104,14 +104,17 @@ public class ItemOrderService {
 
     private List<OrderCheckItemResponse> buildItemResponses(UUID planId, List<Item> items) {
         Map<UUID, List<String>> conflictReasons = new HashMap<>();
+        Map<UUID, List<String>> warningReasons = new HashMap<>();
         checkSemanticPairRules(items, conflictReasons);
         checkMissingRecipient(items, conflictReasons);
-        checkMissingBackup(planId, items, conflictReasons);
+        checkMissingBackup(planId, items, warningReasons);
         checkAuthorityConcentration(items, conflictReasons);
 
         return items.stream().map(item -> {
             List<String> reasons = conflictReasons.get(item.getItemId());
             String message = reasons == null ? null : String.join(" ", reasons);
+            List<String> warnings = warningReasons.get(item.getItemId());
+            String warningMessage = warnings == null ? null : String.join(" ", warnings);
             Recipient recipient = item.getRecipient();
             return new OrderCheckItemResponse(
                     item.getItemId(),
@@ -123,7 +126,9 @@ public class ItemOrderService {
                     recipient == null ? null : recipient.getMaxWaitHours(),
                     recipient == null ? null : recipient.getAcceptanceStatus().name(),
                     message != null,
-                    message
+                    message,
+                    warningMessage != null,
+                    warningMessage
             );
         }).toList();
     }
@@ -165,8 +170,9 @@ public class ItemOrderService {
         }
     }
 
-    // 규칙 6 - 대체 담당자 부재. 대체 담당자 자신은 대상에서 제외한다(대체 담당자에게 또 대체 담당자가 필요한 건 아님)
-    private void checkMissingBackup(UUID planId, List<Item> items, Map<UUID, List<String>> conflictReasons) {
+    // 규칙 6 - 대체 담당자 부재 (경고 전용 - 확정을 막지 않는다). 대체 담당자 자신은 대상에서 제외한다
+    // (대체 담당자에게 또 대체 담당자가 필요한 건 아님)
+    private void checkMissingBackup(UUID planId, List<Item> items, Map<UUID, List<String>> warningReasons) {
         List<Recipient> planRecipients = recipientRepository.findByPlan_PlanId(planId);
         Set<UUID> primaryIdsWithBackup = planRecipients.stream()
                 .filter(r -> Boolean.TRUE.equals(r.getIsBackup()) && r.getBackupFor() != null)
@@ -179,7 +185,7 @@ public class ItemOrderService {
                 continue;
             }
             if (!primaryIdsWithBackup.contains(recipient.getAssigneeId())) {
-                addReason(conflictReasons, item.getItemId(), String.format(
+                addReason(warningReasons, item.getItemId(), String.format(
                         "%s의 대체 담당자가 없어요. 무응답 시 다음 단계가 막힐 수 있어요. 대체 담당자를 등록해 주세요.", recipient.getName()));
             }
         }

--- a/src/test/java/com/mamoki/ieojuda/domain/plan/service/ItemOrderServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/plan/service/ItemOrderServiceTest.java
@@ -190,9 +190,9 @@ class ItemOrderServiceTest {
         assertThat(assignedResult.conflict()).isFalse();
     }
 
-    // 규칙 6 - 대체 담당자 부재
+    // 규칙 6 - 대체 담당자 부재 (경고 전용 - 확정을 막지 않는다)
     @Test
-    void getOrderCheck_whenRecipientHasNoBackup_flagsMissingBackup() {
+    void getOrderCheck_whenRecipientHasNoBackup_flagsMissingBackupAsWarningOnly() {
         Recipient noBackupRecipient = buildRecipient("박서준");
         Recipient hasBackupRecipient = buildRecipient("최유진");
         Recipient backupOfHasBackup = buildBackupRecipient("대체최유진", hasBackupRecipient);
@@ -207,9 +207,14 @@ class ItemOrderServiceTest {
 
         var withoutBackupResult = response.items().stream().filter(i -> i.itemId().equals(withoutBackup.getItemId())).findFirst().orElseThrow();
         var withBackupResult = response.items().stream().filter(i -> i.itemId().equals(withBackup.getItemId())).findFirst().orElseThrow();
-        assertThat(withoutBackupResult.conflict()).isTrue();
-        assertThat(withoutBackupResult.conflictMessage()).contains("대체 담당자가 없어요");
+        // 확정을 막는 conflict는 아니다
+        assertThat(withoutBackupResult.conflict()).isFalse();
+        assertThat(withoutBackupResult.conflictMessage()).isNull();
+        // 대신 경고로만 표시된다
+        assertThat(withoutBackupResult.warning()).isTrue();
+        assertThat(withoutBackupResult.warningMessage()).contains("대체 담당자가 없어요");
         assertThat(withBackupResult.conflict()).isFalse();
+        assertThat(withBackupResult.warning()).isFalse();
     }
 
     // 규칙 5 - 권한 집중 (전체 항목의 과반을 한 담당자가 맡으면 경고)
@@ -253,6 +258,20 @@ class ItemOrderServiceTest {
         assertThatThrownBy(() -> itemOrderService.confirm(USER_ID, PLAN_ID))
                 .isInstanceOfSatisfying(CustomException.class,
                         e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.ITEM_ORDER_CONFLICT));
+    }
+
+    // 대체 담당자 부재는 경고일 뿐이므로, 다른 충돌이 없다면 확정이 막혀서는 안 된다
+    @Test
+    void confirm_whenOnlyMissingBackupWarningExists_confirmsSuccessfully() {
+        Recipient noBackupRecipient = buildRecipient("박서준");
+        when(recipientRepository.findByPlan_PlanId(PLAN_ID)).thenReturn(List.of(noBackupRecipient));
+        Item withoutBackup = buildItem(noBackupRecipient, "인스타그램", ItemActionType.OTHER, null, 0);
+        stubItems(withoutBackup);
+
+        var response = itemOrderService.confirm(USER_ID, PLAN_ID);
+
+        assertThat(response).isNotNull();
+        org.mockito.Mockito.verify(plan).confirmOrder();
     }
 
     @Test

--- a/src/test/java/com/mamoki/ieojuda/domain/plan/service/PlanSummaryServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/plan/service/PlanSummaryServiceTest.java
@@ -96,9 +96,9 @@ class PlanSummaryServiceTest {
                 List.of(acceptedAssignee, pendingAssignee), List.of(acceptedConfirmer, pendingConfirmer)));
 
         OrderCheckItemResponse conflicting = new OrderCheckItemResponse(
-                UUID.randomUUID(), 0, "삭제 항목", "DELETE", "CLOUD_DELETE", "담당자", 24, "ACCEPTED", true, "충돌 사유");
+                UUID.randomUUID(), 0, "삭제 항목", "DELETE", "CLOUD_DELETE", "담당자", 24, "ACCEPTED", true, "충돌 사유", false, null);
         OrderCheckItemResponse clean = new OrderCheckItemResponse(
-                UUID.randomUUID(), 1, "정상 항목", "OTHER", null, "담당자", 24, "ACCEPTED", false, null);
+                UUID.randomUUID(), 1, "정상 항목", "OTHER", null, "담당자", 24, "ACCEPTED", false, null, false, null);
         when(itemOrderService.getOrderCheck(USER_ID, PLAN_ID))
                 .thenReturn(OrderCheckResponse.of(List.of(conflicting, conflicting, clean)));
 


### PR DESCRIPTION
PR 본문 초안입니다. 복사해서 쓰시면 됩니다.

---

## 연관 Issue

- Closes #133

## 요약

"실행 순서 점검"에서 대체 담당자 부재가 순서 확정을 막지 않도록 변경했습니다. 확정을 막는 진짜 충돌(conflict)과, 확정은 가능하되 알려주기만 하는 경고(warning)를 분리했습니다.

## 변경 사항

- `ItemOrderService`: 대체 담당자 부재 판정(`checkMissingBackup`)을 `conflictReasons`가 아닌 별도 `warningReasons`로 분리. `confirm()`은 여전히 conflict만 검사하므로 대체 담당자 부재만 있어도 확정 가능
- `OrderCheckItemResponse`에 `warning`/`warningMessage` 필드 추가
- `ItemOrderController` Swagger description에 conflict/warning 구분 명시
- 대체 담당자 부재 관련 테스트를 warning 기준으로 수정, "대체 담당자 부재만 있어도 confirm 성공" 테스트 추가

## 범위

### 포함

- 대체 담당자 부재 규칙(규칙 6)의 확정 차단 여부 변경
- `OrderCheckItemResponse` API 응답 필드 추가 및 Swagger 문서 반영
- 관련 단위 테스트 갱신

### 제외

- 나머지 5개 충돌 규칙(순서 쌍 3종, 담당자 누락, 권한 집중)의 확정 차단 동작 — 그대로 유지
- 프론트엔드 변경 (이 저장소에는 프론트엔드 코드 없음)

## 스크린샷 / 미리 보기

- API 응답/UI 변경 없음 (백엔드 응답 필드만 추가)