### PR TITLE
[Test/#53]: PR 시 전체 테스트를 실행하는 CI 워크플로 추가

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,122 @@
+name: Test
+
+on:
+  pull_request:
+    branches: [main, develop]
+  push:
+    branches: [main, develop]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: ieojuda
+          POSTGRES_USER: ieojuda
+          POSTGRES_PASSWORD: ieojuda
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DB_URL: jdbc:postgresql://localhost:5432/ieojuda
+      DB_USERNAME: ieojuda
+      DB_PASSWORD: ieojuda
+      DB_DRIVER_CLASS_NAME: org.postgresql.Driver
+
+      APP_NAME: ieojuda
+      JPA_DDL_AUTO: create-drop
+      JPA_SHOW_SQL: false
+      JPA_FORMAT_SQL: false
+
+      # 외부 서비스는 테스트에서 전부 목(mock) 처리되어 있어 CI에서는 값이 필요하지 않고,
+      # 스프링 컨텍스트 바인딩(@ConfigurationProperties 등)을 위해 더미 값만 채운다
+      OPENAI_API_KEY: dummy-openai-api-key
+      OPENAI_API_URL: https://api.openai.com/v1/chat/completions
+      OPENAI_MODEL: gpt-3.5-turbo
+
+      MAIL_HOST: smtp.gmail.com
+      MAIL_PORT: 587
+      MAIL_USERNAME: dummy@example.com
+      MAIL_PASSWORD: dummy-mail-password
+      MAIL_SMTP_AUTH: true
+      MAIL_SMTP_STARTTLS_ENABLE: true
+      MAIL_SMTP_CONNECTION_TIMEOUT_MS: 5000
+      MAIL_SMTP_TIMEOUT_MS: 5000
+      MAIL_SMTP_WRITE_TIMEOUT_MS: 5000
+
+      RESILIENCE4J_EMAIL_RETRY_MAX_ATTEMPTS: 3
+      RESILIENCE4J_EMAIL_RETRY_WAIT_DURATION: 1s
+      RESILIENCE4J_EMAIL_RETRY_EXPONENTIAL_BACKOFF: true
+      RESILIENCE4J_EMAIL_RETRY_BACKOFF_MULTIPLIER: 2
+      RESILIENCE4J_EMAIL_CB_SLIDING_WINDOW_SIZE: 10
+      RESILIENCE4J_EMAIL_CB_FAILURE_RATE_THRESHOLD: 50
+      RESILIENCE4J_EMAIL_CB_WAIT_DURATION_OPEN: 30s
+      RESILIENCE4J_EMAIL_CB_PERMITTED_CALLS_HALF_OPEN: 3
+
+      RESILIENCE4J_S3PUT_RETRY_MAX_ATTEMPTS: 3
+      RESILIENCE4J_S3PUT_RETRY_WAIT_DURATION: 500ms
+      RESILIENCE4J_S3GET_RETRY_MAX_ATTEMPTS: 3
+      RESILIENCE4J_S3GET_RETRY_WAIT_DURATION: 500ms
+      RESILIENCE4J_S3DELETE_RETRY_MAX_ATTEMPTS: 3
+      RESILIENCE4J_S3DELETE_RETRY_WAIT_DURATION: 500ms
+      RESILIENCE4J_S3PUT_CB_SLIDING_WINDOW_SIZE: 10
+      RESILIENCE4J_S3PUT_CB_FAILURE_RATE_THRESHOLD: 50
+      RESILIENCE4J_S3PUT_CB_WAIT_DURATION_OPEN: 30s
+      RESILIENCE4J_S3GET_CB_SLIDING_WINDOW_SIZE: 10
+      RESILIENCE4J_S3GET_CB_FAILURE_RATE_THRESHOLD: 50
+      RESILIENCE4J_S3GET_CB_WAIT_DURATION_OPEN: 30s
+      RESILIENCE4J_S3DELETE_CB_SLIDING_WINDOW_SIZE: 10
+      RESILIENCE4J_S3DELETE_CB_FAILURE_RATE_THRESHOLD: 50
+      RESILIENCE4J_S3DELETE_CB_WAIT_DURATION_OPEN: 30s
+
+      MULTIPART_MAX_FILE_SIZE: 50MB
+      MULTIPART_MAX_REQUEST_SIZE: 55MB
+      TOMCAT_MAX_SWALLOW_SIZE: 60MB
+
+      AWS_S3_BUCKET: dummy-bucket
+      AWS_S3_REGION: ap-northeast-2
+      AWS_ACCESS_KEY_ID: dummy-access-key
+      AWS_SECRET_ACCESS_KEY: dummy-secret-key
+
+      JWT_SECRET: ci-dummy-secret-key-at-least-32-characters-long
+      JWT_ACCESS_TOKEN_EXPIRATION_MS: 3600000
+      JWT_REFRESH_TOKEN_EXPIRATION_MS: 1209600000
+      JWT_ISSUER: ieoduda-backend
+      JWT_AUDIENCE: ieoduda-client
+
+      APP_BASE_URL: http://localhost:3000
+      APP_CONTACT_EMAIL: support@example.com
+      APP_INVITE_TOKEN_TTL_HOURS: 72
+      APP_ACTIVE_TOKEN_TTL_DAYS: 3650
+      APP_EMAIL_OUTBOX_MAX_ATTEMPTS: 5
+      APP_EMAIL_OUTBOX_DISPATCH_INTERVAL_MS: 15000
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Run tests
+        run: ./gradlew test --no-daemon
+
+      - name: Upload test report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: build/reports/tests/test

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,6 +7,12 @@ spring.config.import=optional:file:.env[.properties]
 spring.jpa.hibernate.ddl-auto=${JPA_DDL_AUTO}
 spring.jpa.show-sql=${JPA_SHOW_SQL}
 spring.jpa.properties.hibernate.format_sql=${JPA_FORMAT_SQL}
+# schema.sql이 있으면 Hibernate DDL 이후에 실행되도록 순서를 미룬다 (테스트 전용 schema.sql이
+# Hibernate가 만든 테이블에 이어서 수동 인덱스를 추가하는 용도라, 테이블보다 먼저 실행되면 안 됨)
+spring.jpa.defer-datasource-initialization=true
+# spring.sql.init.mode 기본값(embedded)은 내장 DB에만 schema.sql을 자동 실행하므로,
+# 실제 Postgres를 쓰는 테스트에서도 실행되도록 always로 지정한다
+spring.sql.init.mode=always
 
 #Postgresql DB 연결
 spring.datasource.url=${DB_URL}

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -1,0 +1,6 @@
+-- ddl-auto가 만드는 테이블만으로는 재현되지 않는 수동 제약을 테스트 DB에도 적용한다
+-- (로컬 개발 DB에는 이미 수동으로 적용돼 있음). Hibernate DDL 이후 실행되도록
+-- spring.jpa.defer-datasource-initialization=true로 순서를 미뤄뒀다.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_release_cases_active_plan
+    ON release_cases (plan_id)
+    WHERE canceled_at IS NULL;


### PR DESCRIPTION
## 요약
- `.github/workflows/test.yml` 추가: PR/push 시 Postgres 서비스 컨테이너 + `.env.example` 기반 더미 값으로 `./gradlew test` 실행
- 외부 서비스(S3/SMTP/OpenAI) 관련 테스트가 전부 목(mock) 처리돼 있어 더미 자격증명으로도 안전하게 통과함을 로컬에서 실제 검증(fresh Postgres 컨테이너 + 실제 env var로 전체 스위트 실행, 410 tests, BUILD SUCCESSFUL)
- 검증 중 발견한 부수 이슈: `release_cases`의 수동 부분 유니크 인덱스(`uq_release_cases_active_plan`)가 새 CI DB엔 없어 `IssueFiftySevenConcurrencyTest` 동시성 테스트가 실패 → 테스트 전용 `schema.sql` + `spring.jpa.defer-datasource-initialization` / `spring.sql.init.mode=always`로 Hibernate DDL 직후 자동 적용되도록 수정. 로컬 개발 DB는 이미 인덱스가 있어 `IF NOT EXISTS`로 방어, 영향 없음 확인

## 테스트
- [x] 로컬에서 신규 Postgres 컨테이너 + 워크플로와 동일한 더미 env var로 `./gradlew clean test` 전체 통과 확인
- [x] 로컬 개발 DB(.env 사용)에서 회귀 없음 확인

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)