### PR TITLE
[Fix/#145]: 사망 신고 접수 시 증빙 제출 화면으로 즉시 이어지도록 흐름 개선

### DIFF
--- a/src/main/java/com/mamoki/ieojuda/domain/confirmer/controller/DeathReportController.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/confirmer/controller/DeathReportController.java
@@ -1,5 +1,6 @@
 package com.mamoki.ieojuda.domain.confirmer.controller;
 
+import com.mamoki.ieojuda.domain.confirmer.dto.DeathReportInviteResponse;
 import com.mamoki.ieojuda.domain.confirmer.dto.DeathReportRequest;
 import com.mamoki.ieojuda.domain.confirmer.dto.DeathReportResponse;
 import com.mamoki.ieojuda.domain.confirmer.service.DeathReportService;
@@ -9,6 +10,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -24,6 +26,14 @@ import org.springframework.web.bind.annotation.RestController;
 public class DeathReportController {
 
     private final DeathReportService deathReportService;
+
+    @Operation(summary = "사망 신고 화면 조회", description = "사망 신고 이메일의 링크로 진입했을 때 확인자 이름, 작성자 이름, 발송된 이메일 주소, 만료 시각, 문의 주소를 조회합니다. 만료·사용된 링크는 차단됩니다.")
+    @GetMapping("/death-report")
+    public ResponseEntity<RsData<DeathReportInviteResponse>> getInvite(
+            @Parameter(description = "사망 신고 토큰") @PathVariable String token
+    ) {
+        return ResponseEntity.ok(RsData.success(deathReportService.getInvite(token)));
+    }
 
     @Operation(summary = "사망 사실 신고", description = "수락 완료한 확인자만 신고할 수 있습니다. 다른 확인자가 이미 신고했고 날짜가 일치하면 사후 인계 사건이 자동 생성됩니다. Idempotency-Key 헤더를 보내면 같은 키의 재전송은 중복 요청(409)으로 응답합니다.")
     @PostMapping("/death-report")

--- a/src/main/java/com/mamoki/ieojuda/domain/confirmer/dto/DeathReportInviteResponse.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/confirmer/dto/DeathReportInviteResponse.java
@@ -1,0 +1,27 @@
+package com.mamoki.ieojuda.domain.confirmer.dto;
+
+import com.mamoki.ieojuda.domain.confirmer.entity.Confirmer;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+// "사망 신고 이메일" 화면 - 신고 링크로 진입했을 때 보여줄 내용
+public record DeathReportInviteResponse(
+        @Schema(description = "확인자 이름", example = "유지민") String confirmerName,
+        @Schema(description = "작성자(계획 소유자) 이름", example = "김나무") String ownerName,
+        @Schema(description = "신고 상태", example = "NOT_REPORTED", allowableValues = {"NOT_REPORTED", "REPORTED", "MATCHED", "MISMATCHED"}) String reportStatus,
+        @Schema(description = "신고 이메일이 발송된 주소") String email,
+        @Schema(description = "신고 링크 만료 시각") LocalDateTime expiresAt,
+        @Schema(description = "문의 주소") String contactEmail
+) {
+    public static DeathReportInviteResponse of(Confirmer confirmer, String ownerName, LocalDateTime expiresAt, String contactEmail) {
+        return new DeathReportInviteResponse(
+                confirmer.getName(),
+                ownerName,
+                confirmer.getReportStatus().name(),
+                confirmer.getEmail(),
+                expiresAt,
+                contactEmail
+        );
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/confirmer/dto/DeathReportResponse.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/confirmer/dto/DeathReportResponse.java
@@ -6,17 +6,22 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.UUID;
 import java.time.LocalDateTime;
 
-// 사망 신고 접수 결과
+// 사망 신고 접수 결과 - issue #41 재설계: 상대 확인자의 매칭 여부와 무관하게 사건과 증빙 제출 토큰이
+// 즉시 함께 발급되므로, 프런트가 이 응답만으로 바로 "공식 증빙 제출" 화면으로 넘어갈 수 있다.
 public record DeathReportResponse(
         @Schema(description = "확인자 ID") UUID confirmId,
         @Schema(description = "신고 상태", example = "REPORTED", allowableValues = {"NOT_REPORTED", "REPORTED", "MATCHED", "MISMATCHED"}) String reportStatus,
-        @Schema(description = "신고 접수 시각") LocalDateTime reportedAt
+        @Schema(description = "신고 접수 시각") LocalDateTime reportedAt,
+        @Schema(description = "이 신고가 속한 사건 ID") UUID caseId,
+        @Schema(description = "증빙 제출용 토큰 - /api/confirmer-acceptances/{token}/death-report(caseId 쿼리 포함)로 바로 제출 가능") String evidenceUploadToken
 ) {
-    public static DeathReportResponse from(Confirmer confirmer) {
+    public static DeathReportResponse of(Confirmer confirmer, UUID caseId, String evidenceUploadToken) {
         return new DeathReportResponse(
                 confirmer.getConfirmId(),
                 confirmer.getReportStatus().name(),
-                confirmer.getReportedAt()
+                confirmer.getReportedAt(),
+                caseId,
+                evidenceUploadToken
         );
     }
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/confirmer/service/ConfirmerInviteService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/confirmer/service/ConfirmerInviteService.java
@@ -1,5 +1,6 @@
 package com.mamoki.ieojuda.domain.confirmer.service;
 
+import com.mamoki.ieojuda.domain.audit.entity.EmailType;
 import com.mamoki.ieojuda.domain.confirmer.dto.ConfirmerDecisionRequest;
 import com.mamoki.ieojuda.domain.confirmer.dto.ConfirmerDecisionResponse;
 import com.mamoki.ieojuda.domain.confirmer.dto.ConfirmerInviteResponse;
@@ -9,6 +10,9 @@ import com.mamoki.ieojuda.domain.securitytoken.entity.SecurityToken;
 import com.mamoki.ieojuda.domain.securitytoken.entity.SecurityTokenPurpose;
 import com.mamoki.ieojuda.domain.securitytoken.service.SecurityTokenService;
 import com.mamoki.ieojuda.global.config.AppProperties;
+import com.mamoki.ieojuda.global.email.contract.EmailContent;
+import com.mamoki.ieojuda.global.email.outbox.EmailOutboxService;
+import com.mamoki.ieojuda.global.email.template.EmailBuilder;
 import com.mamoki.ieojuda.global.exception.CustomException;
 import com.mamoki.ieojuda.global.exception.ErrorCode;
 import com.mamoki.ieojuda.global.ratelimit.PublicLinkAuditor;
@@ -17,6 +21,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 
 // 명세서 "지정확인자 수락 이메일/화면" - 확인자가 초대 링크로 진입해 역할을 확인하고 수락/거절 (로그인 불필요, 토큰이 곧 인증)
 // issue #41 - 수락/거절은 ACCEPT_ROLE 목적 토큰으로만 처리한다. 수락이 완료되는 순간, 이후 사망 신고에
@@ -27,9 +32,13 @@ import java.time.LocalDateTime;
 @Transactional(readOnly = true)
 public class ConfirmerInviteService {
 
+    // 사망 신고는 수락 시점으로부터 수십 년 뒤에 이뤄질 수도 있어, 다른 토큰과 달리 사실상 무기한 수준으로 길게 둔다
+    private static final long REPORT_DEATH_TOKEN_TTL_YEARS = 100;
+
     private final AppProperties appProperties;
     private final PublicLinkAuditor publicLinkAuditor;
     private final SecurityTokenService securityTokenService;
+    private final EmailOutboxService emailOutboxService;
 
     // 초대 조회 - 만료·사용·폐기·목적 불일치 링크는 차단
     @Transactional
@@ -51,11 +60,25 @@ public class ConfirmerInviteService {
         confirmer.accept(inquiryOf(request));
         securityTokenService.consume(token);
 
-        LocalDateTime reportDeathExpiresAt = LocalDateTime.now().plusDays(appProperties.getActiveTokenTtlDays());
+        LocalDateTime reportDeathExpiresAt = LocalDateTime.now().plusYears(REPORT_DEATH_TOKEN_TTL_YEARS);
         String reportDeathToken = securityTokenService.issueForConfirmer(
                 SecurityTokenPurpose.REPORT_DEATH, confirmer, null, reportDeathExpiresAt);
+        sendDeathReportEmail(confirmer, reportDeathToken, reportDeathExpiresAt);
 
         return ConfirmerDecisionResponse.of(confirmer, reportDeathToken);
+    }
+
+    // 수락 완료 즉시 "사망 신고" 화면 링크를 이메일로 보내, 이후 응답을 잃어버려도 이 이메일로 돌아올 수 있게 한다
+    private void sendDeathReportEmail(Confirmer confirmer, String plainToken, LocalDateTime expiresAt) {
+        String secureLink = appProperties.getBaseUrl() + "/death-report?token=" + plainToken;
+        EmailContent content = EmailBuilder.build(
+                "지정 확인자",
+                "사망 사실을 신고해 주세요.",
+                expiresAt.atZone(ZoneId.systemDefault()),
+                secureLink,
+                appProperties.getContactEmail()
+        );
+        emailOutboxService.enqueue(confirmer.getPlan(), null, EmailType.DEATH_REPORT_REQUEST, confirmer.getEmail(), content);
     }
 
     // 역할 거절

--- a/src/main/java/com/mamoki/ieojuda/domain/confirmer/service/DeathReportService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/confirmer/service/DeathReportService.java
@@ -1,11 +1,11 @@
 package com.mamoki.ieojuda.domain.confirmer.service;
 
 import com.mamoki.ieojuda.domain.audit.entity.EmailType;
+import com.mamoki.ieojuda.domain.confirmer.dto.DeathReportInviteResponse;
 import com.mamoki.ieojuda.domain.confirmer.dto.DeathReportRequest;
 import com.mamoki.ieojuda.domain.confirmer.dto.DeathReportResponse;
 import com.mamoki.ieojuda.domain.confirmer.entity.Confirmer;
 import com.mamoki.ieojuda.domain.confirmer.entity.ReportStatus;
-import com.mamoki.ieojuda.domain.confirmer.repository.ConfirmerRepository;
 import com.mamoki.ieojuda.domain.plan.dto.PlanSnapshotDto;
 import com.mamoki.ieojuda.domain.plan.entity.Plan;
 import com.mamoki.ieojuda.domain.plan.entity.PlanVersion;
@@ -31,10 +31,9 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.List;
+import java.util.Optional;
 
 // 명세서 "사망 신고 이메일" 화면 - 지정 확인자가 사망 사실을 신고한다 (로그인 불필요, REPORT_DEATH 토큰이 곧 인증).
 // issue #41 - 수락 시 발급된 ACCEPT_ROLE 토큰과는 별개인 REPORT_DEATH 전용 토큰만 여기서 받는다
@@ -47,7 +46,6 @@ public class DeathReportService {
     // issue #41 - 증빙 제출은 사건 생성 시점부터 일정 기간 내에 이뤄져야 하므로, 사망신고 토큰보다 짧게 둔다
     private static final long EVIDENCE_TOKEN_TTL_DAYS = 30;
 
-    private final ConfirmerRepository confirmerRepository;
     private final ReleaseCaseRepository releaseCaseRepository;
     private final PlanVersionRepository planVersionRepository;
     private final PlanSnapshotService planSnapshotService;
@@ -57,6 +55,16 @@ public class DeathReportService {
     private final AppProperties appProperties;
     private final PlanReadinessValidator planReadinessValidator;
     private final ReleaseCaseWarningService releaseCaseWarningService;
+
+    // 신고 조회 - 사망 신고 이메일의 링크로 진입했을 때 화면에 보여줄 정보. 만료·사용·폐기·목적 불일치 링크는 차단
+    @Transactional
+    public DeathReportInviteResponse getInvite(String plainToken) {
+        SecurityToken token = securityTokenService.resolve(plainToken, SecurityTokenPurpose.REPORT_DEATH);
+        Confirmer confirmer = token.getConfirmer();
+
+        String ownerName = confirmer.getPlan().getUser().getName();
+        return DeathReportInviteResponse.of(confirmer, ownerName, token.getExpiresAt(), appProperties.getContactEmail());
+    }
 
     @Transactional
     public DeathReportResponse report(String plainToken, DeathReportRequest request, String idempotencyKey) {
@@ -74,29 +82,30 @@ public class DeathReportService {
         confirmer.report(request == null ? null : request.deathDate());
         securityTokenService.consume(token);
 
-        List<Confirmer> siblings = confirmerRepository.findByPlan_PlanIdAndConfirmIdNotAndReportStatus(
-                confirmer.getPlan().getPlanId(), confirmer.getConfirmId(), ReportStatus.REPORTED);
+        // issue #41 재설계 - 매칭 판정(날짜 비교)은 더 이상 여기서 하지 않는다. 상대 확인자 상태와 무관하게
+        // 사건을 찾거나 만들고, 이 확인자 몫의 증빙 제출 토큰을 즉시 발급해 응답에 담아 돌려준다 - 매칭 판정은
+        // 두 확인자 모두 증빙까지 제출을 마친 시점(EvidenceSubmitService)으로 미뤄진다.
+        ReleaseCase releaseCase = resolveActiveReleaseCase(confirmer.getPlan());
+        String evidenceUploadToken = issueEvidenceUploadTokenAndSend(confirmer, releaseCase);
 
-        if (!siblings.isEmpty()) {
-            Confirmer sibling = siblings.get(0);
-            if (datesAgree(confirmer.getReportedDeathDate(), sibling.getReportedDeathDate())) {
-                confirmer.markMatched();
-                sibling.markMatched();
-                ReleaseCase releaseCase = createReleaseCase(confirmer.getPlan());
-                issueEvidenceUploadTokenAndSend(confirmer, releaseCase);
-                issueEvidenceUploadTokenAndSend(sibling, releaseCase);
-            } else {
-                confirmer.markMismatched();
-                sibling.markMismatched();
-            }
-        }
-
-        return DeathReportResponse.from(confirmer);
+        return DeathReportResponse.of(confirmer, releaseCase.getCaseId(), evidenceUploadToken);
     }
 
-    // issue #41 - 증빙 제출은 노션 명세서상 "제출 안내 이메일"을 통해서만 진입하므로, 사건이 열리는 즉시
-    // 매칭된 두 확인자 각각에게 자신만의 UPLOAD_EVIDENCE 토큰(사건 바인딩)을 발급해 이메일로 보낸다.
-    private void issueEvidenceUploadTokenAndSend(Confirmer confirmer, ReleaseCase releaseCase) {
+    // issue #41 재설계 - 이 계획에 이미 진행 중인 사건이 있으면(다른 확인자가 먼저 신고했다면) 그대로 재사용하고,
+    // 없으면(첫 신고) 새로 만든다. "사건 존재 = 매칭 완료"라는 이전 전제가 더 이상 성립하지 않는다.
+    private ReleaseCase resolveActiveReleaseCase(Plan plan) {
+        return findActiveReleaseCase(plan).orElseGet(() -> createReleaseCase(plan));
+    }
+
+    private Optional<ReleaseCase> findActiveReleaseCase(Plan plan) {
+        return releaseCaseRepository.findFirstByPlan_PlanIdOrderByCaseIdDesc(plan.getPlanId())
+                .filter(existing -> existing.getCanceledAt() == null);
+    }
+
+    // issue #41 - 증빙 제출은 노션 명세서상 "제출 안내 이메일"을 통해서만 진입하므로, 신고를 받는 즉시 이
+    // 확인자 몫의 UPLOAD_EVIDENCE 토큰(사건 바인딩)을 발급해 이메일로도 보낸다(세션이 끊겨도 돌아올 수 있도록
+    // 하는 백업 채널) - 동시에 이 토큰 문자열을 반환해, 프런트가 응답만으로 바로 증빙 제출 화면으로 넘어갈 수 있게 한다.
+    private String issueEvidenceUploadTokenAndSend(Confirmer confirmer, ReleaseCase releaseCase) {
         LocalDateTime expiresAt = LocalDateTime.now().plusDays(EVIDENCE_TOKEN_TTL_DAYS);
         String plainToken = securityTokenService.issueForConfirmer(
                 SecurityTokenPurpose.UPLOAD_EVIDENCE, confirmer, releaseCase, expiresAt);
@@ -110,21 +119,10 @@ public class DeathReportService {
                 appProperties.getContactEmail()
         );
         emailOutboxService.enqueue(confirmer.getPlan(), null, EmailType.EVIDENCE_SUBMISSION_REQUEST, confirmer.getEmail(), content);
-    }
-
-    // 둘 다 사망일을 명시했고 그 값이 같을 때만 일치로 본다.
-    // 하나라도 모르면(null)이거나 날짜가 다르면 불일치 처리 - 재확인/운영 검토로 전환한다.
-    private boolean datesAgree(LocalDate a, LocalDate b) {
-        return a != null && b != null && a.equals(b);
+        return plainToken;
     }
 
     private ReleaseCase createReleaseCase(Plan plan) {
-        if (releaseCaseRepository.findFirstByPlan_PlanIdOrderByCaseIdDesc(plan.getPlanId())
-                .filter(existing -> existing.getCanceledAt() == null)
-                .isPresent()) {
-            throw new CustomException(ErrorCode.ACTIVE_RELEASE_CASE_EXISTS);
-        }
-
         // 준비되지 않았거나 비활성인 계획에서 사건이 시작되지 않도록, 사건 생성 직전 계획 준비도를
         // 재검증한다 (봉인 이후에도 확인자 거절·항목 추가 등으로 상태가 바뀔 수 있어 독립적으로 확인).
         planReadinessValidator.validate(plan);
@@ -138,14 +136,16 @@ public class DeathReportService {
                 PlanVersion.builder().plan(plan).versionNum(nextVersionNum).snapshotData(snapshotJson).build());
         planVersion.seal(snapshotHash);
 
-        // 위 존재 여부 검사만으로는 두 확인자의 신고가 정확히 동시에 매칭되는 경쟁 조건을 막을 수 없으므로,
-        // DB의 부분 유니크 인덱스(활성 사건은 계획당 1개)가 최종 방어선이다 - 즉시 flush해서 위반 시 여기서 잡는다.
+        // 두 확인자가 거의 동시에 첫 신고를 하면 둘 다 "활성 사건 없음"으로 보고 동시에 생성을 시도할 수 있다.
+        // DB의 부분 유니크 인덱스(활성 사건은 계획당 1개)가 최종 방어선이므로 즉시 flush해서 위반 시 여기서 잡되,
+        // 이건 이제 정상적인 경쟁 상황(두 번째 확인자의 신고)이므로 에러로 취급하지 않고 먼저 만들어진 사건을 찾아 재사용한다.
         ReleaseCase releaseCase;
         try {
             releaseCase = releaseCaseRepository.saveAndFlush(
                     ReleaseCase.builder().plan(plan).planVersion(planVersion).build());
         } catch (DataIntegrityViolationException e) {
-            throw new CustomException(ErrorCode.ACTIVE_RELEASE_CASE_EXISTS);
+            return findActiveReleaseCase(plan)
+                    .orElseThrow(() -> new CustomException(ErrorCode.ACTIVE_RELEASE_CASE_EXISTS));
         }
         releaseCase.confirmReport();
         releaseCase.awaitEvidence();

--- a/src/main/java/com/mamoki/ieojuda/domain/evidence/repository/EvidenceRepository.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/evidence/repository/EvidenceRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.List;
 
@@ -17,6 +18,10 @@ public interface EvidenceRepository extends JpaRepository<Evidence, UUID> {
 
     // issue #45 - "이 확인자가 이 사건에 이미 냈는지" 중복 제출 방지용
     boolean existsByReleaseCase_CaseIdAndConfirmer_ConfirmId(UUID caseId, UUID confirmId);
+
+    // issue #41 재설계 - 이 사건에 이미 제출된 "다른 확인자"의 증빙이 있는지 찾는다. 있으면 그 확인자가
+    // 이 사건의 신고 짝(sibling)이라는 뜻이라, 그 시점에 두 사람의 신고 날짜를 비교해 매칭 판정을 내린다.
+    Optional<Evidence> findFirstByReleaseCase_CaseIdAndConfirmer_ConfirmIdNot(UUID caseId, UUID confirmId);
 
     // issue #45 - "여러 증빙의 승인 정책" - 이 사건에서 승인된 증빙이 몇 건인지 세어, 매칭된 확인자 수와
     // 비교해 전부 승인됐는지 판단한다.

--- a/src/main/java/com/mamoki/ieojuda/domain/evidence/service/EvidenceSubmitService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/evidence/service/EvidenceSubmitService.java
@@ -36,6 +36,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.LocalDate;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -119,7 +120,33 @@ public class EvidenceSubmitService {
             releaseCase.startEvidenceReview();
         }
 
+        matchAgainstSiblingIfPresent(confirmer, releaseCase);
+
         return EvidenceSubmitResponse.from(evidence);
+    }
+
+    // issue #41 재설계 - "독립된 2인 확인 원칙"의 매칭 판정을 신고 접수 시점이 아니라 두 확인자 모두 증빙까지
+    // 제출을 마친 시점으로 미룬다. 이 사건에 이미 다른 확인자의 증빙이 있으면 그 사람이 신고 짝(sibling)이므로,
+    // 이 자리에서 두 사람이 신고한 사망일을 비교해 MATCHED/MISMATCHED를 확정한다. 불일치해도 이미 제출된
+    // 증빙은 폐기하지 않는다 - 외부 파트너가 자료를 보고 직접 승인/반려를 판단한다.
+    private void matchAgainstSiblingIfPresent(Confirmer confirmer, ReleaseCase releaseCase) {
+        evidenceRepository.findFirstByReleaseCase_CaseIdAndConfirmer_ConfirmIdNot(releaseCase.getCaseId(), confirmer.getConfirmId())
+                .ifPresent(siblingEvidence -> {
+                    Confirmer sibling = siblingEvidence.getConfirmer();
+                    if (datesAgree(confirmer.getReportedDeathDate(), sibling.getReportedDeathDate())) {
+                        confirmer.markMatched();
+                        sibling.markMatched();
+                    } else {
+                        confirmer.markMismatched();
+                        sibling.markMismatched();
+                    }
+                });
+    }
+
+    // 둘 다 사망일을 명시했고 그 값이 같을 때만 일치로 본다.
+    // 하나라도 모르면(null)이거나 날짜가 다르면 불일치 처리 - 재확인/운영 검토로 전환한다.
+    private boolean datesAgree(LocalDate a, LocalDate b) {
+        return a != null && b != null && a.equals(b);
     }
 
     private void validateBasics(MultipartFile file) {

--- a/src/main/java/com/mamoki/ieojuda/domain/partner/service/PartnerReviewService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/partner/service/PartnerReviewService.java
@@ -155,13 +155,24 @@ public class PartnerReviewService {
         switch (request.decision()) {
             // issue #45 - "여러 증빙의 승인 정책" - 사건에 매칭된 확인자 각각이 낸 증빙이 전부 승인돼야
             // 대기(WAITING)로 넘어간다. 아직 다 안 됐으면 EVIDENCE_APPROVED(부분 승인) 상태로만 남겨둔다.
+            // issue #41 재설계 - 매칭 판정이 증빙 제출 이후로 미뤄지면서, 상대 확인자가 아직 증빙까지
+            // 제출하지 못해 이 확인자의 신고 상태가 여전히 REPORTED(매칭 미확정)인 경우가 생길 수 있다.
+            // 그 상태에서 증빙을 승인하면 아래 requiredCount가 부정확해져(상대방 몫이 아직 안 잡혀서) 조기에
+            // WAITING으로 새어나갈 수 있으므로, 매칭 판정이 끝난(MATCHED 또는 MISMATCHED) 증빙만 승인을 허용한다.
             case APPROVE -> {
                 ReleaseCase releaseCase = evidence.getReleaseCase();
+                if (evidence.getConfirmer().getReportStatus() == ReportStatus.REPORTED) {
+                    throw new CustomException(ErrorCode.RELEASE_CASE_INVALID_TRANSITION);
+                }
                 long alreadyApprovedCount = evidenceRepository.countByReleaseCase_CaseIdAndReviewStatus(
                         releaseCase.getCaseId(), EvidenceReviewStatus.APPROVED);
                 evidence.approve();
+                // 불일치(MISMATCHED)여도 이미 제출된 증빙은 파트너가 검토·승인할 수 있어야 하므로,
+                // MATCHED뿐 아니라 MISMATCHED로 확정된 확인자도 함께 센다.
                 long requiredCount = confirmerRepository.findByPlan_PlanIdAndReportStatus(
-                        releaseCase.getPlan().getPlanId(), ReportStatus.MATCHED).size();
+                        releaseCase.getPlan().getPlanId(), ReportStatus.MATCHED).size()
+                        + confirmerRepository.findByPlan_PlanIdAndReportStatus(
+                        releaseCase.getPlan().getPlanId(), ReportStatus.MISMATCHED).size();
 
                 if (alreadyApprovedCount + 1 >= requiredCount) {
                     // 이의 제기 연락처 전원에게 경고를 보내 발송이 확인된 뒤에만 WAITING으로 전이한다

--- a/src/main/java/com/mamoki/ieojuda/domain/releasecase/entity/ReleaseCase.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/releasecase/entity/ReleaseCase.java
@@ -81,7 +81,9 @@ public class ReleaseCase {
         this.frozen = false;
     }
 
-    // REPORT_PENDING → REPORT_CONFIRMED : 두 확인자의 신고 내용이 일치해 사건이 생성된 직후
+    // REPORT_PENDING → REPORT_CONFIRMED : 첫 확인자의 사망 신고가 접수되어 사건이 생성된 직후
+    // (issue #41 재설계 - 매칭 여부와 무관하게 첫 신고 즉시 전이한다. 매칭 판정은 두 확인자 모두
+    // 증빙까지 제출을 마친 뒤 별도로 이뤄진다)
     public void confirmReport() {
         ensureTransitionAllowed(EnumSet.of(ReleaseCaseStatus.REPORT_PENDING));
         this.confirmedAt = LocalDateTime.now();

--- a/src/test/java/com/mamoki/ieojuda/domain/confirmer/service/ConfirmerInviteServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/confirmer/service/ConfirmerInviteServiceTest.java
@@ -1,0 +1,94 @@
+package com.mamoki.ieojuda.domain.confirmer.service;
+
+import com.mamoki.ieojuda.domain.confirmer.dto.ConfirmerDecisionRequest;
+import com.mamoki.ieojuda.domain.confirmer.dto.ConfirmerDecisionResponse;
+import com.mamoki.ieojuda.domain.confirmer.entity.Confirmer;
+import com.mamoki.ieojuda.domain.confirmer.entity.Relationship;
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.securitytoken.entity.SecurityToken;
+import com.mamoki.ieojuda.domain.securitytoken.entity.SecurityTokenPurpose;
+import com.mamoki.ieojuda.domain.securitytoken.service.SecurityTokenService;
+import com.mamoki.ieojuda.global.config.AppProperties;
+import com.mamoki.ieojuda.global.email.contract.EmailContent;
+import com.mamoki.ieojuda.global.email.outbox.EmailOutboxService;
+import com.mamoki.ieojuda.global.ratelimit.PublicLinkAuditor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.time.LocalDateTime;
+
+import static com.mamoki.ieojuda.domain.audit.entity.EmailType.DEATH_REPORT_REQUEST;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+// issue #41 - 역할 수락 시 사망 신고 화면 링크를 담은 이메일이 함께 발송되는지, 그리고 그 토큰의
+// 만료 시각이 다른 토큰과 달리 사실상 무기한(100년) 수준으로 길게 설정되는지 검증한다.
+class ConfirmerInviteServiceTest {
+
+    private PublicLinkAuditor publicLinkAuditor;
+    private SecurityTokenService securityTokenService;
+    private EmailOutboxService emailOutboxService;
+    private AppProperties appProperties;
+    private ConfirmerInviteService confirmerInviteService;
+
+    @BeforeEach
+    void setUp() {
+        publicLinkAuditor = mock(PublicLinkAuditor.class);
+        securityTokenService = mock(SecurityTokenService.class);
+        emailOutboxService = mock(EmailOutboxService.class);
+        appProperties = mock(AppProperties.class);
+        confirmerInviteService = new ConfirmerInviteService(appProperties, publicLinkAuditor, securityTokenService, emailOutboxService);
+
+        when(appProperties.getBaseUrl()).thenReturn("https://ieoduda.example.com");
+        when(appProperties.getContactEmail()).thenReturn("support@ieoduda.example.com");
+    }
+
+    private Confirmer pendingConfirmer(Plan plan) {
+        return Confirmer.builder().plan(plan).name("확인자").relationship(Relationship.FRIEND).email("confirmer@test.com").build();
+    }
+
+    @Test
+    void accept_sendsDeathReportEmailWithLinkAndFarFutureExpiry() {
+        Plan plan = mock(Plan.class);
+        Confirmer confirmer = pendingConfirmer(plan);
+
+        SecurityToken acceptToken = mock(SecurityToken.class);
+        when(acceptToken.getConfirmer()).thenReturn(confirmer);
+        when(securityTokenService.resolve(eq("accept-token"), eq(SecurityTokenPurpose.ACCEPT_ROLE))).thenReturn(acceptToken);
+        when(securityTokenService.issueForConfirmer(eq(SecurityTokenPurpose.REPORT_DEATH), eq(confirmer), eq(null), any()))
+                .thenReturn("report-death-token");
+
+        ConfirmerDecisionResponse response = confirmerInviteService.accept("accept-token", null);
+
+        assertThat(response.reportDeathToken()).isEqualTo("report-death-token");
+
+        ArgumentCaptor<EmailContent> contentCaptor = ArgumentCaptor.forClass(EmailContent.class);
+        verify(emailOutboxService).enqueue(eq(plan), eq(null), eq(DEATH_REPORT_REQUEST), eq("confirmer@test.com"), contentCaptor.capture());
+        assertThat(contentCaptor.getValue().body()).contains("https://ieoduda.example.com/death-report?token=report-death-token");
+
+        ArgumentCaptor<LocalDateTime> expiresAtCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+        verify(securityTokenService).issueForConfirmer(eq(SecurityTokenPurpose.REPORT_DEATH), eq(confirmer), eq(null), expiresAtCaptor.capture());
+        assertThat(expiresAtCaptor.getValue()).isAfter(LocalDateTime.now().plusYears(99));
+    }
+
+    @Test
+    void decline_doesNotSendAnyEmail() {
+        Plan plan = mock(Plan.class);
+        Confirmer confirmer = pendingConfirmer(plan);
+
+        SecurityToken acceptToken = mock(SecurityToken.class);
+        when(acceptToken.getConfirmer()).thenReturn(confirmer);
+        when(securityTokenService.resolve(eq("accept-token"), eq(SecurityTokenPurpose.ACCEPT_ROLE))).thenReturn(acceptToken);
+
+        ConfirmerDecisionResponse response = confirmerInviteService.decline("accept-token", new ConfirmerDecisionRequest(null));
+
+        assertThat(response.reportDeathToken()).isNull();
+        verify(emailOutboxService, never()).enqueue(any(), any(), any(), any(), any());
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/domain/confirmer/service/DeathReportReadinessIntegrationTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/confirmer/service/DeathReportReadinessIntegrationTest.java
@@ -262,18 +262,16 @@ class DeathReportReadinessIntegrationTest {
                 .isEqualTo(ErrorCode.ORDER_NOT_CONFIRMED);
     }
 
+    // issue #41 재설계 - 사건 생성(과 그에 딸린 준비도 검증)은 더 이상 "매칭 시점"이 아니라
+    // "첫 신고 시점"에 일어난다. 봉인되지 않은 계획은 첫 신고에서 곧바로 막혀야 한다.
     @Test
-    void report_whenPlanIsNotSealed_blocksReleaseCaseCreationEvenWhenReportsMatch() {
+    void report_whenPlanIsNotSealed_blocksReleaseCaseCreationOnFirstReport() {
         createFixture(false); // 준비도 조건 중 "봉인"만 깨뜨리고 나머지는 전부 충족시킨다
 
         String tokenA = securityTokenService.issueForConfirmer(
                 SecurityTokenPurpose.REPORT_DEATH, confirmerA, null, LocalDateTime.now().plusDays(1));
-        String tokenB = securityTokenService.issueForConfirmer(
-                SecurityTokenPurpose.REPORT_DEATH, confirmerB, null, LocalDateTime.now().plusDays(1));
 
-        deathReportService.report(tokenA, new DeathReportRequest(REPORTED_DEATH_DATE), null);
-
-        assertThatThrownBy(() -> deathReportService.report(tokenB, new DeathReportRequest(REPORTED_DEATH_DATE), null))
+        assertThatThrownBy(() -> deathReportService.report(tokenA, new DeathReportRequest(REPORTED_DEATH_DATE), null))
                 .isInstanceOf(CustomException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.PLAN_NOT_READY);

--- a/src/test/java/com/mamoki/ieojuda/domain/confirmer/service/DeathReportServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/confirmer/service/DeathReportServiceTest.java
@@ -1,6 +1,10 @@
 package com.mamoki.ieojuda.domain.confirmer.service;
 
+import com.mamoki.ieojuda.domain.account.entity.User;
+import com.mamoki.ieojuda.domain.audit.entity.EmailType;
+import com.mamoki.ieojuda.domain.confirmer.dto.DeathReportInviteResponse;
 import com.mamoki.ieojuda.domain.confirmer.dto.DeathReportRequest;
+import com.mamoki.ieojuda.domain.confirmer.dto.DeathReportResponse;
 import com.mamoki.ieojuda.domain.confirmer.entity.Confirmer;
 import com.mamoki.ieojuda.domain.confirmer.entity.DisputeContact;
 import com.mamoki.ieojuda.domain.confirmer.entity.Relationship;
@@ -15,12 +19,14 @@ import com.mamoki.ieojuda.domain.plan.repository.ItemRepository;
 import com.mamoki.ieojuda.domain.plan.repository.PlanVersionRepository;
 import com.mamoki.ieojuda.domain.plan.service.PlanReadinessValidator;
 import com.mamoki.ieojuda.domain.plan.service.PlanSnapshotService;
+import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCase;
 import com.mamoki.ieojuda.domain.releasecase.repository.ReleaseCaseRepository;
 import com.mamoki.ieojuda.domain.releasecase.service.ReleaseCaseWarningService;
 import com.mamoki.ieojuda.domain.securitytoken.entity.SecurityToken;
 import com.mamoki.ieojuda.domain.securitytoken.entity.SecurityTokenPurpose;
 import com.mamoki.ieojuda.domain.securitytoken.service.SecurityTokenService;
 import com.mamoki.ieojuda.global.config.AppProperties;
+import com.mamoki.ieojuda.global.email.contract.EmailContent;
 import com.mamoki.ieojuda.global.email.outbox.EmailOutboxService;
 import com.mamoki.ieojuda.global.exception.CustomException;
 import com.mamoki.ieojuda.global.exception.ErrorCode;
@@ -28,6 +34,7 @@ import com.mamoki.ieojuda.global.idempotency.service.IdempotencyGuard;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.dao.DataIntegrityViolationException;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -45,13 +52,13 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-// issue #42 회귀 테스트 - 두 확인자의 신고가 매치되어 사건이 생성될 때, 그 시점의 계획 스냅샷이
-// 실제로 직렬화·해시·봉인되고 버전 번호가 정확히 증가하는지 검증한다.
+// issue #41 재설계 - report()는 더 이상 매칭 판정을 하지 않는다. 신고를 받을 때마다 사건을 찾거나(재사용)
+// 만들고, 이 확인자 몫의 증빙 제출 토큰을 즉시 발급해 응답에 담아 돌려주는지 검증한다.
+// 매칭(MATCHED/MISMATCHED) 판정 자체는 EvidenceSubmitServiceTest에서 검증한다.
 class DeathReportServiceTest {
 
     private static final UUID PLAN_ID = UUID.randomUUID();
 
-    private ConfirmerRepository confirmerRepository;
     private ReleaseCaseRepository releaseCaseRepository;
     private PlanVersionRepository planVersionRepository;
     private PlanSnapshotService planSnapshotService;
@@ -65,7 +72,6 @@ class DeathReportServiceTest {
 
     @BeforeEach
     void setUp() {
-        confirmerRepository = mock(ConfirmerRepository.class);
         releaseCaseRepository = mock(ReleaseCaseRepository.class);
         planVersionRepository = mock(PlanVersionRepository.class);
         planSnapshotService = mock(PlanSnapshotService.class);
@@ -76,7 +82,7 @@ class DeathReportServiceTest {
         planReadinessValidator = mock(PlanReadinessValidator.class);
         releaseCaseWarningService = mock(ReleaseCaseWarningService.class);
         deathReportService = new DeathReportService(
-                confirmerRepository, releaseCaseRepository, planVersionRepository,
+                releaseCaseRepository, planVersionRepository,
                 planSnapshotService, idempotencyGuard, securityTokenService, emailOutboxService, appProperties,
                 planReadinessValidator, releaseCaseWarningService);
 
@@ -90,36 +96,73 @@ class DeathReportServiceTest {
         return confirmer;
     }
 
-    @Test
-    void report_whenSecondConfirmerMatchesFirst_sealsFreshSnapshotWithIncrementedVersion() {
-        Plan plan = mock(Plan.class);
-        when(plan.getPlanId()).thenReturn(PLAN_ID);
+    private SecurityToken reportDeathTokenFor(Confirmer confirmer) {
+        SecurityToken token = mock(SecurityToken.class);
+        when(token.getConfirmer()).thenReturn(confirmer);
+        return token;
+    }
 
-        Confirmer reporting = confirmerAcceptedOn(plan, "A", "a@test.com");
-        SecurityToken reportDeathToken = mock(SecurityToken.class);
-        when(reportDeathToken.getConfirmer()).thenReturn(reporting);
-        when(securityTokenService.resolve(eq("token-a"), eq(SecurityTokenPurpose.REPORT_DEATH))).thenReturn(reportDeathToken);
-        when(securityTokenService.issueForConfirmer(eq(SecurityTokenPurpose.UPLOAD_EVIDENCE), any(), any(), any()))
-                .thenReturn("evidence-token");
-
-        Confirmer sibling = confirmerAcceptedOn(plan, "B", "b@test.com");
-        sibling.report(LocalDate.of(2026, 8, 15)); // 이미 먼저 신고해서 REPORTED 상태
-        when(confirmerRepository.findByPlan_PlanIdAndConfirmIdNotAndReportStatus(PLAN_ID, null, ReportStatus.REPORTED))
-                .thenReturn(List.of(sibling));
-
-        // 이 계획에 이미 봉인된 버전이 2개 있었다고 가정 - 새 버전은 3번이어야 한다
-        when(releaseCaseRepository.findFirstByPlan_PlanIdOrderByCaseIdDesc(PLAN_ID)).thenReturn(Optional.empty());
-        when(planVersionRepository.countByPlan_PlanId(PLAN_ID)).thenReturn(2L);
-
+    private void stubSnapshotCreation(Plan plan, long existingVersionCount) {
+        when(planVersionRepository.countByPlan_PlanId(PLAN_ID)).thenReturn(existingVersionCount);
         PlanSnapshotDto snapshot = new PlanSnapshotDto(PLAN_ID, 7, List.of(), List.of());
         when(planSnapshotService.buildSnapshot(plan)).thenReturn(snapshot);
         when(planSnapshotService.serialize(snapshot)).thenReturn("{\"planId\":1}");
         when(planSnapshotService.hash("{\"planId\":1}")).thenReturn("deadbeef");
-
         when(planVersionRepository.save(any(PlanVersion.class))).thenAnswer(invocation -> invocation.getArgument(0));
         when(releaseCaseRepository.saveAndFlush(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    }
 
-        deathReportService.report("token-a", new DeathReportRequest(LocalDate.of(2026, 8, 15)), null);
+    @Test
+    void getInvite_withValidToken_returnsConfirmerAndOwnerInfo() {
+        Plan plan = mock(Plan.class);
+        User owner = mock(User.class);
+        when(plan.getUser()).thenReturn(owner);
+        when(owner.getName()).thenReturn("김나무");
+
+        Confirmer confirmer = confirmerAcceptedOn(plan, "유지민", "confirmer@test.com");
+        SecurityToken reportDeathToken = reportDeathTokenFor(confirmer);
+        LocalDateTime expiresAt = LocalDateTime.now().plusYears(100);
+        when(reportDeathToken.getExpiresAt()).thenReturn(expiresAt);
+        when(securityTokenService.resolve(eq("token-a"), eq(SecurityTokenPurpose.REPORT_DEATH))).thenReturn(reportDeathToken);
+
+        DeathReportInviteResponse response = deathReportService.getInvite("token-a");
+
+        assertThat(response.confirmerName()).isEqualTo("유지민");
+        assertThat(response.ownerName()).isEqualTo("김나무");
+        assertThat(response.reportStatus()).isEqualTo("NOT_REPORTED");
+        assertThat(response.email()).isEqualTo("confirmer@test.com");
+        assertThat(response.expiresAt()).isEqualTo(expiresAt);
+        assertThat(response.contactEmail()).isEqualTo("support@ieoduda.example.com");
+    }
+
+    // 이미 신고를 제출해 토큰이 소모된 링크로 재접속하면, 역할 수락 초대 조회와 동일하게 그대로 예외가 전파되어야 한다
+    @Test
+    void getInvite_withAlreadyUsedToken_propagatesException() {
+        when(securityTokenService.resolve(eq("used-token"), eq(SecurityTokenPurpose.REPORT_DEATH)))
+                .thenThrow(new CustomException(ErrorCode.ACCESS_LINK_ALREADY_USED));
+
+        assertThatThrownBy(() -> deathReportService.getInvite("used-token"))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.ACCESS_LINK_ALREADY_USED);
+    }
+
+    @Test
+    void report_firstConfirmer_createsCaseSealsSnapshotAndReturnsEvidenceToken() {
+        Plan plan = mock(Plan.class);
+        when(plan.getPlanId()).thenReturn(PLAN_ID);
+
+        Confirmer confirmer = confirmerAcceptedOn(plan, "A", "a@test.com");
+        SecurityToken reportDeathToken = reportDeathTokenFor(confirmer);
+        when(securityTokenService.resolve(eq("token-a"), eq(SecurityTokenPurpose.REPORT_DEATH))).thenReturn(reportDeathToken);
+        when(securityTokenService.issueForConfirmer(eq(SecurityTokenPurpose.UPLOAD_EVIDENCE), eq(confirmer), any(), any()))
+                .thenReturn("evidence-token");
+
+        // 상대 확인자가 아직 신고하지 않아 활성 사건이 없는 상태 - 첫 신고이므로 새로 만들어야 한다
+        when(releaseCaseRepository.findFirstByPlan_PlanIdOrderByCaseIdDesc(PLAN_ID)).thenReturn(Optional.empty());
+        stubSnapshotCreation(plan, 2L); // 이미 봉인된 버전이 2개 있었다고 가정 - 새 버전은 3번이어야 한다
+
+        DeathReportResponse response = deathReportService.report("token-a", new DeathReportRequest(LocalDate.of(2026, 8, 15)), null);
 
         ArgumentCaptor<PlanVersion> versionCaptor = ArgumentCaptor.forClass(PlanVersion.class);
         verify(planVersionRepository).save(versionCaptor.capture());
@@ -131,40 +174,89 @@ class DeathReportServiceTest {
         assertThat(savedVersion.getSnapshotHash()).isEqualTo("deadbeef");
         assertThat(savedVersion.getSealedAt()).isNotNull();
 
-        assertThat(reporting.getReportStatus()).isEqualTo(ReportStatus.MATCHED);
-        assertThat(sibling.getReportStatus()).isEqualTo(ReportStatus.MATCHED);
-        // 사건 생성 직후 작성자에게 취소 경고 메일 발송을 시도했는지 확인
+        // 매칭 판정은 더 이상 여기서 일어나지 않는다 - 상대가 없으므로 REPORTED 그대로다
+        assertThat(confirmer.getReportStatus()).isEqualTo(ReportStatus.REPORTED);
+        assertThat(response.evidenceUploadToken()).isEqualTo("evidence-token");
+
         verify(releaseCaseWarningService).sendAuthorCancelWarningOrFreeze(any());
+        ArgumentCaptor<EmailContent> contentCaptor = ArgumentCaptor.forClass(EmailContent.class);
+        verify(emailOutboxService).enqueue(eq(plan), eq(null), eq(EmailType.EVIDENCE_SUBMISSION_REQUEST), eq("a@test.com"), contentCaptor.capture());
+        assertThat(contentCaptor.getValue().body()).contains("evidence-token");
     }
 
-    // 작성자 경고 메일 발송이 실패해도(운영 검토로 동결될 뿐) report() 자체는 정상 응답해야 한다 -
-    // 이미 성사된 두 확인자의 신고 매칭까지 되돌릴 이유가 없다.
+    // 두 번째 신고자는 첫 신고자가 만든 활성 사건을 그대로 재사용해야 한다 - 매칭 여부와 무관하게 새 사건을 만들지 않는다
+    @Test
+    void report_whenActiveCaseAlreadyExists_reusesItWithoutCreatingNewOne() {
+        Plan plan = mock(Plan.class);
+        when(plan.getPlanId()).thenReturn(PLAN_ID);
+
+        Confirmer confirmer = confirmerAcceptedOn(plan, "B", "b@test.com");
+        SecurityToken reportDeathToken = reportDeathTokenFor(confirmer);
+        when(securityTokenService.resolve(eq("token-b"), eq(SecurityTokenPurpose.REPORT_DEATH))).thenReturn(reportDeathToken);
+        when(securityTokenService.issueForConfirmer(eq(SecurityTokenPurpose.UPLOAD_EVIDENCE), eq(confirmer), any(), any()))
+                .thenReturn("evidence-token-b");
+
+        ReleaseCase existingCase = mock(ReleaseCase.class);
+        UUID existingCaseId = UUID.randomUUID();
+        when(existingCase.getCaseId()).thenReturn(existingCaseId);
+        when(existingCase.getCanceledAt()).thenReturn(null);
+        when(releaseCaseRepository.findFirstByPlan_PlanIdOrderByCaseIdDesc(PLAN_ID)).thenReturn(Optional.of(existingCase));
+
+        DeathReportResponse response = deathReportService.report("token-b", new DeathReportRequest(LocalDate.of(2026, 8, 15)), null);
+
+        verify(releaseCaseRepository, never()).saveAndFlush(any());
+        verify(planReadinessValidator, never()).validate(any());
+        verify(securityTokenService).issueForConfirmer(eq(SecurityTokenPurpose.UPLOAD_EVIDENCE), eq(confirmer), eq(existingCase), any());
+        assertThat(response.caseId()).isEqualTo(existingCaseId);
+        assertThat(response.evidenceUploadToken()).isEqualTo("evidence-token-b");
+    }
+
+    // 두 확인자가 거의 동시에 첫 신고를 하면 DB 유니크 인덱스가 두 번째 saveAndFlush를 막는다 - 이건 정상적인
+    // 경쟁 상황이므로 에러로 실패하지 않고, 먼저 만들어진 사건을 다시 찾아 재사용해야 한다.
+    @Test
+    void report_whenConcurrentCaseCreationRaces_reusesWinningCaseInsteadOfFailing() {
+        Plan plan = mock(Plan.class);
+        when(plan.getPlanId()).thenReturn(PLAN_ID);
+
+        Confirmer confirmer = confirmerAcceptedOn(plan, "A", "a@test.com");
+        SecurityToken reportDeathToken = reportDeathTokenFor(confirmer);
+        when(securityTokenService.resolve(eq("token-a"), eq(SecurityTokenPurpose.REPORT_DEATH))).thenReturn(reportDeathToken);
+        when(securityTokenService.issueForConfirmer(eq(SecurityTokenPurpose.UPLOAD_EVIDENCE), eq(confirmer), any(), any()))
+                .thenReturn("evidence-token");
+
+        ReleaseCase winningCase = mock(ReleaseCase.class);
+        // 최초 조회 때는 아직 활성 사건이 없다고 보고했다가(경쟁 상대가 방금 만든 참), 저장 충돌 이후
+        // 재조회에서는 경쟁 상대가 이미 만든 사건을 돌려준다.
+        when(releaseCaseRepository.findFirstByPlan_PlanIdOrderByCaseIdDesc(PLAN_ID))
+                .thenReturn(Optional.empty(), Optional.of(winningCase));
+        when(winningCase.getCanceledAt()).thenReturn(null);
+
+        stubSnapshotCreation(plan, 0L);
+        when(releaseCaseRepository.saveAndFlush(any())).thenThrow(new DataIntegrityViolationException("unique violation"));
+
+        DeathReportResponse response = deathReportService.report("token-a", new DeathReportRequest(LocalDate.of(2026, 8, 15)), null);
+
+        verify(securityTokenService).issueForConfirmer(eq(SecurityTokenPurpose.UPLOAD_EVIDENCE), eq(confirmer), eq(winningCase), any());
+        assertThat(response.evidenceUploadToken()).isEqualTo("evidence-token");
+        // 경쟁 상대가 사건을 만들었을 뿐이므로, 취소 경고 메일은 이 요청에서 다시 보내지 않는다
+        verify(releaseCaseWarningService, never()).sendAuthorCancelWarningOrFreeze(any());
+    }
+
+    // 작성자 경고 메일 발송이 실패해도(운영 검토로 동결될 뿐) report() 자체는 정상 응답해야 한다
     @Test
     void report_whenAuthorWarningSendFails_stillReturnsSuccessResponse() {
         Plan plan = mock(Plan.class);
         when(plan.getPlanId()).thenReturn(PLAN_ID);
 
-        Confirmer reporting = confirmerAcceptedOn(plan, "A", "a@test.com");
-        SecurityToken reportDeathToken = mock(SecurityToken.class);
-        when(reportDeathToken.getConfirmer()).thenReturn(reporting);
+        Confirmer confirmer = confirmerAcceptedOn(plan, "A", "a@test.com");
+        SecurityToken reportDeathToken = reportDeathTokenFor(confirmer);
         when(securityTokenService.resolve(eq("token-a"), eq(SecurityTokenPurpose.REPORT_DEATH))).thenReturn(reportDeathToken);
         when(securityTokenService.issueForConfirmer(eq(SecurityTokenPurpose.UPLOAD_EVIDENCE), any(), any(), any()))
                 .thenReturn("evidence-token");
         when(releaseCaseWarningService.sendAuthorCancelWarningOrFreeze(any())).thenReturn(false);
 
-        Confirmer sibling = confirmerAcceptedOn(plan, "B", "b@test.com");
-        sibling.report(LocalDate.of(2026, 8, 15));
-        when(confirmerRepository.findByPlan_PlanIdAndConfirmIdNotAndReportStatus(PLAN_ID, null, ReportStatus.REPORTED))
-                .thenReturn(List.of(sibling));
-
         when(releaseCaseRepository.findFirstByPlan_PlanIdOrderByCaseIdDesc(PLAN_ID)).thenReturn(Optional.empty());
-        when(planVersionRepository.countByPlan_PlanId(PLAN_ID)).thenReturn(0L);
-        PlanSnapshotDto snapshot = new PlanSnapshotDto(PLAN_ID, 7, List.of(), List.of());
-        when(planSnapshotService.buildSnapshot(plan)).thenReturn(snapshot);
-        when(planSnapshotService.serialize(snapshot)).thenReturn("{}");
-        when(planSnapshotService.hash("{}")).thenReturn("hash");
-        when(planVersionRepository.save(any(PlanVersion.class))).thenAnswer(invocation -> invocation.getArgument(0));
-        when(releaseCaseRepository.saveAndFlush(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        stubSnapshotCreation(plan, 0L);
 
         var response = deathReportService.report("token-a", new DeathReportRequest(LocalDate.of(2026, 8, 15)), null);
 
@@ -172,90 +264,15 @@ class DeathReportServiceTest {
         verify(releaseCaseWarningService).sendAuthorCancelWarningOrFreeze(any());
     }
 
-    // 정책 변경 회귀 테스트 - 한쪽만 사망일을 모르는 경우 더 이상 자동 일치로 처리하지 않는다
-    @Test
-    void report_whenOnlyOneConfirmerKnowsDeathDate_marksBothMismatchedWithoutCreatingCase() {
-        Plan plan = mock(Plan.class);
-        when(plan.getPlanId()).thenReturn(PLAN_ID);
-
-        Confirmer reporting = confirmerAcceptedOn(plan, "A", "a@test.com");
-        SecurityToken reportDeathToken = mock(SecurityToken.class);
-        when(reportDeathToken.getConfirmer()).thenReturn(reporting);
-        when(securityTokenService.resolve(eq("token-a"), eq(SecurityTokenPurpose.REPORT_DEATH))).thenReturn(reportDeathToken);
-
-        Confirmer sibling = confirmerAcceptedOn(plan, "B", "b@test.com");
-        sibling.report(LocalDate.of(2026, 8, 15)); // 날짜를 알고 먼저 신고
-        when(confirmerRepository.findByPlan_PlanIdAndConfirmIdNotAndReportStatus(PLAN_ID, null, ReportStatus.REPORTED))
-                .thenReturn(List.of(sibling));
-
-        deathReportService.report("token-a", new DeathReportRequest(null), null); // 사망일을 모른 채 신고
-
-        assertThat(reporting.getReportStatus()).isEqualTo(ReportStatus.MISMATCHED);
-        assertThat(sibling.getReportStatus()).isEqualTo(ReportStatus.MISMATCHED);
-        verify(releaseCaseRepository, never()).saveAndFlush(any());
-    }
-
-    // 정책 변경 회귀 테스트 - 둘 다 사망일을 모르는 경우도 더 이상 자동 일치로 처리하지 않는다
-    @Test
-    void report_whenBothConfirmersDoNotKnowDeathDate_marksBothMismatchedWithoutCreatingCase() {
-        Plan plan = mock(Plan.class);
-        when(plan.getPlanId()).thenReturn(PLAN_ID);
-
-        Confirmer reporting = confirmerAcceptedOn(plan, "A", "a@test.com");
-        SecurityToken reportDeathToken = mock(SecurityToken.class);
-        when(reportDeathToken.getConfirmer()).thenReturn(reporting);
-        when(securityTokenService.resolve(eq("token-a"), eq(SecurityTokenPurpose.REPORT_DEATH))).thenReturn(reportDeathToken);
-
-        Confirmer sibling = confirmerAcceptedOn(plan, "B", "b@test.com");
-        sibling.report(null); // 사망일을 모른 채 먼저 신고
-        when(confirmerRepository.findByPlan_PlanIdAndConfirmIdNotAndReportStatus(PLAN_ID, null, ReportStatus.REPORTED))
-                .thenReturn(List.of(sibling));
-
-        deathReportService.report("token-a", new DeathReportRequest(null), null);
-
-        assertThat(reporting.getReportStatus()).isEqualTo(ReportStatus.MISMATCHED);
-        assertThat(sibling.getReportStatus()).isEqualTo(ReportStatus.MISMATCHED);
-        verify(releaseCaseRepository, never()).saveAndFlush(any());
-    }
-
-    // 둘 다 사망일을 명시했지만 서로 다른 고전적 불일치 케이스
-    @Test
-    void report_whenConfirmersReportDifferentDeathDates_marksBothMismatchedWithoutCreatingCase() {
-        Plan plan = mock(Plan.class);
-        when(plan.getPlanId()).thenReturn(PLAN_ID);
-
-        Confirmer reporting = confirmerAcceptedOn(plan, "A", "a@test.com");
-        SecurityToken reportDeathToken = mock(SecurityToken.class);
-        when(reportDeathToken.getConfirmer()).thenReturn(reporting);
-        when(securityTokenService.resolve(eq("token-a"), eq(SecurityTokenPurpose.REPORT_DEATH))).thenReturn(reportDeathToken);
-
-        Confirmer sibling = confirmerAcceptedOn(plan, "B", "b@test.com");
-        sibling.report(LocalDate.of(2026, 8, 15));
-        when(confirmerRepository.findByPlan_PlanIdAndConfirmIdNotAndReportStatus(PLAN_ID, null, ReportStatus.REPORTED))
-                .thenReturn(List.of(sibling));
-
-        deathReportService.report("token-a", new DeathReportRequest(LocalDate.of(2026, 8, 16)), null);
-
-        assertThat(reporting.getReportStatus()).isEqualTo(ReportStatus.MISMATCHED);
-        assertThat(sibling.getReportStatus()).isEqualTo(ReportStatus.MISMATCHED);
-        verify(releaseCaseRepository, never()).saveAndFlush(any());
-    }
-
-    // 준비도 검증 실패 시 두 신고가 일치하더라도 사건이 생성되지 않아야 한다
+    // 준비도 검증 실패 시 사건이 생성되지 않아야 한다
     @Test
     void report_whenPlanNotReady_propagatesExceptionWithoutCreatingCase() {
         Plan plan = mock(Plan.class);
         when(plan.getPlanId()).thenReturn(PLAN_ID);
 
-        Confirmer reporting = confirmerAcceptedOn(plan, "A", "a@test.com");
-        SecurityToken reportDeathToken = mock(SecurityToken.class);
-        when(reportDeathToken.getConfirmer()).thenReturn(reporting);
+        Confirmer confirmer = confirmerAcceptedOn(plan, "A", "a@test.com");
+        SecurityToken reportDeathToken = reportDeathTokenFor(confirmer);
         when(securityTokenService.resolve(eq("token-a"), eq(SecurityTokenPurpose.REPORT_DEATH))).thenReturn(reportDeathToken);
-
-        Confirmer sibling = confirmerAcceptedOn(plan, "B", "b@test.com");
-        sibling.report(LocalDate.of(2026, 8, 15));
-        when(confirmerRepository.findByPlan_PlanIdAndConfirmIdNotAndReportStatus(PLAN_ID, null, ReportStatus.REPORTED))
-                .thenReturn(List.of(sibling));
 
         when(releaseCaseRepository.findFirstByPlan_PlanIdOrderByCaseIdDesc(PLAN_ID)).thenReturn(Optional.empty());
         doThrow(new CustomException(ErrorCode.PLAN_NOT_READY)).when(planReadinessValidator).validate(plan);
@@ -279,7 +296,7 @@ class DeathReportServiceTest {
         PlanReadinessValidator realValidator =
                 new PlanReadinessValidator(readinessConfirmerRepository, itemRepository, disputeContactRepository);
         deathReportService = new DeathReportService(
-                confirmerRepository, releaseCaseRepository, planVersionRepository,
+                releaseCaseRepository, planVersionRepository,
                 planSnapshotService, idempotencyGuard, securityTokenService, emailOutboxService, appProperties,
                 realValidator, releaseCaseWarningService);
 
@@ -291,14 +308,10 @@ class DeathReportServiceTest {
         when(plan.getOrderConfirmedAt()).thenReturn(LocalDateTime.now());
 
         Confirmer reporting = confirmerAcceptedOn(plan, "A", "same@test.com");
-        SecurityToken reportDeathToken = mock(SecurityToken.class);
-        when(reportDeathToken.getConfirmer()).thenReturn(reporting);
+        SecurityToken reportDeathToken = reportDeathTokenFor(reporting);
         when(securityTokenService.resolve(eq("token-a"), eq(SecurityTokenPurpose.REPORT_DEATH))).thenReturn(reportDeathToken);
 
         Confirmer sibling = confirmerAcceptedOn(plan, "B", "SAME@test.com"); // 정규화하면 reporting과 같은 이메일
-        sibling.report(LocalDate.of(2026, 8, 15));
-        when(confirmerRepository.findByPlan_PlanIdAndConfirmIdNotAndReportStatus(PLAN_ID, null, ReportStatus.REPORTED))
-                .thenReturn(List.of(sibling));
 
         when(releaseCaseRepository.findFirstByPlan_PlanIdOrderByCaseIdDesc(PLAN_ID)).thenReturn(Optional.empty());
         DisputeContact verifiedContact = DisputeContact.builder().plan(mock(Plan.class)).email("dispute@test.com").name("이의").build();

--- a/src/test/java/com/mamoki/ieojuda/domain/confirmer/service/DeathReportToEvidenceFlowIntegrationTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/confirmer/service/DeathReportToEvidenceFlowIntegrationTest.java
@@ -1,0 +1,411 @@
+package com.mamoki.ieojuda.domain.confirmer.service;
+
+import com.mamoki.ieojuda.domain.account.entity.AdminPermission;
+import com.mamoki.ieojuda.domain.account.entity.User;
+import com.mamoki.ieojuda.domain.account.entity.UserRole;
+import com.mamoki.ieojuda.domain.account.repository.UserRepository;
+import com.mamoki.ieojuda.domain.audit.entity.EmailLog;
+import com.mamoki.ieojuda.domain.audit.entity.EmailType;
+import com.mamoki.ieojuda.domain.audit.repository.EmailLogRepository;
+import com.mamoki.ieojuda.domain.confirmer.dto.DeathReportRequest;
+import com.mamoki.ieojuda.domain.confirmer.dto.DeathReportResponse;
+import com.mamoki.ieojuda.domain.confirmer.entity.Confirmer;
+import com.mamoki.ieojuda.domain.confirmer.entity.DisputeContact;
+import com.mamoki.ieojuda.domain.confirmer.entity.ReportStatus;
+import com.mamoki.ieojuda.domain.confirmer.entity.Relationship;
+import com.mamoki.ieojuda.domain.confirmer.repository.ConfirmerRepository;
+import com.mamoki.ieojuda.domain.confirmer.repository.DisputeContactRepository;
+import com.mamoki.ieojuda.domain.evidence.entity.Evidence;
+import com.mamoki.ieojuda.domain.evidence.entity.EvidenceType;
+import com.mamoki.ieojuda.domain.evidence.repository.EvidenceRepository;
+import com.mamoki.ieojuda.domain.evidence.service.EvidenceSubmitService;
+import com.mamoki.ieojuda.domain.partner.dto.PartnerReviewDecisionRequest;
+import com.mamoki.ieojuda.domain.partner.entity.PartnerReviewer;
+import com.mamoki.ieojuda.domain.partner.repository.PartnerReviewerRepository;
+import com.mamoki.ieojuda.domain.partner.service.PartnerReviewService;
+import com.mamoki.ieojuda.domain.plan.entity.Conversation;
+import com.mamoki.ieojuda.domain.plan.entity.DisclosureScope;
+import com.mamoki.ieojuda.domain.plan.entity.Item;
+import com.mamoki.ieojuda.domain.plan.entity.ItemActionType;
+import com.mamoki.ieojuda.domain.plan.entity.LifeArea;
+import com.mamoki.ieojuda.domain.plan.entity.LifeAreaCategory;
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.plan.repository.ConversationRepository;
+import com.mamoki.ieojuda.domain.plan.repository.ItemRepository;
+import com.mamoki.ieojuda.domain.plan.repository.LifeAreaRepository;
+import com.mamoki.ieojuda.domain.plan.repository.PlanRepository;
+import com.mamoki.ieojuda.domain.plan.repository.PlanVersionRepository;
+import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
+import com.mamoki.ieojuda.domain.recipient.entity.RoleType;
+import com.mamoki.ieojuda.domain.recipient.repository.RecipientRepository;
+import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCase;
+import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCaseStatus;
+import com.mamoki.ieojuda.domain.releasecase.repository.ReleaseCaseRepository;
+import com.mamoki.ieojuda.domain.securitytoken.entity.SecurityTokenPurpose;
+import com.mamoki.ieojuda.domain.securitytoken.repository.SecurityTokenRepository;
+import com.mamoki.ieojuda.domain.securitytoken.service.SecurityTokenService;
+import com.mamoki.ieojuda.global.email.contract.EmailSendResult;
+import com.mamoki.ieojuda.global.email.outbox.EmailOutboxRepository;
+import com.mamoki.ieojuda.global.email.sender.EmailSender;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import com.mamoki.ieojuda.global.storage.EvidenceStorageClient;
+import com.mamoki.ieojuda.global.storage.contract.StoredEvidence;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+// issue #41 재설계 - "역할 수락 -> 사망 신고 -> 증빙 제출 -> 매칭 판정 -> 파트너 승인 -> 대기" 전체 흐름을
+// 실제 스프링 컨텍스트·DB·토큰 발급/검증으로 태워 검증한다. 외부 경계(S3, SMTP)만 격리한다.
+@SpringBootTest
+class DeathReportToEvidenceFlowIntegrationTest {
+
+    private static final byte[] PDF_BYTES = "%PDF-1.4\n1 0 obj << >> endobj\n%%EOF".getBytes(StandardCharsets.US_ASCII);
+
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private PlanRepository planRepository;
+    @Autowired
+    private ConversationRepository conversationRepository;
+    @Autowired
+    private LifeAreaRepository lifeAreaRepository;
+    @Autowired
+    private RecipientRepository recipientRepository;
+    @Autowired
+    private ItemRepository itemRepository;
+    @Autowired
+    private ConfirmerRepository confirmerRepository;
+    @Autowired
+    private DisputeContactRepository disputeContactRepository;
+    @Autowired
+    private ReleaseCaseRepository releaseCaseRepository;
+    @Autowired
+    private PlanVersionRepository planVersionRepository;
+    @Autowired
+    private SecurityTokenRepository securityTokenRepository;
+    @Autowired
+    private SecurityTokenService securityTokenService;
+    @Autowired
+    private EvidenceRepository evidenceRepository;
+    @Autowired
+    private EmailLogRepository emailLogRepository;
+    @Autowired
+    private EmailOutboxRepository emailOutboxRepository;
+    @Autowired
+    private PartnerReviewerRepository partnerReviewerRepository;
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+    @Autowired
+    private DeathReportService deathReportService;
+    @Autowired
+    private EvidenceSubmitService evidenceSubmitService;
+    @Autowired
+    private PartnerReviewService partnerReviewService;
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    @MockitoBean
+    private EvidenceStorageClient evidenceStorageClient;
+    @MockitoBean
+    private EmailSender emailSender;
+
+    private User user;
+    private Plan plan;
+    private Conversation conversation;
+    private LifeArea lifeArea;
+    private Recipient recipient;
+    private Item item;
+    private Confirmer confirmerA;
+    private Confirmer confirmerB;
+    private DisputeContact disputeContact;
+    private User reviewerUser;
+
+    @BeforeEach
+    void setUp() {
+        when(evidenceStorageClient.store(any(), any()))
+                .thenAnswer(invocation -> new StoredEvidence("evidence/flow-test/" + UUID.randomUUID() + ".pdf", PDF_BYTES.length));
+        // 이의 연락처 경고 발송은 항상 성공한다고 가정 - "매칭/불일치 모두 승인되면 WAITING까지 도달하는가"가
+        // 이 테스트의 관심사이지, 경고 메일 발송 자체의 성공/실패 분기는 PartnerReviewWarningIntegrationTest가 이미 다룬다.
+        when(emailSender.send(any(), any())).thenReturn(EmailSendResult.success("msg-1"));
+    }
+
+    // 이의 연락처 인증·대기 기간·본인 경고 이메일 인증·실행 순서 확정·수락 확인자 2명까지 전부 충족한
+    // 계획을 만든다 (DeathReportReadinessIntegrationTest.createFixture와 동일한 패턴).
+    private void createReadyFixture() {
+        user = userRepository.saveAndFlush(User.builder()
+                .email("flow-" + UUID.randomUUID() + "@test.com").password("hash").name("김나무").build());
+        plan = planRepository.saveAndFlush(Plan.builder().user(user).build());
+        conversation = conversationRepository.saveAndFlush(Conversation.builder().plan(plan).build());
+        lifeArea = lifeAreaRepository.saveAndFlush(
+                LifeArea.builder().plan(plan).conversation(conversation).category(LifeAreaCategory.RELATIONSHIP_CLEANUP).build());
+        recipient = recipientRepository.saveAndFlush(Recipient.builder()
+                .plan(plan).lifeArea(lifeArea).name("이지수").email("recipient-" + UUID.randomUUID() + "@test.com")
+                .roleType(RoleType.RELATIONSHIP_MANAGER).isBackup(false)
+                .disclosureScope(DisclosureScope.RELATIONSHIP).maxWaitHours(168).backupFor(null).build());
+        item = Item.builder()
+                .lifeArea(lifeArea).targetName("이지수").locationType("인스타그램").action("정리해줘")
+                .title("SNS 정리").content("비공개로 전환").precondition("")
+                .disclosureScope(DisclosureScope.RELATIONSHIP).sourceExcerpt("근거 발췌")
+                .sortOrder(0).actionType(ItemActionType.DELETE).build();
+        item.assignRecipient(recipient);
+        item = itemRepository.saveAndFlush(item);
+
+        confirmerA = Confirmer.builder().plan(plan).name("확인자A").relationship(Relationship.FRIEND)
+                .email("confirmer-a-" + UUID.randomUUID() + "@test.com").build();
+        confirmerA.accept(null);
+        confirmerA = confirmerRepository.saveAndFlush(confirmerA);
+        confirmerB = Confirmer.builder().plan(plan).name("확인자B").relationship(Relationship.FRIEND)
+                .email("confirmer-b-" + UUID.randomUUID() + "@test.com").build();
+        confirmerB.accept(null);
+        confirmerB = confirmerRepository.saveAndFlush(confirmerB);
+
+        disputeContact = DisputeContact.builder().plan(plan)
+                .email("dispute-" + UUID.randomUUID() + "@test.com").name("이의연락처").build();
+        disputeContact.verify();
+        disputeContact = disputeContactRepository.saveAndFlush(disputeContact);
+
+        plan.updateWaitingDays(7);
+        plan.requestSelfWarningEmailVerification("warn-" + UUID.randomUUID() + "@test.com", "hash", LocalDateTime.now().plusDays(1));
+        plan.verifySelfWarningEmail();
+        plan.confirmOrder();
+        plan.seal();
+        plan = planRepository.saveAndFlush(plan);
+    }
+
+    private void createReviewer() {
+        reviewerUser = User.builder().email("reviewer-" + UUID.randomUUID() + "@test.com")
+                .password(passwordEncoder.encode("correct-pw")).name("검토자").build();
+        ReflectionTestUtils.setField(reviewerUser, "role", UserRole.EXTERNAL);
+        ReflectionTestUtils.setField(reviewerUser, "permissions", Set.of(AdminPermission.EVIDENCE_REVIEW));
+        reviewerUser = userRepository.saveAndFlush(reviewerUser);
+        partnerReviewerRepository.saveAndFlush(PartnerReviewer.builder()
+                .user(reviewerUser).name("검토자").email(reviewerUser.getEmail()).build());
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (plan == null) {
+            return;
+        }
+        evidenceRepository.findByPlan_PlanId(plan.getPlanId()).forEach(evidenceRepository::delete);
+        releaseCaseRepository.findByPlan_PlanId(plan.getPlanId()).forEach(releaseCase -> {
+            new TransactionTemplate(transactionManager).executeWithoutResult(
+                    status -> securityTokenRepository.deleteByReleaseCase_CaseId(releaseCase.getCaseId()));
+            releaseCaseRepository.delete(releaseCase);
+        });
+        planVersionRepository.findByPlan_PlanId(plan.getPlanId()).forEach(planVersionRepository::delete);
+        new TransactionTemplate(transactionManager).executeWithoutResult(status -> {
+            securityTokenRepository.deleteByConfirmer_ConfirmId(confirmerA.getConfirmId());
+            securityTokenRepository.deleteByConfirmer_ConfirmId(confirmerB.getConfirmId());
+        });
+        confirmerRepository.delete(confirmerA);
+        confirmerRepository.delete(confirmerB);
+        if (disputeContact != null) {
+            disputeContactRepository.delete(disputeContact);
+        }
+        for (EmailLog emailLog : emailLogRepository.findByPlan_PlanIdOrderByRequestedAtDesc(plan.getPlanId())) {
+            new TransactionTemplate(transactionManager).executeWithoutResult(
+                    status -> emailOutboxRepository.deleteByEmailLog_LogId(emailLog.getLogId()));
+            emailLogRepository.delete(emailLog);
+        }
+        itemRepository.delete(item);
+        recipientRepository.delete(recipient);
+        lifeAreaRepository.delete(lifeArea);
+        conversationRepository.delete(conversation);
+        planRepository.delete(plan);
+        userRepository.delete(user);
+        if (reviewerUser != null) {
+            partnerReviewerRepository.findByUser_UserId(reviewerUser.getUserId())
+                    .ifPresent(partnerReviewerRepository::delete);
+            userRepository.delete(reviewerUser);
+        }
+        plan = null;
+    }
+
+    private DeathReportResponse report(Confirmer confirmer, LocalDate deathDate) {
+        String token = securityTokenService.issueForConfirmer(
+                SecurityTokenPurpose.REPORT_DEATH, confirmer, null, LocalDateTime.now().plusDays(1));
+        return deathReportService.report(token, new DeathReportRequest(deathDate), UUID.randomUUID().toString());
+    }
+
+    private Evidence submitEvidence(UUID caseId, String evidenceUploadToken, String fileName) {
+        MockMultipartFile file = new MockMultipartFile("file", fileName, "application/pdf", PDF_BYTES);
+        evidenceSubmitService.submit(caseId, evidenceUploadToken, file, EvidenceType.DEATH_CERTIFICATE, UUID.randomUUID().toString());
+        return evidenceRepository.findByPlan_PlanId(plan.getPlanId()).stream()
+                .filter(e -> e.getStorageKey() != null)
+                .reduce((first, second) -> second) // 방금 저장된 것
+                .orElseThrow();
+    }
+
+    private void approve(Evidence evidence) {
+        partnerReviewService.decide(evidence.getEvidenceId(), reviewerUser.getUserId(),
+                new PartnerReviewDecisionRequest(PartnerReviewDecisionRequest.PartnerReviewDecision.APPROVE, null, "correct-pw"),
+                UUID.randomUUID().toString());
+    }
+
+    private boolean hasEvidenceSubmissionRequestEmailFor(String recipientEmail) {
+        return emailLogRepository.findByPlan_PlanIdOrderByRequestedAtDesc(plan.getPlanId()).stream()
+                .anyMatch(log -> log.getEmailType() == EmailType.EVIDENCE_SUBMISSION_REQUEST
+                        && log.getRecipientEmail().equals(recipientEmail));
+    }
+
+    // ===================== 성공 흐름 =====================
+
+    @Test
+    void success_reportImmediatelyReturnsUsableEvidenceTokenWithoutWaitingForEmail() {
+        createReadyFixture();
+
+        DeathReportResponse response = report(confirmerA, LocalDate.of(2026, 8, 15));
+
+        // 응답에 담긴 토큰만으로, 이메일을 기다리지 않고 바로 증빙 제출 화면(API)으로 넘어갈 수 있어야 한다
+        assertThat(response.caseId()).isNotNull();
+        assertThat(response.evidenceUploadToken()).isNotBlank();
+        Evidence evidence = submitEvidence(response.caseId(), response.evidenceUploadToken(), "proof-a.pdf");
+        assertThat(evidence.getConfirmer().getConfirmId()).isEqualTo(confirmerA.getConfirmId());
+
+        // 백업 이메일도 함께 발송(큐잉)됐어야 한다
+        assertThat(hasEvidenceSubmissionRequestEmailFor(confirmerA.getEmail())).isTrue();
+    }
+
+    @Test
+    void success_secondConfirmerReport_reusesSameActiveCaseInsteadOfCreatingNew() {
+        createReadyFixture();
+
+        DeathReportResponse responseA = report(confirmerA, LocalDate.of(2026, 8, 15));
+        DeathReportResponse responseB = report(confirmerB, LocalDate.of(2026, 8, 15));
+
+        assertThat(responseB.caseId()).isEqualTo(responseA.caseId());
+        assertThat(releaseCaseRepository.findByPlan_PlanId(plan.getPlanId())).hasSize(1);
+        // 신고 시점에는 아직 매칭 판정을 하지 않는다 - 증빙까지 제출해야 판정된다
+        assertThat(confirmerRepository.findById(confirmerA.getConfirmId()).orElseThrow().getReportStatus())
+                .isEqualTo(ReportStatus.REPORTED);
+        assertThat(confirmerRepository.findById(confirmerB.getConfirmId()).orElseThrow().getReportStatus())
+                .isEqualTo(ReportStatus.REPORTED);
+    }
+
+    @Test
+    void success_wholeFlow_bothReportAndSubmitMatchingEvidence_thenPartnerApprovesBoth_reachesWaiting() {
+        createReadyFixture();
+        createReviewer();
+
+        DeathReportResponse responseA = report(confirmerA, LocalDate.of(2026, 8, 15));
+        DeathReportResponse responseB = report(confirmerB, LocalDate.of(2026, 8, 15)); // 같은 날짜
+
+        Evidence evidenceA = submitEvidence(responseA.caseId(), responseA.evidenceUploadToken(), "proof-a.pdf");
+        // 첫 번째 증빙만 들어온 시점에는 아직 매칭 판정이 나지 않는다 (상대가 아직 증빙을 안 냄)
+        assertThat(confirmerRepository.findById(confirmerA.getConfirmId()).orElseThrow().getReportStatus())
+                .isEqualTo(ReportStatus.REPORTED);
+
+        Evidence evidenceB = submitEvidence(responseB.caseId(), responseB.evidenceUploadToken(), "proof-b.pdf");
+
+        // 두 번째 증빙까지 들어오면 그제서야 매칭 판정 - 날짜가 같으므로 MATCHED
+        assertThat(confirmerRepository.findById(confirmerA.getConfirmId()).orElseThrow().getReportStatus())
+                .isEqualTo(ReportStatus.MATCHED);
+        assertThat(confirmerRepository.findById(confirmerB.getConfirmId()).orElseThrow().getReportStatus())
+                .isEqualTo(ReportStatus.MATCHED);
+
+        approve(evidenceA);
+        approve(evidenceB);
+
+        ReleaseCase updated = releaseCaseRepository.findById(responseA.caseId()).orElseThrow();
+        assertThat(updated.getStatus()).isEqualTo(ReleaseCaseStatus.WAITING);
+    }
+
+    // ===================== 실패(불일치) 흐름 =====================
+
+    @Test
+    void failure_mismatchedDeathDates_marksBothMismatchedButStillStoresEvidence() {
+        createReadyFixture();
+
+        DeathReportResponse responseA = report(confirmerA, LocalDate.of(2026, 8, 15));
+        DeathReportResponse responseB = report(confirmerB, LocalDate.of(2026, 8, 16)); // 다른 날짜
+
+        submitEvidence(responseA.caseId(), responseA.evidenceUploadToken(), "proof-a.pdf");
+        submitEvidence(responseB.caseId(), responseB.evidenceUploadToken(), "proof-b.pdf");
+
+        assertThat(confirmerRepository.findById(confirmerA.getConfirmId()).orElseThrow().getReportStatus())
+                .isEqualTo(ReportStatus.MISMATCHED);
+        assertThat(confirmerRepository.findById(confirmerB.getConfirmId()).orElseThrow().getReportStatus())
+                .isEqualTo(ReportStatus.MISMATCHED);
+
+        // 불일치해도 이미 제출된 증빙 2건은 폐기되지 않고 그대로 남아있어야 한다
+        assertThat(evidenceRepository.countByReleaseCase_CaseId(responseA.caseId())).isEqualTo(2);
+    }
+
+    @Test
+    void failure_mismatchedDeathDates_partnerCanStillApproveBothAndReachWaiting() {
+        createReadyFixture();
+        createReviewer();
+
+        DeathReportResponse responseA = report(confirmerA, LocalDate.of(2026, 8, 15));
+        DeathReportResponse responseB = report(confirmerB, LocalDate.of(2026, 8, 16));
+
+        Evidence evidenceA = submitEvidence(responseA.caseId(), responseA.evidenceUploadToken(), "proof-a.pdf");
+        Evidence evidenceB = submitEvidence(responseB.caseId(), responseB.evidenceUploadToken(), "proof-b.pdf");
+
+        // 날짜가 불일치해도 파트너는 자료를 보고 승인할 수 있어야 한다
+        approve(evidenceA);
+        approve(evidenceB);
+
+        ReleaseCase updated = releaseCaseRepository.findById(responseA.caseId()).orElseThrow();
+        assertThat(updated.getStatus()).isEqualTo(ReleaseCaseStatus.WAITING);
+    }
+
+    @Test
+    void failure_partnerCannotApproveBeforeSiblingConfirmerSubmitsEvidence() {
+        createReadyFixture();
+        createReviewer();
+
+        DeathReportResponse responseA = report(confirmerA, LocalDate.of(2026, 8, 15));
+        report(confirmerB, LocalDate.of(2026, 8, 15)); // B는 신고만 하고 증빙은 아직 제출하지 않음
+
+        Evidence evidenceA = submitEvidence(responseA.caseId(), responseA.evidenceUploadToken(), "proof-a.pdf");
+
+        // 상대(B)가 아직 증빙을 내지 않아 매칭 판정이 안 난 상태 - 승인 자체가 막혀야 한다
+        assertThatThrownBy(() -> approve(evidenceA))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.RELEASE_CASE_INVALID_TRANSITION);
+
+        ReleaseCase updated = releaseCaseRepository.findById(responseA.caseId()).orElseThrow();
+        assertThat(updated.getStatus()).isNotEqualTo(ReleaseCaseStatus.WAITING);
+    }
+
+    @Test
+    void failure_secondEvidenceSubmissionForSameConfirmer_isRejectedAsAlreadySubmitted() {
+        createReadyFixture();
+
+        DeathReportResponse responseA = report(confirmerA, LocalDate.of(2026, 8, 15));
+        submitEvidence(responseA.caseId(), responseA.evidenceUploadToken(), "proof-a-1.pdf");
+
+        MockMultipartFile secondFile = new MockMultipartFile("file", "proof-a-2.pdf", "application/pdf", PDF_BYTES);
+        assertThatThrownBy(() -> evidenceSubmitService.submit(
+                responseA.caseId(), responseA.evidenceUploadToken(), secondFile, EvidenceType.DEATH_CERTIFICATE, UUID.randomUUID().toString()))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.EVIDENCE_ALREADY_SUBMITTED);
+
+        assertThat(evidenceRepository.countByReleaseCase_CaseId(responseA.caseId())).isEqualTo(1);
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/domain/evidence/service/EvidenceSubmitServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/evidence/service/EvidenceSubmitServiceTest.java
@@ -29,6 +29,7 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 import org.springframework.transaction.support.TransactionSynchronizationUtils;
 
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -49,6 +50,7 @@ class EvidenceSubmitServiceTest {
 
     private static final UUID PLAN_ID = UUID.randomUUID();
     private static final UUID CASE_ID = UUID.randomUUID();
+    private static final UUID CONFIRM_ID = UUID.randomUUID();
 
     private ReleaseCaseRepository releaseCaseRepository;
     private EvidenceRepository evidenceRepository;
@@ -80,6 +82,7 @@ class EvidenceSubmitServiceTest {
 
         confirmer = mock(Confirmer.class);
         when(confirmer.getAcceptanceStatus()).thenReturn(AcceptanceStatus.ACCEPTED);
+        when(confirmer.getConfirmId()).thenReturn(CONFIRM_ID);
         plan = mock(Plan.class);
         when(plan.getPlanId()).thenReturn(PLAN_ID);
         when(confirmer.getPlan()).thenReturn(plan);
@@ -195,6 +198,69 @@ class EvidenceSubmitServiceTest {
         evidenceSubmitService.submit(CASE_ID, "token", file, EvidenceType.DEATH_CERTIFICATE, null);
 
         verify(releaseCase, never()).startEvidenceReview();
+    }
+
+    // issue #41 재설계 - 상대 확인자의 증빙이 아직 없으면 매칭 판정을 하지 않고 그대로 대기해야 한다
+    @Test
+    void submit_whenNoSiblingEvidenceSubmittedYet_doesNotMarkMatchOrMismatch() {
+        byte[] pdfBytes = "%PDF-1.4\n%%EOF".getBytes(StandardCharsets.US_ASCII);
+        MockMultipartFile file = new MockMultipartFile("file", "proof.pdf", "application/pdf", pdfBytes);
+        when(malwareScanner.scan(any())).thenReturn(ScanResult.passed());
+        when(evidenceStorageClient.store(eq(CASE_ID), any())).thenReturn(new StoredEvidence("evidence/10/uuid.pdf", pdfBytes.length));
+        when(evidenceRepository.findFirstByReleaseCase_CaseIdAndConfirmer_ConfirmIdNot(CASE_ID, CONFIRM_ID))
+                .thenReturn(Optional.empty());
+
+        evidenceSubmitService.submit(CASE_ID, "token", file, EvidenceType.DEATH_CERTIFICATE, null);
+
+        verify(confirmer, never()).markMatched();
+        verify(confirmer, never()).markMismatched();
+    }
+
+    // issue #41 재설계 - 두 번째 증빙이 들어오는 시점에 상대 확인자의 신고 날짜와 비교해 매칭 판정을 내린다
+    @Test
+    void submit_whenSiblingEvidenceAlreadySubmittedAndDatesAgree_marksBothMatched() {
+        byte[] pdfBytes = "%PDF-1.4\n%%EOF".getBytes(StandardCharsets.US_ASCII);
+        MockMultipartFile file = new MockMultipartFile("file", "proof.pdf", "application/pdf", pdfBytes);
+        when(malwareScanner.scan(any())).thenReturn(ScanResult.passed());
+        when(evidenceStorageClient.store(eq(CASE_ID), any())).thenReturn(new StoredEvidence("evidence/10/uuid.pdf", pdfBytes.length));
+
+        when(confirmer.getReportedDeathDate()).thenReturn(LocalDate.of(2026, 8, 15));
+        Confirmer sibling = mock(Confirmer.class);
+        when(sibling.getReportedDeathDate()).thenReturn(LocalDate.of(2026, 8, 15));
+        Evidence siblingEvidence = mock(Evidence.class);
+        when(siblingEvidence.getConfirmer()).thenReturn(sibling);
+        when(evidenceRepository.findFirstByReleaseCase_CaseIdAndConfirmer_ConfirmIdNot(CASE_ID, CONFIRM_ID))
+                .thenReturn(Optional.of(siblingEvidence));
+
+        evidenceSubmitService.submit(CASE_ID, "token", file, EvidenceType.DEATH_CERTIFICATE, null);
+
+        verify(confirmer).markMatched();
+        verify(sibling).markMatched();
+        verify(confirmer, never()).markMismatched();
+        verify(sibling, never()).markMismatched();
+    }
+
+    // issue #41 재설계 - 불일치해도 이미 제출된 증빙은 폐기하지 않는다(외부 파트너가 검토할 수 있도록)
+    @Test
+    void submit_whenSiblingEvidenceAlreadySubmittedAndDatesDiffer_marksBothMismatchedButStillStoresEvidence() {
+        byte[] pdfBytes = "%PDF-1.4\n%%EOF".getBytes(StandardCharsets.US_ASCII);
+        MockMultipartFile file = new MockMultipartFile("file", "proof.pdf", "application/pdf", pdfBytes);
+        when(malwareScanner.scan(any())).thenReturn(ScanResult.passed());
+        when(evidenceStorageClient.store(eq(CASE_ID), any())).thenReturn(new StoredEvidence("evidence/10/uuid.pdf", pdfBytes.length));
+
+        when(confirmer.getReportedDeathDate()).thenReturn(LocalDate.of(2026, 8, 15));
+        Confirmer sibling = mock(Confirmer.class);
+        when(sibling.getReportedDeathDate()).thenReturn(LocalDate.of(2026, 8, 16));
+        Evidence siblingEvidence = mock(Evidence.class);
+        when(siblingEvidence.getConfirmer()).thenReturn(sibling);
+        when(evidenceRepository.findFirstByReleaseCase_CaseIdAndConfirmer_ConfirmIdNot(CASE_ID, CONFIRM_ID))
+                .thenReturn(Optional.of(siblingEvidence));
+
+        evidenceSubmitService.submit(CASE_ID, "token", file, EvidenceType.DEATH_CERTIFICATE, null);
+
+        verify(confirmer).markMismatched();
+        verify(sibling).markMismatched();
+        verify(evidenceStorageClient).store(eq(CASE_ID), any());
     }
 
     // issue #51 - DB 트랜잭션이 롤백된 뒤 보정 삭제(afterCompletion) 자체가 실패하면, 이전에는 로그만

--- a/src/test/java/com/mamoki/ieojuda/domain/partner/service/PartnerReviewServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/partner/service/PartnerReviewServiceTest.java
@@ -5,6 +5,7 @@ import com.mamoki.ieojuda.domain.account.entity.User;
 import com.mamoki.ieojuda.domain.audit.entity.AdminActionType;
 import com.mamoki.ieojuda.domain.audit.service.AdminActionAuditService;
 import com.mamoki.ieojuda.domain.confirmer.entity.Confirmer;
+import com.mamoki.ieojuda.domain.confirmer.entity.ReportStatus;
 import com.mamoki.ieojuda.domain.confirmer.repository.ConfirmerRepository;
 import com.mamoki.ieojuda.domain.evidence.entity.Evidence;
 import com.mamoki.ieojuda.domain.evidence.entity.EvidenceDownloadToken;
@@ -38,6 +39,7 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -109,6 +111,10 @@ class PartnerReviewServiceTest {
         when(releaseCase.getPlan()).thenReturn(plan);
         Confirmer confirmer = mock(Confirmer.class);
         when(confirmer.getName()).thenReturn("확인자");
+        // issue #41 재설계 - 매칭 판정이 끝난(MATCHED) 증빙만 승인할 수 있다. REPORTED(매칭 미확정)인
+        // 채로 두면 새로 추가한 가드에 막히므로, 기본값은 "이미 매칭 확정"으로 둔다
+        // (미확정 상태 자체를 검증하는 테스트는 개별적으로 REPORTED로 재정의한다).
+        when(confirmer.getReportStatus()).thenReturn(ReportStatus.MATCHED);
         evidence = mock(Evidence.class);
         when(evidence.getEvidenceId()).thenReturn(REVIEW_ID);
         when(evidence.getReleaseCase()).thenReturn(releaseCase);
@@ -119,8 +125,11 @@ class PartnerReviewServiceTest {
         when(evidenceRepository.findById(REVIEW_ID)).thenReturn(Optional.of(evidence));
         // 기본값: 매칭된 확인자가 1명뿐인 사건 - 승인 1건만으로 정족수를 채워 바로 WAITING까지 진행된다
         // (다중 확인자 정족수 시나리오는 별도 테스트에서 개별적으로 재정의한다)
-        when(confirmerRepository.findByPlan_PlanIdAndReportStatus(any(), any()))
+        when(confirmerRepository.findByPlan_PlanIdAndReportStatus(any(), eq(ReportStatus.MATCHED)))
                 .thenReturn(List.of(mock(Confirmer.class)));
+        // 불일치(MISMATCHED)로 확정된 확인자는 기본적으로 없다고 가정한다
+        when(confirmerRepository.findByPlan_PlanIdAndReportStatus(any(), eq(ReportStatus.MISMATCHED)))
+                .thenReturn(List.of());
         when(evidenceRepository.countByReleaseCase_CaseIdAndReviewStatus(any(), any())).thenReturn(0L);
     }
 
@@ -144,7 +153,7 @@ class PartnerReviewServiceTest {
     // WAITING으로 넘기지 않고 부분 승인(EVIDENCE_APPROVED) 상태로만 남겨야 한다.
     @Test
     void decide_whenOnlyOneOfTwoMatchedConfirmersApproved_leavesCasePartiallyApproved() {
-        when(confirmerRepository.findByPlan_PlanIdAndReportStatus(any(), any()))
+        when(confirmerRepository.findByPlan_PlanIdAndReportStatus(any(), eq(ReportStatus.MATCHED)))
                 .thenReturn(List.of(mock(Confirmer.class), mock(Confirmer.class)));
         when(evidenceRepository.countByReleaseCase_CaseIdAndReviewStatus(any(), any())).thenReturn(0L);
         PartnerReviewDecisionRequest request = new PartnerReviewDecisionRequest(
@@ -161,7 +170,7 @@ class PartnerReviewServiceTest {
     // 그때 비로소 WAITING으로 전환돼야 한다.
     @Test
     void decide_whenSecondOfTwoMatchedConfirmersApproved_startsWaiting() {
-        when(confirmerRepository.findByPlan_PlanIdAndReportStatus(any(), any()))
+        when(confirmerRepository.findByPlan_PlanIdAndReportStatus(any(), eq(ReportStatus.MATCHED)))
                 .thenReturn(List.of(mock(Confirmer.class), mock(Confirmer.class)));
         when(evidenceRepository.countByReleaseCase_CaseIdAndReviewStatus(any(), any())).thenReturn(1L);
         PartnerReviewDecisionRequest request = new PartnerReviewDecisionRequest(
@@ -172,6 +181,38 @@ class PartnerReviewServiceTest {
         verify(evidence).approve();
         verify(releaseCaseWarningService).sendDisputeWarningsAndStartWaiting(releaseCase, 7);
         verify(releaseCase, never()).markEvidencePartiallyApproved();
+    }
+
+    // issue #41 재설계 - 상대 확인자가 아직 증빙까지 제출하지 못해 매칭 판정이 안 난(REPORTED) 증빙은
+    // 승인할 수 없어야 한다. 이걸 막지 않으면 requiredCount가 부정확해져 조기에 WAITING으로 샐 수 있다.
+    @Test
+    void decide_whenMatchingNotYetDecided_isBlockedFromApproving() {
+        when(evidence.getConfirmer().getReportStatus()).thenReturn(ReportStatus.REPORTED);
+        PartnerReviewDecisionRequest request = new PartnerReviewDecisionRequest(
+                PartnerReviewDecisionRequest.PartnerReviewDecision.APPROVE, null, "correct-pw");
+
+        assertThatThrownBy(() -> partnerReviewService.decide(REVIEW_ID, USER_ID, request, null))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.RELEASE_CASE_INVALID_TRANSITION));
+        verify(evidence, never()).approve();
+    }
+
+    // issue #41 재설계 - 두 확인자의 신고 날짜가 불일치(MISMATCHED)해도, 이미 제출된 증빙은 파트너가
+    // 검토·승인할 수 있어야 한다 (검토 기회를 막지 않는다).
+    @Test
+    void decide_whenBothConfirmersMismatched_stillAllowsApprovalAndCountsTowardRequiredCount() {
+        when(evidence.getConfirmer().getReportStatus()).thenReturn(ReportStatus.MISMATCHED);
+        when(confirmerRepository.findByPlan_PlanIdAndReportStatus(any(), eq(ReportStatus.MATCHED)))
+                .thenReturn(List.of());
+        when(confirmerRepository.findByPlan_PlanIdAndReportStatus(any(), eq(ReportStatus.MISMATCHED)))
+                .thenReturn(List.of(mock(Confirmer.class)));
+        PartnerReviewDecisionRequest request = new PartnerReviewDecisionRequest(
+                PartnerReviewDecisionRequest.PartnerReviewDecision.APPROVE, null, "correct-pw");
+
+        partnerReviewService.decide(REVIEW_ID, USER_ID, request, null);
+
+        verify(evidence).approve();
+        verify(releaseCaseWarningService).sendDisputeWarningsAndStartWaiting(releaseCase, 7);
     }
 
     @Test


### PR DESCRIPTION
## 연관 Issue

- Closes #145

## 요약

지정확인자가 "역할 수락"을 마치면 사망 신고 화면으로 이어지는 이메일이 발송되지 않던 문제를 고치고, 나아가 "사망 신고 → 증빙 제출" 흐름 전체를 재설계했다. 이제 신고를 제출하면 상대 확인자 상태와 무관하게 즉시 증빙 제출로 이어질 수 있고, "독립된 2인 확인 원칙"에 따른 매칭 판정은 두 확인자 모두 증빙까지 제출을 마친 뒤로 미뤄진다.

## 변경 사항

- 역할 수락(`accept()`) 완료 시 `REPORT_DEATH` 토큰 링크가 담긴 이메일(`DEATH_REPORT_REQUEST`)을 발송하도록 배선, 토큰 만료를 100년으로 설정 (사망 신고까지 수십 년 걸릴 수 있는 시나리오 고려)
- 사망 신고 화면 진입 시 확인자/작성자 정보를 조회하는 `GET /api/confirmer-acceptances/{token}/death-report` API 추가
- `DeathReportService.report()`에서 매칭 판정 로직을 제거하고, 신고 접수 즉시 사건(`ReleaseCase`)을 찾거나 새로 만들어 증빙 제출 토큰을 응답에 담아 반환 (이메일 대기 없이 바로 다음 화면으로 이동 가능), 두 확인자가 동시에 첫 신고를 하는 경쟁 상황도 안전하게 처리
- 매칭(`MATCHED`/`MISMATCHED`) 판정을 `EvidenceSubmitService`로 이동 - 같은 사건에 상대 확인자의 증빙이 이미 있으면 그 시점에 날짜를 비교해 판정
- 날짜가 불일치해도 이미 제출된 증빙은 폐기하지 않고, 외부 파트너가 직접 검토·승인할 수 있도록 유지
- `PartnerReviewService.decide()`에 조기 승인 방지 가드 추가 - 상대 확인자가 아직 증빙까지 제출하지 못해 매칭 판정이 안 난 상태에서는 승인 자체를 차단 (그렇지 않으면 혼자만의 신고로 대기 단계까지 새어나가는 결함이 생김)
- 단위/통합 테스트 다수 추가 (성공 흐름, 불일치 흐름, 조기 승인 차단, 중복 제출 차단 등 실제 DB·토큰으로 검증)

## 범위

### 포함

- 사망 신고 관련 API(`accept`, `death-report` 조회/제출) 및 증빙 제출·파트너 승인 로직
- `ReleaseCase` 생성 시점 이동 및 관련 동시성 처리
- 위 변경에 대한 단위 테스트 및 실제 DB 기반 통합 테스트

### 제외

- 사망 신고 화면 조회(GET) API를 프런트엔드가 실제로 연동하는 작업
- 실제 Gmail 발송 확인 (이메일 큐 등록까지만 검증, 실제 SMTP 전송은 검증 범위 밖)
- `SecurityToken.expiresAt`을 nullable로 바꿔 진짜 "무기한" 토큰을 지원하는 스키마 변경
- `REPORT_DEATH` 토큰 재발송(resend) API 신설

## 스크린샷 / 미리 보기

- 백엔드 API/로직 변경으로, UI 화면 변경 없음 (프런트엔드 미연동 상태)