### PR TITLE
[Fix/#135]: 계획 홈 구역 요약을 하드코딩 문구 대신 승인된 항목 기반으로 변경

### DIFF
--- a/src/main/java/com/mamoki/ieojuda/domain/plan/dto/LifeAreaSummaryResponse.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/dto/LifeAreaSummaryResponse.java
@@ -1,19 +1,38 @@
 package com.mamoki.ieojuda.domain.plan.dto;
 
+import com.mamoki.ieojuda.domain.plan.entity.ItemStatus;
 import com.mamoki.ieojuda.domain.plan.entity.LifeAreaCategory;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 // "계획 홈" 화면 - 구역 카드 하나 (전체 항목 목록이 아니라 개수·작성 여부만)
 public record LifeAreaSummaryResponse(
         @Schema(description = "구역 분류", example = "FAMILY", allowableValues = {"FAMILY", "RELATIONSHIP_CLEANUP", "WORK_CONTINUITY"}) String category,
         @Schema(description = "구역 표시 이름") String label,
-        @Schema(description = "구역 한 줄 설명") String summary,
-        @Schema(description = "이 구역에 쌓인 항목 수") int itemCount,
-        @Schema(description = "항목을 하나라도 작성했는지 여부") boolean isWritten
+        @Schema(description = "구역 한 줄 설명 - 승인된 항목의 title/content를 조합, 승인된 항목이 없으면 null", example = "인스타그램 탈퇴 처리, 카카오톡 탈퇴 처리") String summary,
+        @Schema(description = "이 구역에서 승인된 항목 수") int itemCount,
+        @Schema(description = "승인된 항목을 하나라도 작성했는지 여부") boolean isWritten
 ) {
+    private static final int SUMMARY_ITEM_LIMIT = 3;
+
     public static LifeAreaSummaryResponse from(LifeAreaResponse lifeAreaResponse) {
         LifeAreaCategory category = LifeAreaCategory.valueOf(lifeAreaResponse.category());
-        int itemCount = lifeAreaResponse.items().size();
-        return new LifeAreaSummaryResponse(category.name(), category.label(), category.summary(), itemCount, itemCount > 0);
+        List<ItemResponse> approvedItems = lifeAreaResponse.items().stream()
+                .filter(item -> ItemStatus.APPROVED.name().equals(item.status()))
+                .toList();
+        int itemCount = approvedItems.size();
+        String summary = itemCount == 0 ? null : buildSummary(approvedItems);
+        return new LifeAreaSummaryResponse(category.name(), category.label(), summary, itemCount, itemCount > 0);
+    }
+
+    private static String buildSummary(List<ItemResponse> approvedItems) {
+        String joined = approvedItems.stream()
+                .limit(SUMMARY_ITEM_LIMIT)
+                .map(item -> item.title() + " " + item.content())
+                .collect(Collectors.joining(", "));
+        int remaining = approvedItems.size() - SUMMARY_ITEM_LIMIT;
+        return remaining > 0 ? joined + " 외 " + remaining + "건" : joined;
     }
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/entity/LifeAreaCategory.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/entity/LifeAreaCategory.java
@@ -7,22 +7,11 @@ public enum LifeAreaCategory {
 
     ;
 
-    // 계획 홈 화면(#84)에서 쓰는 구역별 고정 문구 - 백엔드-구현-스펙.md 3-2 예시 그대로.
-    // (검토 필요) summary는 예시 문구를 그대로 가져온 것이라 실제로는 카테고리 설명이 아니라
-    // 항목 내용 기반 동적 요약이어야 할 수도 있음 - 기획/디자인 확인 후 조정.
     public String label() {
         return switch (this) {
             case FAMILY -> "전달 메세지";
             case RELATIONSHIP_CLEANUP -> "관계 정리";
             case WORK_CONTINUITY -> "업무 처리";
-        };
-    }
-
-    public String summary() {
-        return switch (this) {
-            case FAMILY -> "가족·친구·지인에게";
-            case RELATIONSHIP_CLEANUP -> "SNS 계정·부고 전달";
-            case WORK_CONTINUITY -> "디자인 프로젝트 인수인계";
         };
     }
 }

--- a/src/test/java/com/mamoki/ieojuda/domain/plan/dto/LifeAreaSummaryResponseTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/plan/dto/LifeAreaSummaryResponseTest.java
@@ -1,0 +1,79 @@
+package com.mamoki.ieojuda.domain.plan.dto;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LifeAreaSummaryResponseTest {
+
+    private ItemResponse item(String title, String content, String status) {
+        return new ItemResponse(UUID.randomUUID(), "target", "location", "action", title, content,
+                "", "FAMILY", "excerpt", status, 0, "OTHER", null);
+    }
+
+    @Test
+    void from_returnsNullSummary_whenNoApprovedItems() {
+        LifeAreaResponse lifeAreaResponse = new LifeAreaResponse("FAMILY", List.of(
+                item("인스타그램", "탈퇴 처리", "PROPOSED")));
+
+        LifeAreaSummaryResponse response = LifeAreaSummaryResponse.from(lifeAreaResponse);
+
+        assertThat(response.summary()).isNull();
+        assertThat(response.itemCount()).isZero();
+        assertThat(response.isWritten()).isFalse();
+    }
+
+    @Test
+    void from_returnsNullSummary_whenNoItemsAtAll() {
+        LifeAreaResponse lifeAreaResponse = new LifeAreaResponse("FAMILY", List.of());
+
+        LifeAreaSummaryResponse response = LifeAreaSummaryResponse.from(lifeAreaResponse);
+
+        assertThat(response.summary()).isNull();
+        assertThat(response.itemCount()).isZero();
+        assertThat(response.isWritten()).isFalse();
+    }
+
+    @Test
+    void from_joinsApprovedItemTitleAndContent_whenThreeOrFewer() {
+        LifeAreaResponse lifeAreaResponse = new LifeAreaResponse("FAMILY", List.of(
+                item("인스타그램", "탈퇴 처리", "APPROVED"),
+                item("카카오톡", "탈퇴 처리", "APPROVED"),
+                item("네이버클라우드", "자료 이전", "PROPOSED")));
+
+        LifeAreaSummaryResponse response = LifeAreaSummaryResponse.from(lifeAreaResponse);
+
+        assertThat(response.summary()).isEqualTo("인스타그램 탈퇴 처리, 카카오톡 탈퇴 처리");
+        assertThat(response.itemCount()).isEqualTo(2);
+        assertThat(response.isWritten()).isTrue();
+    }
+
+    @Test
+    void from_limitsToThreeItemsAndAppendsRemainingCount_whenMoreThanThreeApproved() {
+        LifeAreaResponse lifeAreaResponse = new LifeAreaResponse("FAMILY", List.of(
+                item("A", "정리", "APPROVED"),
+                item("B", "정리", "APPROVED"),
+                item("C", "정리", "APPROVED"),
+                item("D", "정리", "APPROVED"),
+                item("E", "정리", "APPROVED")));
+
+        LifeAreaSummaryResponse response = LifeAreaSummaryResponse.from(lifeAreaResponse);
+
+        assertThat(response.summary()).isEqualTo("A 정리, B 정리, C 정리 외 2건");
+        assertThat(response.itemCount()).isEqualTo(5);
+        assertThat(response.isWritten()).isTrue();
+    }
+
+    @Test
+    void from_keepsFixedCategoryAndLabel_regardlessOfItems() {
+        LifeAreaResponse lifeAreaResponse = new LifeAreaResponse("WORK_CONTINUITY", List.of());
+
+        LifeAreaSummaryResponse response = LifeAreaSummaryResponse.from(lifeAreaResponse);
+
+        assertThat(response.category()).isEqualTo("WORK_CONTINUITY");
+        assertThat(response.label()).isEqualTo("업무 처리");
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/domain/plan/service/PlanSummaryServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/plan/service/PlanSummaryServiceTest.java
@@ -75,10 +75,13 @@ class PlanSummaryServiceTest {
     @Test
     void getMySummary_aggregatesEveryCollaboratorResponse() {
         ItemResponse item = new ItemResponse(UUID.randomUUID(), "target", "location", "action", "title", "content",
+                "", "FAMILY", "excerpt", "APPROVED", 0, "OTHER", null);
+        ItemResponse proposedItem = new ItemResponse(UUID.randomUUID(), "target", "location", "action", "title", "content",
                 "", "FAMILY", "excerpt", "PROPOSED", 0, "OTHER", null);
         when(lifeAreaService.getLifeAreas(USER_ID, PLAN_ID)).thenReturn(List.of(
                 new LifeAreaResponse("FAMILY", List.of(item, item, item)),
-                new LifeAreaResponse("RELATIONSHIP_CLEANUP", List.of()),
+                // 아직 검토(승인) 안 된 항목만 있는 구역은 itemCount/isWritten에 반영되면 안 된다
+                new LifeAreaResponse("RELATIONSHIP_CLEANUP", List.of(proposedItem)),
                 new LifeAreaResponse("WORK_CONTINUITY", List.of(item))
         ));
 


### PR DESCRIPTION
## 연관 Issue

- Closes #135

## 요약

"계획 홈" 응답의 구역 요약(`lifeAreas[].summary`)이 실제 데이터와 무관한 고정 문구였던 것을, 승인된 항목 내용을 반영하도록 수정했습니다.

## 변경 사항

- `LifeAreaSummaryResponse.from()`: `summary`를 승인(APPROVED)된 항목의 `title content`를 최대 3개까지 이어붙여 생성 (4개 이상이면 "외 N건" 추가), 승인된 항목이 없으면 `null`
- `itemCount`/`isWritten`도 승인된 항목 기준으로 계산하도록 변경 (기존엔 미검토 PROPOSED 항목도 "작성완료"로 잡히던 문제)
- `LifeAreaCategory.summary()` 하드코딩 고정 문구 제거

## 범위

### 포함

- "계획 홈" API(`GET /api/plans/current/summary`)의 `lifeAreas` summary/itemCount/isWritten 계산 로직
- 관련 단위 테스트 추가/보강

### 제외

- "AI 구조화 결과 검토" 화면(`LifeAreaService`/`LifeAreaController`)의 항목 조회 로직 - PROPOSED+APPROVED 전체를 그대로 반환하도록 유지
- 새로운 AI 요약 호출 도입 없음 (기존 저장된 title/content 필드만 조합)

## 스크린샷 / 미리 보기

- UI 없는 백엔드 API 응답 변경으로 스크린샷 생략