### PR TITLE
[Fix]: 계획 비활성화 후 담당자 조회 및 대화 이력 순서 버그 수정

### DIFF
--- a/src/main/java/com/mamoki/ieojuda/domain/plan/repository/LifeAreaMessageRepository.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/repository/LifeAreaMessageRepository.java
@@ -10,11 +10,14 @@ import java.util.List;
 
 public interface LifeAreaMessageRepository extends JpaRepository<LifeAreaMessage, UUID> {
 
+    // 버그 수정 - messageId는 GenerationType.UUID(랜덤)라 생성 순서와 무관하다. 정렬 기준을
+    // createdAt으로 바꾸고, 같은 시각에 저장된 경우를 대비해 messageId를 보조 정렬키로 둔다.
+
     // OpenAI 호출용 - 이 대화 세션(Conversation) 안의 맥락 전체를 오래된 순으로 조회 (페이지네이션 없이 전부 필요)
-    List<LifeAreaMessage> findByConversation_ConversationIdOrderByMessageIdAsc(UUID conversationId);
+    List<LifeAreaMessage> findByConversation_ConversationIdOrderByCreatedAtAscMessageIdAsc(UUID conversationId);
 
     // 대화 작성 화면용 - 최신 턴부터 페이지 단위로 조회 (무한 스크롤)
-    Slice<LifeAreaMessage> findByConversation_ConversationIdOrderByMessageIdDesc(UUID conversationId, Pageable pageable);
+    Slice<LifeAreaMessage> findByConversation_ConversationIdOrderByCreatedAtDescMessageIdDesc(UUID conversationId, Pageable pageable);
 
     // 계정 삭제 시 이 계획에 속한 모든 대화 세션의 메세지를 한 번에 지우기 위한 조회
     List<LifeAreaMessage> findByConversation_Plan_PlanId(UUID planId);

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/service/ConversationService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/service/ConversationService.java
@@ -76,7 +76,7 @@ public class ConversationService {
         Conversation conversation = findConversation(userId, planId, conversationId);
 
         Slice<LifeAreaMessage> slice = lifeAreaMessageRepository
-                .findByConversation_ConversationIdOrderByMessageIdDesc(conversation.getConversationId(), pageable);
+                .findByConversation_ConversationIdOrderByCreatedAtDescMessageIdDesc(conversation.getConversationId(), pageable);
 
         List<LifeAreaMessageResponse> messages = new ArrayList<>(
                 slice.getContent().stream().map(LifeAreaMessageResponse::from).toList()
@@ -99,7 +99,7 @@ public class ConversationService {
 
         // step 1. 이 세션 안에서 지금까지의 대화 이력 로드
         List<LifeAreaMessage> history = lifeAreaMessageRepository
-                .findByConversation_ConversationIdOrderByMessageIdAsc(conversation.getConversationId());
+                .findByConversation_ConversationIdOrderByCreatedAtAscMessageIdAsc(conversation.getConversationId());
 
         // issue #52 - 전체 이력 길이 상한. 이번 메세지를 저장하기 전에 확인해야
         // "거절된 입력은 저장하지 않는다"는 원칙을 지킬 수 있다.

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/service/PlanOwnershipReader.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/service/PlanOwnershipReader.java
@@ -3,6 +3,7 @@ package com.mamoki.ieojuda.domain.plan.service;
 import java.util.UUID;
 
 import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.plan.entity.PlanStatus;
 import com.mamoki.ieojuda.domain.plan.repository.PlanRepository;
 import com.mamoki.ieojuda.global.exception.CustomException;
 import com.mamoki.ieojuda.global.exception.ErrorCode;
@@ -19,5 +20,16 @@ public class PlanOwnershipReader {
     public Plan findOwnedPlan(UUID userId, UUID planId) {
         return planRepository.findByPlanIdAndUser_UserId(planId, userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.PLAN_NOT_FOUND));
+    }
+
+    // 마이페이지에서 계획을 비활성화한 뒤에는 담당자·항목 등 하위 자원을 더 이상 정상적으로 다룰 수
+    // 없어야 한다. findOwnedPlan()은 계획 상태 조회(예: 계획 홈, 마이페이지) 자체는 계속 되어야 하므로
+    // 그대로 두고, 비활성화 여부를 신경 써야 하는 서비스만 이 메서드를 쓰도록 분리한다.
+    public Plan findOwnedActivePlan(UUID userId, UUID planId) {
+        Plan plan = findOwnedPlan(userId, planId);
+        if (plan.getStatus() == PlanStatus.DEACTIVATED) {
+            throw new CustomException(ErrorCode.PLAN_DEACTIVATED);
+        }
+        return plan;
     }
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/recipient/service/RecipientService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/recipient/service/RecipientService.java
@@ -202,7 +202,7 @@ public class RecipientService {
 
     // "역할 점검" 화면 상세 - 이름 클릭 시 해당 담당자에게 배정된 항목 전체
     public RecipientDetailResponse getRecipient(UUID userId, UUID planId, UUID assigneeId) {
-        planOwnershipReader.findOwnedPlan(userId, planId);
+        planOwnershipReader.findOwnedActivePlan(userId, planId);
         Recipient recipient = findOwnedRecipient(planId, assigneeId);
 
         List<ItemResponse> items = itemRepository.findByRecipient_AssigneeIdOrderByItemIdAsc(assigneeId).stream()

--- a/src/main/java/com/mamoki/ieojuda/domain/rolecheck/service/RoleCheckService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/rolecheck/service/RoleCheckService.java
@@ -25,7 +25,7 @@ public class RoleCheckService {
     private final ConfirmerRepository confirmerRepository;
 
     public List<RoleCheckSummaryResponse> getRoleChecks(UUID userId, UUID planId) {
-        planOwnershipReader.findOwnedPlan(userId, planId);
+        planOwnershipReader.findOwnedActivePlan(userId, planId);
 
         List<RoleCheckSummaryResponse> results = new ArrayList<>();
         for (Recipient recipient : recipientRepository.findByPlan_PlanIdAndIsBackupFalseOrderByAssigneeIdAsc(planId)) {

--- a/src/main/java/com/mamoki/ieojuda/global/exception/ErrorCode.java
+++ b/src/main/java/com/mamoki/ieojuda/global/exception/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
     CIRCULAR_DEPENDENCY_DETECTED(HttpStatus.BAD_REQUEST, "CIRCULAR_DEPENDENCY_DETECTED", "발송 단계에 순환 의존 관계가 존재합니다."),
     PLAN_NOT_SEALED(HttpStatus.BAD_REQUEST, "PLAN_NOT_SEALED", "봉인된 계획만 인계 점검을 보낼 수 있습니다."),
     PLAN_NOT_READY(HttpStatus.BAD_REQUEST, "PLAN_NOT_READY", "준비(봉인)되지 않았거나 비활성화된 계획에서는 사후 사건을 생성할 수 없습니다."),
+    PLAN_DEACTIVATED(HttpStatus.CONFLICT, "PLAN_DEACTIVATED", "비활성화된 계획입니다."),
     WAITING_PERIOD_NOT_SET(HttpStatus.BAD_REQUEST, "WAITING_PERIOD_NOT_SET", "대기 기간이 설정되지 않아 사후 사건을 생성할 수 없습니다."),
     SELF_WARNING_EMAIL_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "SELF_WARNING_EMAIL_NOT_VERIFIED", "본인 경고 이메일 인증이 완료되지 않아 사후 사건을 생성할 수 없습니다."),
 

--- a/src/test/java/com/mamoki/ieojuda/domain/plan/controller/ConversationHistoryOrderingHttpIntegrationTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/plan/controller/ConversationHistoryOrderingHttpIntegrationTest.java
@@ -1,0 +1,122 @@
+package com.mamoki.ieojuda.domain.plan.controller;
+
+import com.mamoki.ieojuda.domain.account.entity.User;
+import com.mamoki.ieojuda.domain.account.repository.UserRepository;
+import com.mamoki.ieojuda.domain.plan.entity.Conversation;
+import com.mamoki.ieojuda.domain.plan.entity.LifeAreaMessage;
+import com.mamoki.ieojuda.domain.plan.entity.MessageRole;
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.plan.repository.ConversationRepository;
+import com.mamoki.ieojuda.domain.plan.repository.LifeAreaMessageRepository;
+import com.mamoki.ieojuda.domain.plan.repository.PlanRepository;
+import com.mamoki.ieojuda.global.jwt.component.JwtTokenProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+// 버그 회귀 방지 - LifeAreaMessage.messageId는 GenerationType.UUID(랜덤)라 생성 순서와 무관하다.
+// findByConversation_ConversationIdOrderByMessageIdAsc/Desc로 정렬하면 실제 대화 흐름과 무관하게
+// 뒤섞인 순서가 나왔다(사용자 발화·AI 응답이 뒤섞여 보이는 문제). createdAt 기준 정렬로 고쳤는지
+// 실제 DB에 저장하고 HTTP로 조회해서 검증한다 (mock으로는 정렬 쿼리 자체를 검증할 수 없음).
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class ConversationHistoryOrderingHttpIntegrationTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private PlanRepository planRepository;
+    @Autowired
+    private ConversationRepository conversationRepository;
+    @Autowired
+    private LifeAreaMessageRepository lifeAreaMessageRepository;
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    private final HttpClient httpClient = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build();
+
+    private User user;
+    private Plan plan;
+    private Conversation conversation;
+    private String accessToken;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder()
+                .email("conv-order-" + UUID.randomUUID() + "@test.com").password("hash").name("김나무").build();
+        user.agreeToConsent();
+        user = userRepository.saveAndFlush(user);
+        plan = planRepository.saveAndFlush(Plan.builder().user(user).build());
+        conversation = conversationRepository.saveAndFlush(Conversation.builder().plan(plan).build());
+        accessToken = jwtTokenProvider.generateAccessToken(user.getUserId(), user.getEmail(), user.getRole().name(), user.getTokenVersion());
+    }
+
+    @AfterEach
+    void tearDown() {
+        lifeAreaMessageRepository.findByConversation_ConversationIdOrderByCreatedAtAscMessageIdAsc(conversation.getConversationId())
+                .forEach(lifeAreaMessageRepository::delete);
+        conversationRepository.delete(conversation);
+        planRepository.delete(plan);
+        userRepository.delete(user);
+    }
+
+    @Test
+    void getHistory_returnsMessagesInActualChronologicalOrder_notRandomUuidOrder() throws Exception {
+        // messageId는 랜덤 UUID라 저장 순서와 뒤섞일 수 있으므로, 실제 대화가 오간 순서 그대로
+        // (아주 짧은 간격을 두고) 저장해 createdAt이 서로 달라지게 만든다.
+        List<String> expectedOrder = List.of(
+                "1번째 사용자 발화", "1번째 AI 응답", "2번째 사용자 발화", "2번째 AI 응답", "3번째 사용자 발화"
+        );
+        List<MessageRole> roles = List.of(
+                MessageRole.USER, MessageRole.ASSISTANT, MessageRole.USER, MessageRole.ASSISTANT, MessageRole.USER
+        );
+        for (int i = 0; i < expectedOrder.size(); i++) {
+            lifeAreaMessageRepository.saveAndFlush(LifeAreaMessage.builder()
+                    .conversation(conversation).role(roles.get(i)).content(expectedOrder.get(i)).build());
+            Thread.sleep(5); // createdAt 값이 확실히 서로 달라지도록 간격을 둔다
+        }
+
+        HttpResponse<String> response = get(
+                "/api/plans/" + plan.getPlanId() + "/conversations/" + conversation.getConversationId() + "/messages?page=0&size=20");
+        assertThat(response.statusCode()).isEqualTo(200);
+
+        List<String> actualOrder = extractContentsInOrder(response.body());
+        assertThat(actualOrder).containsExactlyElementsOf(expectedOrder);
+    }
+
+    // 응답 JSON에서 "content":"..." 값을 등장 순서 그대로 뽑아낸다 (전용 JSON 파서 의존성 없이 정규식으로 충분)
+    private List<String> extractContentsInOrder(String body) {
+        List<String> contents = new java.util.ArrayList<>();
+        Matcher matcher = Pattern.compile("\"content\":\"([^\"]*)\"").matcher(body);
+        while (matcher.find()) {
+            contents.add(matcher.group(1));
+        }
+        return contents;
+    }
+
+    private HttpResponse<String> get(String path) throws Exception {
+        return httpClient.send(HttpRequest.newBuilder(uri(path))
+                .header("Authorization", "Bearer " + accessToken).GET().build(), HttpResponse.BodyHandlers.ofString());
+    }
+
+    private URI uri(String path) {
+        return URI.create("http://localhost:" + port + path);
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/domain/plan/service/ConversationServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/plan/service/ConversationServiceTest.java
@@ -67,7 +67,7 @@ class ConversationServiceTest {
         when(conversation.getPlan()).thenReturn(plan);
         when(planOwnershipReader.findOwnedPlan(USER_ID, PLAN_ID)).thenReturn(plan);
         when(conversationRepository.findById(CONVERSATION_ID)).thenReturn(Optional.of(conversation));
-        when(lifeAreaMessageRepository.findByConversation_ConversationIdOrderByMessageIdAsc(CONVERSATION_ID))
+        when(lifeAreaMessageRepository.findByConversation_ConversationIdOrderByCreatedAtAscMessageIdAsc(CONVERSATION_ID))
                 .thenReturn(List.of());
         when(lifeAreaMessageRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
     }
@@ -89,7 +89,7 @@ class ConversationServiceTest {
         LifeAreaMessage taintedPastMessage = LifeAreaMessage.builder()
                 .conversation(conversation).role(MessageRole.USER)
                 .content("복구코드: XY12-9988").build();
-        when(lifeAreaMessageRepository.findByConversation_ConversationIdOrderByMessageIdAsc(CONVERSATION_ID))
+        when(lifeAreaMessageRepository.findByConversation_ConversationIdOrderByCreatedAtAscMessageIdAsc(CONVERSATION_ID))
                 .thenReturn(List.of(taintedPastMessage));
 
         assertThatThrownBy(() -> conversationService.sendMessage(
@@ -136,7 +136,7 @@ class ConversationServiceTest {
     void sendMessage_whenHistoryPlusNewMessageExceedsTwelveThousandChars_throwsWithoutSavingOrCallingOpenAI() {
         LifeAreaMessage longPastMessage = LifeAreaMessage.builder()
                 .conversation(conversation).role(MessageRole.USER).content("x".repeat(11_990)).build();
-        when(lifeAreaMessageRepository.findByConversation_ConversationIdOrderByMessageIdAsc(CONVERSATION_ID))
+        when(lifeAreaMessageRepository.findByConversation_ConversationIdOrderByCreatedAtAscMessageIdAsc(CONVERSATION_ID))
                 .thenReturn(List.of(longPastMessage));
 
         assertThatThrownBy(() -> conversationService.sendMessage(
@@ -152,7 +152,7 @@ class ConversationServiceTest {
     void sendMessage_whenHistoryPlusNewMessageIsExactlyTwelveThousandChars_proceeds() {
         LifeAreaMessage longPastMessage = LifeAreaMessage.builder()
                 .conversation(conversation).role(MessageRole.USER).content("x".repeat(11_990)).build();
-        when(lifeAreaMessageRepository.findByConversation_ConversationIdOrderByMessageIdAsc(CONVERSATION_ID))
+        when(lifeAreaMessageRepository.findByConversation_ConversationIdOrderByCreatedAtAscMessageIdAsc(CONVERSATION_ID))
                 .thenReturn(List.of(longPastMessage));
         OpenAIResponse response = new OpenAIResponse(List.of(
                 new OpenAIResponse.Choice(new OpenAIMessageDto("assistant",

--- a/src/test/java/com/mamoki/ieojuda/domain/plan/service/PlanOwnershipReaderTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/plan/service/PlanOwnershipReaderTest.java
@@ -1,6 +1,7 @@
 package com.mamoki.ieojuda.domain.plan.service;
 
 import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.plan.entity.PlanStatus;
 import com.mamoki.ieojuda.domain.plan.repository.PlanRepository;
 import com.mamoki.ieojuda.global.exception.CustomException;
 import com.mamoki.ieojuda.global.exception.ErrorCode;
@@ -31,6 +32,12 @@ class PlanOwnershipReaderTest {
         planOwnershipReader = new PlanOwnershipReader(planRepository);
     }
 
+    private Plan planWithStatus(PlanStatus status) {
+        Plan plan = mock(Plan.class);
+        when(plan.getStatus()).thenReturn(status);
+        return plan;
+    }
+
     @Test
     void returnsThePlanWhenTheCallerIsTheOwner() {
         Plan plan = mock(Plan.class);
@@ -58,5 +65,50 @@ class PlanOwnershipReaderTest {
         assertThatThrownBy(() -> planOwnershipReader.findOwnedPlan(OWNER_ID, NONEXISTENT_PLAN_ID))
                 .isInstanceOfSatisfying(CustomException.class,
                         exception -> assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.PLAN_NOT_FOUND));
+    }
+
+    // 버그 회귀 방지 - 계획을 비활성화해도 findOwnedPlan()을 쓰는 하위 서비스들은 PlanStatus를 전혀
+    // 보지 않아서 담당자·항목 등이 계속 조회되던 문제. findOwnedActivePlan()이 그 방어선 역할을 한다.
+
+    @Test
+    void findOwnedPlan_doesNotCareAboutStatus_evenWhenDeactivated() {
+        // 계획 요약(마이페이지, 계획 홈)처럼 비활성화 여부와 무관하게 상태 자체를 보여줘야 하는 화면은
+        // 이 메서드를 그대로 써야 한다 - 일부러 상태를 검사하지 않는다.
+        Plan deactivated = planWithStatus(PlanStatus.DEACTIVATED);
+        when(planRepository.findByPlanIdAndUser_UserId(PLAN_ID, OWNER_ID)).thenReturn(Optional.of(deactivated));
+
+        Plan result = planOwnershipReader.findOwnedPlan(OWNER_ID, PLAN_ID);
+
+        assertThat(result).isSameAs(deactivated);
+    }
+
+    @Test
+    void findOwnedActivePlan_whenDeactivated_throwsPlanDeactivated() {
+        Plan deactivated = planWithStatus(PlanStatus.DEACTIVATED);
+        when(planRepository.findByPlanIdAndUser_UserId(PLAN_ID, OWNER_ID)).thenReturn(Optional.of(deactivated));
+
+        assertThatThrownBy(() -> planOwnershipReader.findOwnedActivePlan(OWNER_ID, PLAN_ID))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.PLAN_DEACTIVATED));
+    }
+
+    @Test
+    void findOwnedActivePlan_whenDraftOrSealed_succeeds() {
+        Plan draft = planWithStatus(PlanStatus.DRAFT);
+        when(planRepository.findByPlanIdAndUser_UserId(PLAN_ID, OWNER_ID)).thenReturn(Optional.of(draft));
+        assertThat(planOwnershipReader.findOwnedActivePlan(OWNER_ID, PLAN_ID)).isSameAs(draft);
+
+        Plan sealed = planWithStatus(PlanStatus.SEALED);
+        when(planRepository.findByPlanIdAndUser_UserId(PLAN_ID, OWNER_ID)).thenReturn(Optional.of(sealed));
+        assertThat(planOwnershipReader.findOwnedActivePlan(OWNER_ID, PLAN_ID)).isSameAs(sealed);
+    }
+
+    @Test
+    void findOwnedActivePlan_whenNotOwner_throwsPlanNotFound() {
+        when(planRepository.findByPlanIdAndUser_UserId(PLAN_ID, OTHER_USER_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> planOwnershipReader.findOwnedActivePlan(OTHER_USER_ID, PLAN_ID))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.PLAN_NOT_FOUND));
     }
 }

--- a/src/test/java/com/mamoki/ieojuda/domain/recipient/service/RecipientServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/recipient/service/RecipientServiceTest.java
@@ -1,0 +1,65 @@
+package com.mamoki.ieojuda.domain.recipient.service;
+
+import com.mamoki.ieojuda.domain.plan.repository.ItemRepository;
+import com.mamoki.ieojuda.domain.plan.service.PlanOwnershipReader;
+import com.mamoki.ieojuda.domain.recipient.repository.RecipientRepository;
+import com.mamoki.ieojuda.domain.securitytoken.service.SecurityTokenService;
+import com.mamoki.ieojuda.global.config.AppProperties;
+import com.mamoki.ieojuda.global.email.outbox.EmailOutboxService;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+// 버그 회귀 방지 - 계획을 비활성화("삭제")한 뒤에도 "역할 담당자 상세 조회"가 예전처럼 그대로
+// 동작하던 문제. findOwnedActivePlan()이 담당자 조회보다 먼저 막아야 한다.
+class RecipientServiceTest {
+
+    private static final UUID USER_ID = UUID.randomUUID();
+    private static final UUID PLAN_ID = UUID.randomUUID();
+    private static final UUID ASSIGNEE_ID = UUID.randomUUID();
+
+    private ItemRepository itemRepository;
+    private RecipientRepository recipientRepository;
+    private PlanOwnershipReader planOwnershipReader;
+    private EmailOutboxService emailOutboxService;
+    private AppProperties appProperties;
+    private SecurityTokenService securityTokenService;
+    private RecipientService recipientService;
+
+    @BeforeEach
+    void setUp() {
+        itemRepository = mock(ItemRepository.class);
+        recipientRepository = mock(RecipientRepository.class);
+        planOwnershipReader = mock(PlanOwnershipReader.class);
+        emailOutboxService = mock(EmailOutboxService.class);
+        appProperties = mock(AppProperties.class);
+        securityTokenService = mock(SecurityTokenService.class);
+        recipientService = new RecipientService(
+                itemRepository, recipientRepository, planOwnershipReader, emailOutboxService,
+                appProperties, securityTokenService);
+    }
+
+    @Test
+    void getRecipient_whenPlanDeactivated_throwsAndNeverQueriesRecipient() {
+        doThrow(new CustomException(ErrorCode.PLAN_DEACTIVATED))
+                .when(planOwnershipReader).findOwnedActivePlan(USER_ID, PLAN_ID);
+
+        assertThatThrownBy(() -> recipientService.getRecipient(USER_ID, PLAN_ID, ASSIGNEE_ID))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.PLAN_DEACTIVATED));
+
+        verify(recipientRepository, never()).findById(any());
+        verify(itemRepository, never()).findByRecipient_AssigneeIdOrderByItemIdAsc(any());
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/domain/rolecheck/service/RoleCheckServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/rolecheck/service/RoleCheckServiceTest.java
@@ -1,0 +1,53 @@
+package com.mamoki.ieojuda.domain.rolecheck.service;
+
+import com.mamoki.ieojuda.domain.confirmer.repository.ConfirmerRepository;
+import com.mamoki.ieojuda.domain.plan.service.PlanOwnershipReader;
+import com.mamoki.ieojuda.domain.recipient.repository.RecipientRepository;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+// 버그 회귀 방지 - 계획이 비활성화된 뒤에도 "역할 점검" 상단 이름 목록(담당자·확인자)이 그대로
+// 조회되던 문제. findOwnedActivePlan()이 계획 조회 단계에서 먼저 막아야 한다.
+class RoleCheckServiceTest {
+
+    private static final UUID USER_ID = UUID.randomUUID();
+    private static final UUID PLAN_ID = UUID.randomUUID();
+
+    private PlanOwnershipReader planOwnershipReader;
+    private RecipientRepository recipientRepository;
+    private ConfirmerRepository confirmerRepository;
+    private RoleCheckService roleCheckService;
+
+    @BeforeEach
+    void setUp() {
+        planOwnershipReader = mock(PlanOwnershipReader.class);
+        recipientRepository = mock(RecipientRepository.class);
+        confirmerRepository = mock(ConfirmerRepository.class);
+        roleCheckService = new RoleCheckService(planOwnershipReader, recipientRepository, confirmerRepository);
+    }
+
+    @Test
+    void getRoleChecks_whenPlanDeactivated_throwsAndNeverQueriesRecipientsOrConfirmers() {
+        doThrow(new CustomException(ErrorCode.PLAN_DEACTIVATED))
+                .when(planOwnershipReader).findOwnedActivePlan(USER_ID, PLAN_ID);
+
+        assertThatThrownBy(() -> roleCheckService.getRoleChecks(USER_ID, PLAN_ID))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.PLAN_DEACTIVATED));
+
+        verify(recipientRepository, never()).findByPlan_PlanIdAndIsBackupFalseOrderByAssigneeIdAsc(any());
+        verify(confirmerRepository, never()).findByPlan_PlanIdOrderByConfirmIdAsc(any());
+    }
+}


### PR DESCRIPTION
## 요약
사용자가 발견한 버그 2건 수정:
1. 계획을 비활성화("삭제")해도 역할 담당자 관련 조회가 예전처럼 그대로 동작하던 문제
2. 삶의 구역 대화를 다시 불러오면 사용자/AI 메세지 순서가 뒤섞이던 문제

## 변경 사항

### 1) 계획 비활성화 후에도 담당자 조회가 막히지 않던 문제
`PlanOwnershipReader.findOwnedPlan()`은 소유권만 검사하고 `PlanStatus`는 전혀 보지 않았습니다. 그래서 계획을 비활성화한 뒤에도 역할 담당자 상세 조회·"역할 점검" 목록이 그대로 조회됐습니다.

- `findOwnedActivePlan()` 신설 — `DEACTIVATED`면 신규 에러코드 `PLAN_DEACTIVATED`(409)로 차단
- 계획 상태 자체를 보여줘야 하는 화면(계획 홈 `GET /api/plans/me`, 마이페이지 `GET /api/plans/{planId}`)은 기존 `findOwnedPlan()`을 그대로 사용 — 비활성화 여부와 무관하게 상태 조회는 계속 가능해야 하므로 의도적으로 유지
- `RecipientService.getRecipient()`, `RoleCheckService.getRoleChecks()`만 새 메서드로 교체

### 2) 대화 이력 재조회 시 순서가 뒤섞이던 문제
`LifeAreaMessage.messageId`는 `GenerationType.UUID`(랜덤)라 생성 순서와 무관한데, 대화 이력 조회 쿼리와 OpenAI 컨텍스트 구성 쿼리 양쪽 다 이 컬럼으로 정렬하고 있었습니다. 화면에서 사용자/AI 메세지가 뒤섞여 보일 뿐 아니라, **OpenAI에 전달되는 대화 맥락 자체도 순서가 깨진 채로 나가고 있었습니다.**

- `BaseCreatedAtEntity`의 `createdAt` 기준 정렬로 교체 (+ 동시각 충돌 대비 `messageId` 보조 정렬)
- `findByConversation_ConversationIdOrderByMessageIdAsc/Desc` → `...OrderByCreatedAtAscMessageIdAsc` / `...OrderByCreatedAtDescMessageIdDesc`

## 테스트 내역
- `PlanOwnershipReaderTest`에 `findOwnedActivePlan()` 케이스 추가 (기존 테스트 3건은 그대로 유지)
- `RecipientServiceTest`(신규), `RoleCheckServiceTest`(신규) — 비활성화된 계획에서 하위 리포지토리를 아예 건드리지 않고 즉시 차단되는지 검증
- `ConversationHistoryOrderingHttpIntegrationTest`(신규) — mock으로는 정렬 쿼리 자체를 검증할 수 없어, 실제 Postgres에 메세지를 저장하고 HTTP로 조회해서 순서를 확인
- 전체 테스트 스위트 406개 중 1개 실패 — 이 PR과 무관한 사전 존재 플레이키 테스트(`InputLimitHttpIntegrationTest`, 대용량 멀티파트 HTTP 클라이언트 결함)