### PR TITLE
[Feat]: 이메일 링크를 실제 프론트엔드 경로로 교체

### DIFF
--- a/src/main/java/com/mamoki/ieojuda/domain/audit/service/EmailAuditService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/audit/service/EmailAuditService.java
@@ -83,7 +83,8 @@ public class EmailAuditService {
         LocalDateTime expiresAt = LocalDateTime.now().plusHours(appProperties.getInviteTokenTtlHours());
         String plainToken = securityTokenService.issueForRecipient(SecurityTokenPurpose.ACCEPT_ROLE, recipient, expiresAt);
 
-        String secureLink = appProperties.getBaseUrl() + "/recipient-acceptances/" + plainToken;
+        String path = Boolean.TRUE.equals(recipient.getIsBackup()) ? "/backup-accept" : "/role-acceptance";
+        String secureLink = appProperties.getBaseUrl() + path + "?token=" + plainToken;
         EmailContent content = EmailBuilder.build(
                 "사후 인계 안내",
                 "역할 수락 여부를 다시 확인해 주세요.",

--- a/src/main/java/com/mamoki/ieojuda/domain/confirmer/service/ConfirmerService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/confirmer/service/ConfirmerService.java
@@ -98,7 +98,7 @@ public class ConfirmerService {
     }
 
     private void sendAcceptanceEmail(Confirmer confirmer, String plainToken, LocalDateTime expiresAt) {
-        String secureLink = appProperties.getBaseUrl() + "/confirmer-acceptances/" + plainToken;
+        String secureLink = appProperties.getBaseUrl() + "/verifier-accept?token=" + plainToken;
         EmailContent content = EmailBuilder.build(
                 "지정 확인자",
                 "지정 확인자 역할 수락 여부를 확인해 주세요.",

--- a/src/main/java/com/mamoki/ieojuda/domain/confirmer/service/DeathReportService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/confirmer/service/DeathReportService.java
@@ -101,7 +101,7 @@ public class DeathReportService {
         String plainToken = securityTokenService.issueForConfirmer(
                 SecurityTokenPurpose.UPLOAD_EVIDENCE, confirmer, releaseCase, expiresAt);
 
-        String secureLink = appProperties.getBaseUrl() + "/evidence-submissions/" + releaseCase.getCaseId() + "/" + plainToken;
+        String secureLink = appProperties.getBaseUrl() + "/death-report?token=" + plainToken + "&caseId=" + releaseCase.getCaseId();
         EmailContent content = EmailBuilder.build(
                 "공식 증빙 자료 제출",
                 "사망 관련 공식 증빙 자료(사망진단서 등)를 제출해 주세요.",

--- a/src/main/java/com/mamoki/ieojuda/domain/confirmer/service/DisputeContactService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/confirmer/service/DisputeContactService.java
@@ -159,7 +159,7 @@ public class DisputeContactService {
             String plainToken = securityTokenService.issueForDisputeContact(
                     SecurityTokenPurpose.RAISE_OBJECTION, contact, releaseCase, expiresAt);
 
-            String secureLink = appProperties.getBaseUrl() + "/release-cases/" + releaseCase.getCaseId() + "/disputes/" + plainToken;
+            String secureLink = appProperties.getBaseUrl() + "/waiting?caseId=" + releaseCase.getCaseId() + "&token=" + plainToken;
             EmailContent content = EmailBuilder.build(
                     "이의 제기 가능 기간 안내",
                     "잘못된 점이 있다면 링크로 들어가 이의를 제기해 주세요.",

--- a/src/main/java/com/mamoki/ieojuda/domain/recipient/service/RecipientService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/recipient/service/RecipientService.java
@@ -162,7 +162,9 @@ public class RecipientService {
 
     private void sendAcceptanceEmail(Recipient recipient, String roleName,
                                       String plainToken, LocalDateTime expiresAt) {
-        String secureLink = appProperties.getBaseUrl() + "/recipient-acceptances/" + plainToken;
+        // 프론트 실제 경로 - 주 담당자와 대체 담당자는 서로 다른 화면으로 안내한다.
+        String path = Boolean.TRUE.equals(recipient.getIsBackup()) ? "/backup-accept" : "/role-acceptance";
+        String secureLink = appProperties.getBaseUrl() + path + "?token=" + plainToken;
         EmailContent content = EmailBuilder.build(
                 roleName,
                 "역할 수락 여부를 확인해 주세요.",

--- a/src/main/java/com/mamoki/ieojuda/domain/releasecase/service/ReleaseCaseWarningService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/releasecase/service/ReleaseCaseWarningService.java
@@ -48,7 +48,7 @@ public class ReleaseCaseWarningService {
         LocalDateTime expiresAt = LocalDateTime.now().plusDays(CANCEL_TOKEN_TTL_DAYS);
         String plainToken = securityTokenService.issueForCase(SecurityTokenPurpose.CANCEL_CASE, releaseCase, expiresAt);
 
-        String secureLink = appProperties.getBaseUrl() + "/release-cases/" + releaseCase.getCaseId() + "/cancellations/" + plainToken;
+        String secureLink = appProperties.getBaseUrl() + "/waiting?caseId=" + releaseCase.getCaseId() + "&token=" + plainToken;
         EmailContent content = EmailBuilder.build(
                 "사후 절차 시작 및 취소 안내",
                 "본인이 아니거나 절차를 멈추고 싶다면 링크를 눌러 즉시 취소해 주세요.",
@@ -96,7 +96,7 @@ public class ReleaseCaseWarningService {
         String plainToken = securityTokenService.issueForDisputeContact(
                 SecurityTokenPurpose.RAISE_OBJECTION, contact, releaseCase, expiresAt);
 
-        String secureLink = appProperties.getBaseUrl() + "/release-cases/" + releaseCase.getCaseId() + "/disputes/" + plainToken;
+        String secureLink = appProperties.getBaseUrl() + "/waiting?caseId=" + releaseCase.getCaseId() + "&token=" + plainToken;
         EmailContent content = EmailBuilder.build(
                 "이의 제기 가능 기간 안내",
                 "잘못된 점이 있다면 링크로 들어가 이의를 제기해 주세요.",

--- a/src/main/java/com/mamoki/ieojuda/domain/stage/service/HandoverStageService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/stage/service/HandoverStageService.java
@@ -214,7 +214,7 @@ public class HandoverStageService {
                 .expiresAt(expiresAt)
                 .build());
 
-        String secureLink = appProperties.getBaseUrl() + "/posthumous-access/" + plainToken;
+        String secureLink = appProperties.getBaseUrl() + "/handoff-email?token=" + plainToken;
         EmailContent content = kind == InviteKind.INITIAL
                 ? EmailBuilder.build(
                         "사후 인계 안내",

--- a/src/test/java/com/mamoki/ieojuda/domain/stage/service/HandoverStageServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/stage/service/HandoverStageServiceTest.java
@@ -125,8 +125,8 @@ class HandoverStageServiceTest {
     // 버그 회귀 방지(#79) - 이메일 링크에 박힌 평문 토큰이, 실제로 AccessToken 테이블에 그 해시로
     // 저장됐는지까지 끝까지 추적해서 확인한다. 링크 문자열만 바뀌고 발급처는 그대로였던 버그를 이 검증이 잡는다.
     private void assertLinkTokenWasIssuedAsAccessToken(EmailContent content) {
-        Matcher matcher = Pattern.compile("/posthumous-access/([\\w-]+)").matcher(content.body());
-        assertThat(matcher.find()).as("본문에 /posthumous-access/{token} 링크가 있어야 한다").isTrue();
+        Matcher matcher = Pattern.compile("/handoff-email\\?token=([\\w-]+)").matcher(content.body());
+        assertThat(matcher.find()).as("본문에 /handoff-email?token={token} 링크가 있어야 한다").isTrue();
         String plainToken = matcher.group(1);
         String expectedHash = TokenProvider.hashToken(plainToken);
 
@@ -206,7 +206,7 @@ class HandoverStageServiceTest {
         EmailContent content = captor.getValue();
         assertThat(content.body()).doesNotContain("대체 담당자로 지정되었습니다");
         assertThat(content.body()).contains("업무 담당자 역할로 전달드릴 내용이 있습니다");
-        assertThat(content.body()).contains("https://ieoduda.example/posthumous-access/");
+        assertThat(content.body()).contains("https://ieoduda.example/handoff-email?token=");
         assertThat(content.body()).doesNotContain("/recipient-acceptances/");
         assertLinkTokenWasIssuedAsAccessToken(content);
     }
@@ -266,7 +266,7 @@ class HandoverStageServiceTest {
         assertThat(content.subject()).doesNotContain("대체 담당자");
         assertThat(content.body()).doesNotContain("이전 담당자가 응답하지 않아");
         assertThat(content.body()).contains("가족 담당자 역할로 전달드릴 내용이 있습니다");
-        assertThat(content.body()).contains("/posthumous-access/");
+        assertThat(content.body()).contains("/handoff-email?token=");
         assertLinkTokenWasIssuedAsAccessToken(content);
     }
 
@@ -290,7 +290,7 @@ class HandoverStageServiceTest {
         EmailContent content = captor.getValue();
         assertThat(content.subject()).contains("대체 담당자");
         assertThat(content.body()).contains("이전 담당자가 응답하지 않아 대체 담당자로 지정되었습니다. 역할 수락 여부를 확인해 주세요.");
-        assertThat(content.body()).contains("/posthumous-access/");
+        assertThat(content.body()).contains("/handoff-email?token=");
         assertThat(content.body()).doesNotContain("/recipient-acceptances/");
         assertLinkTokenWasIssuedAsAccessToken(content);
         // issue #47 완료 조건 - "전환 대상과 사유를 감사 로그에서 확인할 수 있다"

--- a/src/test/java/com/mamoki/ieojuda/domain/stage/service/StageDispatchHttpIntegrationTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/stage/service/StageDispatchHttpIntegrationTest.java
@@ -246,14 +246,14 @@ class StageDispatchHttpIntegrationTest {
                 .findFirst()
                 .orElseThrow(() -> new AssertionError("2단계 담당자 앞으로 등록된 아웃박스 행이 없다"));
         assertThat(stage2Outbox.getBody()).doesNotContain("대체 담당자로 지정되었습니다");
-        assertThat(stage2Outbox.getBody()).contains("/posthumous-access/");
+        assertThat(stage2Outbox.getBody()).contains("/handoff-email?token=");
         assertThat(stage2Outbox.getBody()).doesNotContain("/recipient-acceptances/");
 
         // 메일 본문에 박힌 링크에서 토큰을 뽑아 둔다 (버그 회귀 방지 - #76의 실제 인증 API를 호출해볼 것이다.
         // 이전엔 링크 문자열만 /posthumous-access/로 바뀌고 토큰은 여전히 recipient.inviteToken에
         // 저장되고 있어서, 이 호출이 전부 TOKEN_INVALID로 실패했었다 - 단위 테스트로는 못 잡던 버그)
         java.util.regex.Matcher linkMatcher = java.util.regex.Pattern
-                .compile("/posthumous-access/([\\w-]+)").matcher(stage2Outbox.getBody());
+                .compile("/handoff-email\\?token=([\\w-]+)").matcher(stage2Outbox.getBody());
         assertThat(linkMatcher.find()).as("메일 본문에 사후 인증 링크가 있어야 한다").isTrue();
         String dispatchedPlainToken = linkMatcher.group(1);
 


### PR DESCRIPTION
## 요약
이메일 본문에 들어가는 프론트 링크 경로가 실제 배포된 프론트엔드(`https://ieoduda-frontend.vercel.app`) 라우팅과 달라 전부 404가 나는 문제를 수정합니다. **발송 로직·토큰 발급 방식은 그대로 두고 링크 문자열만 교체**했습니다.

## 변경 사항
| 이메일 | 이전 경로 | 이후 경로 |
|---|---|---|
| 역할 담당자 초대 | `/recipient-acceptances/{token}` | `/role-acceptance?token={token}` |
| 대체 담당자 초대 | 주 담당자와 동일(구분 없음) | `/backup-accept?token={token}` (신규 분기) |
| 지정확인자 초대 | `/confirmer-acceptances/{token}` | `/verifier-accept?token={token}` |
| 사망 사실 확인 요청(증빙 제출 안내) | `/evidence-submissions/{caseId}/{token}` | `/death-report?token={token}&caseId={caseId}` |
| 대기 기간 취소·이의 제기 | `.../cancellations/{token}` / `.../disputes/{token}` (2개) | `/waiting?caseId={caseId}&token={token}` (통합) |
| 사후 인계 안내 | `/posthumous-access/{token}` | `/handoff-email?token={token}` |

대체 담당자 분기는 `RecipientService`(신규 발송)와 `EmailAuditService`(재발송) 양쪽 모두 `recipient.getIsBackup()`으로 처리했습니다.

## 범위
### 포함
- 위 6개 이메일의 링크 문자열 교체
- 사용처 없는 `DisputeContactService`의 구 코드도 일관성을 위해 함께 수정(호출되지 않음)

### 제외
- 이메일 제목/본문 문구, 발송 조건, 토큰 발급·만료 로직 — 전부 변경 없음
- 백엔드 API 경로(`/api/posthumous-access/**` 등) — 변경 없음, 프론트 페이지 경로만 변경

## 테스트 내역
- `HandoverStageServiceTest`, `StageDispatchHttpIntegrationTest`의 링크 문자열 검증을 새 경로로 갱신
- 전체 테스트 스위트 377개 중 1개 실패 — 이 PR과 무관한 기존 플레이키 테스트(`InputLimitHttpIntegrationTest`, 대용량 멀티파트 소켓 처리)