### PR TITLE
[Feat/#139] 필수동의 전 사용자 정보 가져옴 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 DB_URL=jdbc:postgresql://localhost:5432/ieojuda
 DB_USERNAME=ieojuda
 DB_PASSWORD=replace-with-local-password
+POSTGRES_DB=ieojuda
 
 # Application dependencies required at startup
 OPENAI_API_KEY=replace-with-openai-api-key

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+services:
+  db:
+    image: postgres:18-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${DB_USERNAME}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+    volumes:
+      - pgdata:/var/lib/postgresql
+    ports:
+      - "127.0.0.1:5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USERNAME} -d ${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  app:
+    image: leemingu03/ieoduda2026:latest
+    build: .
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      DB_URL: jdbc:postgresql://db:5432/${POSTGRES_DB}
+    depends_on:
+      db:
+        condition: service_healthy
+    ports:
+      - "8080:8080"
+
+volumes:
+  pgdata:

--- a/src/main/java/com/mamoki/ieojuda/global/consent/filter/ConsentCheckFilter.java
+++ b/src/main/java/com/mamoki/ieojuda/global/consent/filter/ConsentCheckFilter.java
@@ -38,6 +38,12 @@ public class ConsentCheckFilter extends OncePerRequestFilter {
             "/api/consents"
     };
 
+    // GET /users/me(내 정보 조회)는 동의 안내 화면 헤더 등에서도 호출되므로 조회만 예외로 둔다.
+    // PUT/DELETE는 같은 경로를 쓰지만 계속 동의를 요구해야 하므로 메서드까지 함께 검사한다.
+    private static final String[] EXCLUDED_GET_PATHS = {
+            "/users/me"
+    };
+
     private final UserRepository userRepository;
     private final AntPathMatcher pathMatcher = new AntPathMatcher();
 
@@ -48,7 +54,7 @@ public class ConsentCheckFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
-        if (isExcluded(request.getServletPath())) {
+        if (isExcluded(request.getServletPath()) || isExcludedGet(request)) {
             filterChain.doFilter(request, response);
             return;
         }
@@ -78,6 +84,18 @@ public class ConsentCheckFilter extends OncePerRequestFilter {
     private boolean isExcluded(String path) {
         for (String pattern : EXCLUDED_PATHS) {
             if (pathMatcher.match(pattern, path)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isExcludedGet(HttpServletRequest request) {
+        if (!"GET".equalsIgnoreCase(request.getMethod())) {
+            return false;
+        }
+        for (String pattern : EXCLUDED_GET_PATHS) {
+            if (pathMatcher.match(pattern, request.getServletPath())) {
                 return true;
             }
         }

--- a/src/test/java/com/mamoki/ieojuda/domain/account/controller/ConsentCheckFilterHttpIntegrationTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/account/controller/ConsentCheckFilterHttpIntegrationTest.java
@@ -1,0 +1,157 @@
+package com.mamoki.ieojuda.domain.account.controller;
+
+import com.mamoki.ieojuda.domain.account.entity.User;
+import com.mamoki.ieojuda.domain.account.repository.UserRepository;
+import com.mamoki.ieojuda.global.jwt.component.JwtTokenProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+// 필수동의(consentAgreedAt)를 하지 않은 사용자도 GET /users/me(내 정보 조회)는 할 수 있어야 하지만,
+// PUT/DELETE /users/me는 여전히 ConsentCheckFilter가 막아야 한다.
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class ConsentCheckFilterHttpIntegrationTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    private final HttpClient httpClient = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build();
+
+    private User user;
+    private String accessToken;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder()
+                .email("consent-filter-" + UUID.randomUUID() + "@test.com").password("hash").name("김미동의").build();
+        // 일부러 agreeToConsent()를 호출하지 않아 필수동의 미완료 상태로 둔다.
+        user = userRepository.saveAndFlush(user);
+        accessToken = jwtTokenProvider.generateAccessToken(user.getUserId(), user.getEmail(), "USER", user.getTokenVersion());
+    }
+
+    @AfterEach
+    void tearDown() {
+        userRepository.delete(user);
+    }
+
+    @Test
+    void getMe_whenConsentNotAgreed_returns200() throws Exception {
+        HttpResponse<String> response = get("/users/me");
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.body()).contains("\"name\":\"김미동의\"");
+    }
+
+    @Test
+    void updateMe_whenConsentNotAgreed_returns400WithConsentRequired() throws Exception {
+        String body = "{\"name\":\"바뀐이름\"}";
+        HttpResponse<String> response = httpClient.send(HttpRequest.newBuilder(uri("/users/me"))
+                .header("Authorization", "Bearer " + accessToken)
+                .header("Content-Type", "application/json")
+                .PUT(HttpRequest.BodyPublishers.ofString(body)).build(), HttpResponse.BodyHandlers.ofString());
+
+        assertThat(response.statusCode()).isEqualTo(400);
+        assertThat(response.body()).contains("\"code\":\"CONSENT_REQUIRED\"");
+    }
+
+    @Test
+    void deleteMe_whenConsentNotAgreed_returns400WithConsentRequired() throws Exception {
+        HttpResponse<String> response = httpClient.send(HttpRequest.newBuilder(uri("/users/me"))
+                .header("Authorization", "Bearer " + accessToken)
+                .DELETE().build(), HttpResponse.BodyHandlers.ofString());
+
+        assertThat(response.statusCode()).isEqualTo(400);
+        assertThat(response.body()).contains("\"code\":\"CONSENT_REQUIRED\"");
+    }
+
+    // 필수동의를 이미 완료한 사용자는 이번 변경 전과 동일하게 세 API 모두 정상 동작해야 한다(회귀 방지).
+    // 공용 user/accessToken을 건드리면(특히 삭제) 다른 테스트와 상태가 얽히므로 각자 별도 사용자를 쓴다.
+
+    @Test
+    void getMe_whenConsentAgreed_returns200() throws Exception {
+        User consentedUser = createConsentedUser("김동의-조회");
+        try {
+            HttpResponse<String> response = getWithToken("/users/me", tokenFor(consentedUser));
+
+            assertThat(response.statusCode()).isEqualTo(200);
+            assertThat(response.body()).contains("\"name\":\"김동의-조회\"");
+        } finally {
+            userRepository.delete(consentedUser);
+        }
+    }
+
+    @Test
+    void updateMe_whenConsentAgreed_returns200AndUpdatesProfile() throws Exception {
+        User consentedUser = createConsentedUser("김동의-수정전");
+        try {
+            // 이메일은 그대로 두고 이름만 바꿔서 이메일 변경에 딸린 별도 정책(세션 폐기 등)은 건드리지 않는다.
+            String body = "{\"email\":\"" + consentedUser.getEmail() + "\",\"name\":\"김동의-수정후\"}";
+            HttpResponse<String> response = httpClient.send(HttpRequest.newBuilder(uri("/users/me"))
+                    .header("Authorization", "Bearer " + tokenFor(consentedUser))
+                    .header("Content-Type", "application/json")
+                    .PUT(HttpRequest.BodyPublishers.ofString(body)).build(), HttpResponse.BodyHandlers.ofString());
+
+            assertThat(response.statusCode()).isEqualTo(200);
+            assertThat(response.body()).contains("\"name\":\"김동의-수정후\"");
+            assertThat(userRepository.findById(consentedUser.getUserId()).orElseThrow().getName())
+                    .isEqualTo("김동의-수정후");
+        } finally {
+            userRepository.deleteById(consentedUser.getUserId());
+        }
+    }
+
+    @Test
+    void deleteMe_whenConsentAgreed_returns200AndDeletesAccount() throws Exception {
+        User consentedUser = createConsentedUser("김동의-삭제");
+
+        HttpResponse<String> response = httpClient.send(HttpRequest.newBuilder(uri("/users/me"))
+                .header("Authorization", "Bearer " + tokenFor(consentedUser))
+                .DELETE().build(), HttpResponse.BodyHandlers.ofString());
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(userRepository.findById(consentedUser.getUserId())).isEmpty();
+    }
+
+    private User createConsentedUser(String name) {
+        User consentedUser = User.builder()
+                .email("consent-filter-agreed-" + UUID.randomUUID() + "@test.com").password("hash").name(name).build();
+        consentedUser.agreeToConsent();
+        return userRepository.saveAndFlush(consentedUser);
+    }
+
+    private String tokenFor(User targetUser) {
+        return jwtTokenProvider.generateAccessToken(
+                targetUser.getUserId(), targetUser.getEmail(), "USER", targetUser.getTokenVersion());
+    }
+
+    private HttpResponse<String> get(String path) throws Exception {
+        return getWithToken(path, accessToken);
+    }
+
+    private HttpResponse<String> getWithToken(String path, String token) throws Exception {
+        return httpClient.send(HttpRequest.newBuilder(uri(path))
+                .header("Authorization", "Bearer " + token)
+                .GET().build(), HttpResponse.BodyHandlers.ofString());
+    }
+
+    private URI uri(String path) {
+        return URI.create("http://127.0.0.1:" + port + path);
+    }
+}


### PR DESCRIPTION
## 연관 Issue

- Closes #139

## 요약

필수동의(사후 인계 안내)를 아직 완료하지 않은 사용자도 `GET /users/me`(내 정보 조회)를 호출할 수 있도록 `ConsentCheckFilter`를 수정했습니다. 기존에는 동의 안내 화면 자체에서 헤더가 사용자 이름을 불러오지 못하고 "불러오는 중"에 멈춰 있었습니다.

## 변경 사항

- `ConsentCheckFilter`에 GET 전용 예외 경로(`EXCLUDED_GET_PATHS`)를 추가해 `GET /users/me`만 필수동의 체크에서 제외
- 위 동작을 검증하는 HTTP 통합 테스트(`ConsentCheckFilterHttpIntegrationTest`) 추가 — 미동의/동의 완료 사용자 각각에 대해 GET/PUT/DELETE 3종 API 응답 확인
- 로컬 개발용 `docker-compose.yml` 추가 및 `.env.example`에 `POSTGRES_DB` 항목 추가

## 범위

### 포함

- `GET /users/me`를 필수동의 체크에서 예외 처리
- 필수동의 필터 관련 회귀 테스트 (GET/PUT/DELETE × 동의 여부)
- 로컬 Docker Compose 실행 환경 구성

### 제외

- `PUT /users/me`, `DELETE /users/me`는 이번 변경 대상이 아니며, 기존대로 필수동의를 요구합니다 (테스트로 회귀 없음 확인)
- 프론트엔드 코드 변경 없음 (백엔드 필터 동작만 수정)

## 스크린샷 / 미리 보기

- 변경 전: 필수동의 안내 화면 헤더의 사용자 정보가 "불러오는 중"에서 멈춤 (`GET /users/me`가 400 `CONSENT_REQUIRED`로 차단됨)
- 변경 후: 같은 화면에서 `GET /users/me`가 200으로 응답해 사용자 정보가 정상 표시됨