### PR TITLE
[Fix]: 사후 인계 OTP 재발송 쿨다운 경쟁 조건 수정

### DIFF
--- a/src/main/java/com/mamoki/ieojuda/domain/postaccess/repository/AccessTokenRepository.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/postaccess/repository/AccessTokenRepository.java
@@ -3,7 +3,11 @@ package com.mamoki.ieojuda.domain.postaccess.repository;
 import com.mamoki.ieojuda.domain.postaccess.entity.AccessToken;
 
 import java.util.UUID;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -12,4 +16,11 @@ public interface AccessTokenRepository extends JpaRepository<AccessToken, UUID> 
     // "사후 인계 이메일" 화면 진입 - 링크의 토큰으로 열람 대상을 찾기 위한 조회.
     // OTP 인증 성공 후에는 이 같은 토큰이 열람 세션 식별자로도 쓰인다(verifiedAt으로 세션 유효성 판단).
     Optional<AccessToken> findByTokenHash(String tokenHash);
+
+    // OTP 발송 전용 - "쿨다운 확인 후 발송 시각 갱신" 사이의 경쟁 조건을 막기 위해 행에 비관적 잠금을 건다.
+    // 동시에 들어온 요청 중 하나가 커밋될 때까지 나머지는 대기했다가, 갱신된 otpSentAt으로 쿨다운을 다시
+    // 확인하게 되어 중복 발송을 막는다 (ReleaseCaseRepository.findByIdForUpdate와 같은 패턴).
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select a from AccessToken a where a.tokenHash = :tokenHash")
+    Optional<AccessToken> findByTokenHashForUpdate(@Param("tokenHash") String tokenHash);
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/postaccess/service/PosthumousAccessService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/postaccess/service/PosthumousAccessService.java
@@ -61,7 +61,7 @@ public class PosthumousAccessService {
     // ② OTP 발송 - 별도 이메일로 4자리 코드 발송, 해시만 저장
     @Transactional
     public OtpSendResponse sendOtp(String plainToken) {
-        AccessToken accessToken = findByToken(plainToken);
+        AccessToken accessToken = findByTokenForUpdate(plainToken);
         checkUsable(accessToken);
         checkAttemptsRemaining(accessToken);
         checkResendCooldown(accessToken);
@@ -115,6 +115,12 @@ public class PosthumousAccessService {
     private AccessToken findByToken(String plainToken) {
         return tokenLookupGuard.resolve(plainToken,
                 () -> accessTokenRepository.findByTokenHash(TokenProvider.hashToken(plainToken)));
+    }
+
+    // OTP 발송 - 쿨다운 체크·발송 시각 갱신을 같은 잠긴 행 위에서 원자적으로 수행하기 위해 잠금 조회를 쓴다.
+    private AccessToken findByTokenForUpdate(String plainToken) {
+        return tokenLookupGuard.resolve(plainToken,
+                () -> accessTokenRepository.findByTokenHashForUpdate(TokenProvider.hashToken(plainToken)));
     }
 
     // 만료·재사용(1회성 소진)·역할 불일치 링크를 차단 (이슈 #76 완료 조건 3가지)

--- a/src/test/java/com/mamoki/ieojuda/domain/postaccess/service/PosthumousAccessOtpConcurrencyTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/postaccess/service/PosthumousAccessOtpConcurrencyTest.java
@@ -1,0 +1,158 @@
+package com.mamoki.ieojuda.domain.postaccess.service;
+
+import com.mamoki.ieojuda.domain.account.entity.User;
+import com.mamoki.ieojuda.domain.account.repository.UserRepository;
+import com.mamoki.ieojuda.domain.audit.repository.EmailLogRepository;
+import com.mamoki.ieojuda.domain.plan.entity.Conversation;
+import com.mamoki.ieojuda.domain.plan.entity.DisclosureScope;
+import com.mamoki.ieojuda.domain.plan.entity.LifeArea;
+import com.mamoki.ieojuda.domain.plan.entity.LifeAreaCategory;
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.plan.repository.ConversationRepository;
+import com.mamoki.ieojuda.domain.plan.repository.LifeAreaRepository;
+import com.mamoki.ieojuda.domain.plan.repository.PlanRepository;
+import com.mamoki.ieojuda.domain.postaccess.entity.AccessToken;
+import com.mamoki.ieojuda.domain.postaccess.repository.AccessTokenRepository;
+import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
+import com.mamoki.ieojuda.domain.recipient.entity.RoleType;
+import com.mamoki.ieojuda.domain.recipient.repository.RecipientRepository;
+import com.mamoki.ieojuda.domain.stage.entity.HandoverStage;
+import com.mamoki.ieojuda.domain.stage.repository.HandoverStageRepository;
+import com.mamoki.ieojuda.global.email.outbox.EmailOutboxRepository;
+import com.mamoki.ieojuda.global.email.token.TokenProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+// 백엔드 코드 리뷰로 발견 - sendOtp()가 재발송 쿨다운을 잠금 없이 확인해서, 같은 토큰으로 거의 동시에
+// 여러 요청이 들어오면 전부 같은(갱신 전) otpSentAt을 읽고 쿨다운을 동시에 통과해 OTP 메일이 요청 수만큼
+// 중복 발송됐다. findByTokenHashForUpdate()로 비관적 잠금을 걸어, 동시 요청 중 하나만 실제로 발송하고
+// 나머지는 갱신된 otpSentAt으로 쿨다운에 막히는지 검증한다.
+@SpringBootTest
+class PosthumousAccessOtpConcurrencyTest {
+
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private PlanRepository planRepository;
+    @Autowired
+    private ConversationRepository conversationRepository;
+    @Autowired
+    private LifeAreaRepository lifeAreaRepository;
+    @Autowired
+    private RecipientRepository recipientRepository;
+    @Autowired
+    private HandoverStageRepository handoverStageRepository;
+    @Autowired
+    private AccessTokenRepository accessTokenRepository;
+    @Autowired
+    private EmailLogRepository emailLogRepository;
+    @Autowired
+    private EmailOutboxRepository emailOutboxRepository;
+    @Autowired
+    private PosthumousAccessService posthumousAccessService;
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    @Test
+    void sendOtp_whenFiveRequestsRaceForTheSameToken_onlyOneEnqueuesAnEmail() throws Exception {
+        User user = userRepository.saveAndFlush(User.builder()
+                .email("otp-race-" + UUID.randomUUID() + "@test.com").password("hash").name("김나무").build());
+        Plan plan = planRepository.saveAndFlush(Plan.builder().user(user).build());
+        Conversation conversation = conversationRepository.saveAndFlush(Conversation.builder().plan(plan).build());
+        LifeArea lifeArea = lifeAreaRepository.saveAndFlush(
+                LifeArea.builder().plan(plan).conversation(conversation).category(LifeAreaCategory.RELATIONSHIP_CLEANUP).build());
+        String recipientEmail = "otp-race-recipient-" + UUID.randomUUID() + "@test.com";
+        Recipient recipient = recipientRepository.saveAndFlush(Recipient.builder()
+                .plan(plan).lifeArea(lifeArea).name("이지수").email(recipientEmail)
+                .roleType(RoleType.RELATIONSHIP_MANAGER).isBackup(false)
+                .disclosureScope(DisclosureScope.RELATIONSHIP).maxWaitHours(168).backupFor(null).build());
+        HandoverStage stage = handoverStageRepository.saveAndFlush(
+                HandoverStage.builder().plan(plan).recipient(recipient).stageOrder(0).build());
+        stage.send();
+        stage = handoverStageRepository.saveAndFlush(stage);
+
+        String plainToken = "otp-race-token-" + UUID.randomUUID();
+        accessTokenRepository.saveAndFlush(AccessToken.builder()
+                .handoverStage(stage).tokenHash(TokenProvider.hashToken(plainToken))
+                .expiresAt(LocalDateTime.now().plusHours(1)).build());
+
+        int attempts = 5;
+        CountDownLatch ready = new CountDownLatch(attempts);
+        CountDownLatch start = new CountDownLatch(1);
+        ExecutorService pool = Executors.newFixedThreadPool(attempts);
+        try {
+            List<Future<Boolean>> futures = IntStream.range(0, attempts)
+                    .mapToObj(i -> pool.<Boolean>submit(() -> {
+                        // TokenLookupGuard -> ClientIpResolver가 스레드 바인딩 HttpServletRequest를 요구한다
+                        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(new MockHttpServletRequest()));
+                        try {
+                            ready.countDown();
+                            start.await();
+                            try {
+                                posthumousAccessService.sendOtp(plainToken);
+                                return true;
+                            } catch (Exception e) {
+                                return false;
+                            }
+                        } finally {
+                            RequestContextHolder.resetRequestAttributes();
+                        }
+                    }))
+                    .toList();
+            ready.await(5, TimeUnit.SECONDS);
+            start.countDown();
+
+            long successCount = 0;
+            for (Future<Boolean> f : futures) {
+                if (f.get(10, TimeUnit.SECONDS)) {
+                    successCount++;
+                }
+            }
+
+            // 잠금 없이는 5건 모두 쿨다운을 동시에 통과해 5건 다 발송됐다 - 잠금이 걸리면 정확히 1건만 통과한다.
+            assertThat(successCount).isEqualTo(1);
+            long enqueuedCount = emailOutboxRepository.findAll().stream()
+                    .filter(o -> o.getRecipientEmail().equals(recipientEmail))
+                    .count();
+            assertThat(enqueuedCount).isEqualTo(1);
+        } finally {
+            pool.shutdown();
+            Plan finalPlan = plan;
+            HandoverStage finalStage = stage;
+            new TransactionTemplate(transactionManager).executeWithoutResult(status ->
+                    emailLogRepository.findByPlan_PlanIdOrderByRequestedAtDesc(finalPlan.getPlanId())
+                            .forEach(log -> {
+                                emailOutboxRepository.deleteByEmailLog_LogId(log.getLogId());
+                                emailLogRepository.delete(log);
+                            }));
+            accessTokenRepository.findAll().stream()
+                    .filter(t -> t.getHandoverStage().getStageId().equals(finalStage.getStageId()))
+                    .forEach(accessTokenRepository::delete);
+            handoverStageRepository.delete(finalStage);
+            recipientRepository.delete(recipient);
+            lifeAreaRepository.delete(lifeArea);
+            conversationRepository.delete(conversation);
+            planRepository.delete(plan);
+            userRepository.delete(user);
+        }
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/domain/postaccess/service/PosthumousAccessServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/postaccess/service/PosthumousAccessServiceTest.java
@@ -108,6 +108,10 @@ class PosthumousAccessServiceTest {
                 .build();
         when(accessTokenRepository.findByTokenHash(TokenProvider.hashToken(PLAIN_TOKEN)))
                 .thenReturn(Optional.of(accessToken));
+        // sendOtp()는 쿨다운 경쟁 조건을 막기 위해 잠금 조회를 쓴다 - 단위 테스트에선 실제 잠금 대신
+        // 동일한 값을 반환하는 목으로 대체(잠금 자체의 동시성 효과는 HTTP 통합 테스트가 검증)
+        when(accessTokenRepository.findByTokenHashForUpdate(TokenProvider.hashToken(PLAIN_TOKEN)))
+                .thenReturn(Optional.of(accessToken));
         // OtpAttemptRecorder(REQUIRES_NEW)가 tokenId로 다시 조회하는 부분을 재현
         when(accessTokenRepository.findById(any())).thenReturn(Optional.of(accessToken));
         return accessToken;


### PR DESCRIPTION
## 요약
- OTP 계속 발송되는 문제 보고 받아 코드 확인한 결과, `PosthumousAccessService.sendOtp()`의 60초 재발송 쿨다운이 DB 행 잠금 없이 확인되고 있었음
- 같은 토큰으로 거의 동시에 여러 요청이 들어오면(중복 클릭, 프론트 재시도/폴링 버그 등) 전부 갱신 전 `otpSentAt`을 읽고 쿨다운을 동시에 통과 → 요청 수만큼 OTP 메일 중복 발송
- `AccessTokenRepository`에 `findByTokenHashForUpdate()`(PESSIMISTIC_WRITE) 추가, `sendOtp()`에서만 이 조회를 사용 - `ReleaseCaseRepository.findByIdForUpdate`와 동일 패턴
- `getAccess()`/`verify()`는 기존 잠금 없는 조회 그대로 유지 (이 문제와 무관)

## 테스트
- [x] 신규 동시성 통합 테스트: 같은 토큰으로 5개 요청이 동시에 들어와도 정확히 1건만 발송(이메일 아웃박스에 정확히 1건만 등록)됨을 검증
- [x] 기존 `PosthumousAccessServiceTest`, `PosthumousAccessHttpIntegrationTest`, `StageDispatchHttpIntegrationTest` 전부 통과
- [x] 전체 테스트 스위트 통과 확인 (`InputLimitHttpIntegrationTest`의 55MB 업로드 테스트 1건은 이 변경과 무관한 기존 소켓 레벨 플레이키 테스트로, diff에 관련 파일 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)