### PR TITLE
[Feat]: case_id 조회 api

### DIFF
--- a/src/main/java/com/mamoki/ieojuda/domain/releasecase/controller/ReleaseCaseController.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/releasecase/controller/ReleaseCaseController.java
@@ -1,0 +1,36 @@
+package com.mamoki.ieojuda.domain.releasecase.controller;
+
+import java.util.UUID;
+
+import com.mamoki.ieojuda.domain.releasecase.dto.ReleaseCaseDetailResponse;
+import com.mamoki.ieojuda.domain.releasecase.service.ReleaseCaseDetailService;
+import com.mamoki.ieojuda.global.rsdata.RsData;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+// 관리자 화면 - caseId로 임의의 사건을 상세 조회 (소유자 본인 여부와 무관)
+@Tag(name = "Admin - ReleaseCase", description = "운영관리자 - 사건 상세 조회")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/release-cases/{caseId}")
+public class ReleaseCaseController {
+
+    private final ReleaseCaseDetailService releaseCaseDetailService;
+
+    @Operation(summary = "관리자 사건 상세 조회", description = "caseId로 사건의 상태·이력·소유자 정보를 조회합니다.")
+    @GetMapping
+    public ResponseEntity<RsData<ReleaseCaseDetailResponse>> getDetail(
+            @AuthenticationPrincipal UUID userId,
+            @Parameter(description = "사건 ID") @PathVariable UUID caseId
+    ) {
+        return ResponseEntity.ok(RsData.success(releaseCaseDetailService.getDetail(userId, caseId)));
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/releasecase/dto/ReleaseCaseDetailResponse.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/releasecase/dto/ReleaseCaseDetailResponse.java
@@ -1,0 +1,40 @@
+package com.mamoki.ieojuda.domain.releasecase.dto;
+
+import com.mamoki.ieojuda.domain.account.entity.User;
+import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCase;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+// 관리자 화면 - caseId로 조회한 사건의 전체 상세 (작성자 본인용 ReleaseStatusResponse와 달리 소유자 무관하게 전체 필드 노출)
+public record ReleaseCaseDetailResponse(
+        @Schema(description = "사건 ID") UUID caseId,
+        @Schema(description = "사건 상태", example = "WAITING") String status,
+        @Schema(description = "동결 여부") boolean frozen,
+        @Schema(description = "신고 확인 시각") LocalDateTime confirmedAt,
+        @Schema(description = "증빙 승인 시각") LocalDateTime evidenceApprovedAt,
+        @Schema(description = "예정 발송일") LocalDateTime waitingEndsAt,
+        @Schema(description = "취소된 시각") LocalDateTime canceledAt,
+        @Schema(description = "완료된 시각") LocalDateTime completedAt,
+        @Schema(description = "사건 소유자(작성자) 유저 ID") UUID ownerUserId,
+        @Schema(description = "사건 소유자 이메일") String ownerEmail,
+        @Schema(description = "사건 소유자 이름") String ownerName
+) {
+    public static ReleaseCaseDetailResponse of(ReleaseCase releaseCase) {
+        User owner = releaseCase.getPlan().getUser();
+        return new ReleaseCaseDetailResponse(
+                releaseCase.getCaseId(),
+                releaseCase.getStatus().name(),
+                releaseCase.getFrozen(),
+                releaseCase.getConfirmedAt(),
+                releaseCase.getEvidenceApprovedAt(),
+                releaseCase.getWaitingEndsAt(),
+                releaseCase.getCanceledAt(),
+                releaseCase.getCompletedAt(),
+                owner.getUserId(),
+                owner.getEmail(),
+                owner.getName()
+        );
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/releasecase/service/ReleaseCaseDetailService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/releasecase/service/ReleaseCaseDetailService.java
@@ -1,0 +1,31 @@
+package com.mamoki.ieojuda.domain.releasecase.service;
+
+import java.util.UUID;
+
+import com.mamoki.ieojuda.domain.account.entity.AdminPermission;
+import com.mamoki.ieojuda.domain.releasecase.dto.ReleaseCaseDetailResponse;
+import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCase;
+import com.mamoki.ieojuda.domain.releasecase.repository.ReleaseCaseRepository;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import com.mamoki.ieojuda.global.security.PermissionGuard;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+// 관리자 화면 - caseId로 임의의 사건을 상세 조회 (소유자 무관, ReleaseStatusService.findOwnedCase()와 달리 소유권 검사 없음)
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReleaseCaseDetailService {
+
+    private final ReleaseCaseRepository releaseCaseRepository;
+    private final PermissionGuard permissionGuard;
+
+    public ReleaseCaseDetailResponse getDetail(UUID adminUserId, UUID caseId) {
+        permissionGuard.require(adminUserId, AdminPermission.CASE_SUPERVISE);
+        ReleaseCase releaseCase = releaseCaseRepository.findById(caseId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RELEASE_CASE_NOT_FOUND));
+        return ReleaseCaseDetailResponse.of(releaseCase);
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/domain/releasecase/service/ReleaseCaseDetailServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/releasecase/service/ReleaseCaseDetailServiceTest.java
@@ -1,0 +1,90 @@
+package com.mamoki.ieojuda.domain.releasecase.service;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import com.mamoki.ieojuda.domain.account.entity.AdminPermission;
+import com.mamoki.ieojuda.domain.account.entity.User;
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.releasecase.dto.ReleaseCaseDetailResponse;
+import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCase;
+import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCaseStatus;
+import com.mamoki.ieojuda.domain.releasecase.repository.ReleaseCaseRepository;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import com.mamoki.ieojuda.global.security.PermissionGuard;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+// 관리자가 caseId로 임의의 사건(소유자 무관)을 조회할 수 있는지, 권한 없는 유저와 존재하지 않는 caseId는 거절되는지 검증
+class ReleaseCaseDetailServiceTest {
+
+    private static final UUID ADMIN_ID = UUID.randomUUID();
+    private static final UUID CASE_ID = UUID.randomUUID();
+    private static final UUID OWNER_ID = UUID.randomUUID();
+
+    private ReleaseCaseRepository releaseCaseRepository;
+    private PermissionGuard permissionGuard;
+    private ReleaseCaseDetailService releaseCaseDetailService;
+
+    @BeforeEach
+    void setUp() {
+        releaseCaseRepository = mock(ReleaseCaseRepository.class);
+        permissionGuard = mock(PermissionGuard.class);
+        releaseCaseDetailService = new ReleaseCaseDetailService(releaseCaseRepository, permissionGuard);
+    }
+
+    @Test
+    void CASE_SUPERVISE_권한이_없으면_거절한다() {
+        doThrow(new CustomException(ErrorCode.INSUFFICIENT_PERMISSION))
+                .when(permissionGuard).require(ADMIN_ID, AdminPermission.CASE_SUPERVISE);
+
+        assertThatThrownBy(() -> releaseCaseDetailService.getDetail(ADMIN_ID, CASE_ID))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INSUFFICIENT_PERMISSION);
+    }
+
+    @Test
+    void 존재하지_않는_caseId면_거절한다() {
+        when(releaseCaseRepository.findById(CASE_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> releaseCaseDetailService.getDetail(ADMIN_ID, CASE_ID))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.RELEASE_CASE_NOT_FOUND);
+    }
+
+    @Test
+    void 소유자가_달라도_관리자는_상세를_조회한다() {
+        User owner = mock(User.class);
+        when(owner.getUserId()).thenReturn(OWNER_ID);
+        when(owner.getEmail()).thenReturn("owner@example.com");
+        when(owner.getName()).thenReturn("홍길동");
+
+        Plan plan = mock(Plan.class);
+        when(plan.getUser()).thenReturn(owner);
+
+        ReleaseCase releaseCase = mock(ReleaseCase.class);
+        when(releaseCase.getPlan()).thenReturn(plan);
+        when(releaseCase.getCaseId()).thenReturn(CASE_ID);
+        when(releaseCase.getStatus()).thenReturn(ReleaseCaseStatus.WAITING);
+        when(releaseCase.getFrozen()).thenReturn(false);
+
+        when(releaseCaseRepository.findById(CASE_ID)).thenReturn(Optional.of(releaseCase));
+
+        ReleaseCaseDetailResponse response = releaseCaseDetailService.getDetail(ADMIN_ID, CASE_ID);
+
+        assertThat(response.caseId()).isEqualTo(CASE_ID);
+        assertThat(response.status()).isEqualTo("WAITING");
+        assertThat(response.ownerUserId()).isEqualTo(OWNER_ID);
+        assertThat(response.ownerEmail()).isEqualTo("owner@example.com");
+        assertThat(response.ownerName()).isEqualTo("홍길동");
+    }
+}


### PR DESCRIPTION
cloase #154 

목적

운영관리자가 caseId(사건 ID)로 임의의 사후 인계 사건을 상세 조회할 수 있는 API가 없어, 문의 대응·운영 확인 시 DB를 직접 조회해야 했다. 관리자 전용 사건 상세 조회 API를 추가한다.

범위