### PR TITLE
[Feat/#143]: 관리자 증빙 삭제 감사 목록 API 추가

### DIFF
--- a/src/main/java/com/mamoki/ieojuda/domain/evidence/controller/AdminEvidenceDeletionController.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/evidence/controller/AdminEvidenceDeletionController.java
@@ -1,0 +1,38 @@
+package com.mamoki.ieojuda.domain.evidence.controller;
+
+import java.util.UUID;
+
+import com.mamoki.ieojuda.domain.evidence.dto.EvidenceDeletionStatusResponse;
+import com.mamoki.ieojuda.domain.evidence.service.EvidenceDeletionService;
+import com.mamoki.ieojuda.global.rsdata.RsData;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+// 관리자 "증빙 삭제 감사" 목록 화면 - evidenceId를 몰라도 전체 증빙을 조회할 수 있어야 함
+@Tag(name = "Admin - Evidence Deletion Audit", description = "운영관리자 - 증빙 삭제 감사 목록 조회")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/evidence")
+public class AdminEvidenceDeletionController {
+
+    private final EvidenceDeletionService evidenceDeletionService;
+
+    @Operation(summary = "증빙 삭제 감사 목록 조회", description = "전체 증빙의 검토완료일·삭제예정일·삭제상태를 페이지 단위로 조회합니다.")
+    @GetMapping("/deletion-statuses")
+    public ResponseEntity<RsData<Page<EvidenceDeletionStatusResponse>>> getStatuses(
+            @AuthenticationPrincipal UUID userId,
+            @PageableDefault(size = 50, sort = "submittedAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return ResponseEntity.ok(RsData.success(evidenceDeletionService.getAllStatuses(userId, pageable)));
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/evidence/service/EvidenceDeletionService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/evidence/service/EvidenceDeletionService.java
@@ -14,6 +14,8 @@ import com.mamoki.ieojuda.global.exception.ErrorCode;
 import com.mamoki.ieojuda.global.security.PermissionGuard;
 import com.mamoki.ieojuda.global.storage.EvidenceStorageClient;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,6 +34,12 @@ public class EvidenceDeletionService {
     public EvidenceDeletionStatusResponse getStatus(UUID userId, UUID evidenceId) {
         permissionGuard.require(userId, AdminPermission.EVIDENCE_DELETE_RETRY);
         return EvidenceDeletionStatusResponse.from(findEvidence(evidenceId));
+    }
+
+    // 관리자 "증빙 삭제 감사" 목록 화면 - evidenceId를 몰라도 전체 증빙을 페이지 단위로 조회
+    public Page<EvidenceDeletionStatusResponse> getAllStatuses(UUID userId, Pageable pageable) {
+        permissionGuard.require(userId, AdminPermission.EVIDENCE_DELETE_RETRY);
+        return evidenceRepository.findAll(pageable).map(EvidenceDeletionStatusResponse::from);
     }
 
     // "재처리 요청하기" - 자동 삭제가 실패한 증빙을 다시 삭제 시도. 사람 행위자가 있는 고위험

--- a/src/test/java/com/mamoki/ieojuda/domain/evidence/service/EvidenceDeletionServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/evidence/service/EvidenceDeletionServiceTest.java
@@ -14,7 +14,12 @@ import com.mamoki.ieojuda.global.security.PermissionGuard;
 import com.mamoki.ieojuda.global.storage.EvidenceStorageClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -78,5 +83,22 @@ class EvidenceDeletionServiceTest {
 
         assertThat(response.deletedAt()).isNull();
         assertThat(response.overdue()).isFalse();
+    }
+
+    @Test
+    void getAllStatuses_returnsPagedResponsesMappedFromRepository() {
+        Evidence evidence = Evidence.builder()
+                .confirmer(mock(Confirmer.class)).plan(mock(Plan.class)).releaseCase(mock(ReleaseCase.class))
+                .storageKey("evidence/9/proof.pdf").fileName("proof.pdf").mimeType("application/pdf")
+                .integrityHash("hash-list").evidenceType(EvidenceType.DEATH_CERTIFICATE).build();
+        Pageable pageable = PageRequest.of(0, 50);
+        Page<Evidence> page = new PageImpl<>(List.of(evidence), pageable, 1);
+        when(evidenceRepository.findAll(pageable)).thenReturn(page);
+
+        Page<EvidenceDeletionStatusResponse> result = evidenceDeletionService.getAllStatuses(UUID.randomUUID(), pageable);
+
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent().get(0).fileName()).isEqualTo("proof.pdf");
+        assertThat(result.getContent().get(0).integrityHash()).isEqualTo("hash-list");
     }
 }


### PR DESCRIPTION
템플릿에 맞춰 작성했습니다 (참고용, 아직 실제 PR 생성은 안 했습니다).

---

## 연관 Issue

- Closes #143

## 요약

관리자가 `evidenceId`를 몰라도 전체 증빙의 삭제 감사 상태를 조회할 수 있는 목록 API를 추가합니다. 기존에는 단건 조회 API만 있어 `/admin/evidence` 프런트 목록 화면을 구현할 수 없었습니다.

## 변경 사항

- `GET /api/admin/evidence/deletion-statuses` 신규 API 추가 (`AdminEvidenceDeletionController`)
- `EvidenceDeletionService.getAllStatuses(userId, pageable)` 추가 — 기존 `EVIDENCE_DELETE_RETRY` 권한 검사 후 전체 증빙을 페이지 단위로 조회
- `EvidenceDeletionServiceTest`에 `getAllStatuses` 케이스 추가

## 범위

### 포함

- 관리자 증빙 삭제 감사 목록 조회 API (페이지네이션)
- 기존 `EVIDENCE_DELETE_RETRY` 권한 재사용

### 제외

- 신규 권한 추가
- 서버 측 필터링 (전체 증빙 반환, 필터는 프런트 담당)
- 프런트엔드 `/admin/evidence` 화면 구현 (별도 저장소/작업)

## 스크린샷 / 미리 보기

- 백엔드 API 전용 변경으로 UI 스크린샷 없음. Swagger에 `Admin - Evidence Deletion Audit` 태그로 `GET /api/admin/evidence/deletion-statuses` 노출됨.

---

응답이 `data`가 아니라 `data.content`에 배열로 담기는 점(Page 래퍼 사용)은 프런트 담당자에게 별도로 공유가 필요합니다. 실제 PR 생성은 말씀 주시면 진행하겠습니다.