### PR TITLE
[Fix/#148]: 본인 경고 및 이의제기 연락처 이메일 링크를 프론트엔드 라우트에 맞게 수정

### DIFF
--- a/src/main/java/com/mamoki/ieojuda/domain/confirmer/service/DisputeContactService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/confirmer/service/DisputeContactService.java
@@ -85,7 +85,7 @@ public class DisputeContactService {
         LocalDateTime expiresAt = LocalDateTime.now().plusHours(appProperties.getInviteTokenTtlHours());
         contact.issueInviteToken(TokenProvider.hashToken(plainToken), expiresAt);
 
-        String secureLink = appProperties.getBaseUrl() + "/dispute-contacts/verify/" + plainToken;
+        String secureLink = appProperties.getBaseUrl() + "/dispute-contact-email?token=" + plainToken;
         EmailContent content = EmailBuilder.build(
                 "이의 제기 연락처",
                 "링크를 눌러 이의 제기 연락처로 등록되었음을 확인해 주세요.",

--- a/src/main/java/com/mamoki/ieojuda/domain/plan/service/PlanService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/plan/service/PlanService.java
@@ -85,7 +85,7 @@ public class PlanService {
         LocalDateTime expiresAt = LocalDateTime.now().plusHours(appProperties.getInviteTokenTtlHours());
         plan.requestSelfWarningEmailVerification(request.email(), TokenProvider.hashToken(plainToken), expiresAt);
 
-        String secureLink = appProperties.getBaseUrl() + "/self-warning-email/verify/" + plainToken;
+        String secureLink = appProperties.getBaseUrl() + "/self-warning-email?token=" + plainToken;
         EmailContent content = EmailBuilder.build(
                 "본인 경고 메일",
                 "링크를 눌러 이 이메일 주소를 본인 경고 메일 수신처로 확인해 주세요.",


### PR DESCRIPTION
---

## 연관 Issue

- Closes #148

## 요약

본인 경고 이메일과 이의제기 연락처 검증 이메일에 담기는 링크가 실제 배포된 프론트엔드 라우트(쿼리 파라미터 방식)와 형식이 달라, 이메일 링크를 클릭해도 올바른 화면으로 연결되지 않던 문제를 수정했다.

## 변경 사항

- `PlanService.requestSelfWarningEmailVerification()`의 본인 경고 이메일 링크를 `/self-warning-email/verify/{token}` (path variable) → `/self-warning-email?token={token}` (쿼리 파라미터)로 수정
- `DisputeContactService.issueTokenAndSendVerificationEmail()`의 이의제기 연락처 검증 이메일 링크를 `/dispute-contacts/verify/{token}` (path variable) → `/dispute-contact-email?token={token}` (쿼리 파라미터)로 수정
- 두 케이스 모두 프로젝트 내 다른 이메일 링크(`DeathReportService`, `RecipientService`, `HandoverStageService` 등)에서 이미 쓰이던 `baseUrl + 프론트경로 + "?token="` 컨벤션에 맞춤

## 범위

### 포함

- `PlanService.java`의 본인 경고 이메일 링크 형식 수정
- `DisputeContactService.java`의 이의제기 연락처 검증 이메일 링크 형식 수정

### 제외

- 백엔드 검증 API 경로 변경 (`/api/self-warning-email/{token}/verify`, `/api/dispute-contacts/{token}/verify`는 그대로 유지)
- `SecurityConfig`의 permitAll / 레이트리밋 설정 (두 API 모두 이미 permitAll + 레이트리밋 등록되어 있어 변경 불필요)
- `DisputeContactService`의 이의제기 가능기간 안내 메일 링크(`/waiting?caseId=...&token=...`) — 이미 올바른 형식이라 대상 아님
- 역할담당자(주/대체) 수락 이메일 링크 — 이미 올바른 형식이라 대상 아님

## 스크린샷 / 미리 보기

- 백엔드 이메일 링크 문자열만 바뀌는 변경으로 UI 변화 없음 (N/A)