### PR TITLE
[Fix]: 사용 이력 있는 계정 탈퇴 시 FK 위반으로 실패하던 문제 수정

### DIFF
--- a/src/main/java/com/mamoki/ieojuda/domain/account/service/UserService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/account/service/UserService.java
@@ -10,9 +10,13 @@ import com.mamoki.ieojuda.domain.account.repository.RefreshSessionRepository;
 import com.mamoki.ieojuda.domain.account.repository.UserRepository;
 import com.mamoki.ieojuda.domain.confirmer.repository.ConfirmerRepository;
 import com.mamoki.ieojuda.domain.confirmer.repository.DisputeContactRepository;
+import com.mamoki.ieojuda.domain.confirmer.entity.Confirmer;
+import com.mamoki.ieojuda.domain.confirmer.entity.DisputeContact;
 import com.mamoki.ieojuda.domain.evidence.entity.Evidence;
+import com.mamoki.ieojuda.domain.evidence.repository.EvidenceDownloadTokenRepository;
 import com.mamoki.ieojuda.domain.evidence.repository.EvidenceRepository;
 import com.mamoki.ieojuda.domain.partner.repository.PartnerReviewerRepository;
+import com.mamoki.ieojuda.domain.audit.entity.EmailLog;
 import com.mamoki.ieojuda.domain.audit.repository.EmailLogRepository;
 import com.mamoki.ieojuda.domain.handoffcheck.repository.HandoffCheckRepository;
 import com.mamoki.ieojuda.domain.handoffcheck.repository.HandoffCheckResponseRepository;
@@ -23,14 +27,21 @@ import com.mamoki.ieojuda.domain.plan.repository.LifeAreaMessageRepository;
 import com.mamoki.ieojuda.domain.plan.repository.LifeAreaRepository;
 import com.mamoki.ieojuda.domain.plan.repository.PlanRepository;
 import com.mamoki.ieojuda.domain.plan.repository.PlanVersionRepository;
+import com.mamoki.ieojuda.domain.postaccess.repository.AccessTokenRepository;
+import com.mamoki.ieojuda.domain.postaccess.repository.PackageActionCompletionRepository;
 import com.mamoki.ieojuda.domain.postaccess.repository.PackageIssueRepository;
+import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
 import com.mamoki.ieojuda.domain.recipient.repository.RecipientRepository;
+import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCase;
 import com.mamoki.ieojuda.domain.releasecase.repository.ObjectionRepository;
 import com.mamoki.ieojuda.domain.releasecase.repository.ReleaseCaseRepository;
 import com.mamoki.ieojuda.domain.releasecase.service.ReleaseCaseGuardService;
 import com.mamoki.ieojuda.domain.securitytoken.entity.SecurityTokenPurpose;
+import com.mamoki.ieojuda.domain.securitytoken.repository.SecurityTokenRepository;
 import com.mamoki.ieojuda.domain.securitytoken.service.SecurityTokenService;
+import com.mamoki.ieojuda.domain.stage.entity.HandoverStage;
 import com.mamoki.ieojuda.domain.stage.repository.HandoverStageRepository;
+import com.mamoki.ieojuda.global.email.outbox.EmailOutboxRepository;
 import com.mamoki.ieojuda.global.exception.CustomException;
 import com.mamoki.ieojuda.global.exception.ErrorCode;
 import com.mamoki.ieojuda.global.storage.EvidenceStorageClient;
@@ -38,6 +49,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Comparator;
+import java.util.List;
 
 // 명세서 "마이페이지" 화면 - 계정 정보 변경 / 계정 삭제
 @Service
@@ -69,6 +83,11 @@ public class UserService {
     private final RefreshSessionRepository refreshSessionRepository;
     private final PartnerReviewerRepository partnerReviewerRepository;
     private final SecurityTokenService securityTokenService;
+    private final AccessTokenRepository accessTokenRepository;
+    private final PackageActionCompletionRepository packageActionCompletionRepository;
+    private final SecurityTokenRepository securityTokenRepository;
+    private final EmailOutboxRepository emailOutboxRepository;
+    private final EvidenceDownloadTokenRepository evidenceDownloadTokenRepository;
 
     @Transactional
     public UserResponse updateProfile(UUID userId, UserUpdateRequest request) {
@@ -167,11 +186,18 @@ public class UserService {
         userRepository.delete(user);
     }
 
-    // 자식 -> 부모 순서로 삭제 (FK 제약 위반 방지)
+    // 자식 -> 부모 순서로 삭제 (FK 제약 위반 방지). 아래 각 지점은 실제 운영 FK 제약(ON DELETE 지정
+    // 없음 = NO ACTION)을 전부 조회해서 맞춘 것으로, 이전에는 email_outbox/posthumouse_access_tokens/
+    // package_action_completions/security_tokens/evidence_download_tokens 정리가 빠져 있어 실제
+    // 사용 이력이 있는 계정은 탈퇴 시 전부 DataIntegrityViolationException으로 실패했다(버그 회귀 방지).
     private void deletePlanData(Plan plan) {
         UUID planId = plan.getPlanId();
 
-        emailLogRepository.deleteAll(emailLogRepository.findByPlan_PlanIdOrderByRequestedAtDesc(planId));
+        // email_outbox.log_id -> email_logs 이므로 로그를 지우기 전에 그 로그를 참조하는 아웃박스부터 지운다
+        List<EmailLog> emailLogs = emailLogRepository.findByPlan_PlanIdOrderByRequestedAtDesc(planId);
+        emailLogs.forEach(log -> emailOutboxRepository.deleteByEmailLog_LogId(log.getLogId()));
+        emailLogRepository.deleteAll(emailLogs);
+
         deleteEvidenceWithStorage(planId);
         objectionRepository.deleteAll(objectionRepository.findByPlan_PlanId(planId));
         handoffCheckResponseRepository.deleteAll(handoffCheckResponseRepository.findByHandoffCheck_Plan_PlanId(planId));
@@ -179,12 +205,40 @@ public class UserService {
         packageIssueRepository.deleteAll(packageIssueRepository.findByRecipient_Plan_PlanId(planId));
         lifeAreaMessageRepository.deleteAll(lifeAreaMessageRepository.findByConversation_Plan_PlanId(planId));
         itemRepository.deleteAll(itemRepository.findByLifeArea_Plan_PlanIdOrderByItemIdAsc(planId));
-        handoverStageRepository.deleteAll(handoverStageRepository.findByPlan_PlanId(planId));
-        recipientRepository.deleteAll(recipientRepository.findByPlan_PlanId(planId));
-        disputeContactRepository.deleteAll(disputeContactRepository.findByPlan_PlanId(planId));
-        releaseCaseRepository.deleteAll(releaseCaseRepository.findByPlan_PlanId(planId));
+
+        // posthumouse_access_tokens.stage_id / package_action_completions.stage_id -> handover_stages
+        List<HandoverStage> stages = handoverStageRepository.findByPlan_PlanId(planId);
+        stages.forEach(stage -> {
+            accessTokenRepository.deleteByHandoverStage_StageId(stage.getStageId());
+            packageActionCompletionRepository.deleteByHandoverStage_StageId(stage.getStageId());
+        });
+        handoverStageRepository.deleteAll(stages);
+
+        // security_tokens.recipient_id -> role_assignees. 대체 담당자(backup_for_id)는 role_assignees
+        // 자기 자신을 가리키는 FK라, 대체 담당자를 주 담당자보다 먼저 지워야 순서 위반이 안 난다.
+        List<Recipient> recipients = recipientRepository.findByPlan_PlanId(planId);
+        recipients.forEach(recipient -> securityTokenRepository.deleteByRecipient_AssigneeId(recipient.getAssigneeId()));
+        recipients.stream()
+                .sorted(Comparator.comparing(r -> r.getBackupFor() == null ? 1 : 0))
+                .forEach(recipientRepository::delete);
+
+        // security_tokens.dispute_contact_id -> dispute_contacts
+        List<DisputeContact> disputeContacts = disputeContactRepository.findByPlan_PlanId(planId);
+        disputeContacts.forEach(contact -> securityTokenRepository.deleteByDisputeContact_ContactId(contact.getContactId()));
+        disputeContactRepository.deleteAll(disputeContacts);
+
+        // security_tokens.case_id -> release_cases
+        List<ReleaseCase> releaseCases = releaseCaseRepository.findByPlan_PlanId(planId);
+        releaseCases.forEach(releaseCase -> securityTokenRepository.deleteByReleaseCase_CaseId(releaseCase.getCaseId()));
+        releaseCaseRepository.deleteAll(releaseCases);
+
         planVersionRepository.deleteAll(planVersionRepository.findByPlan_PlanId(planId));
-        confirmerRepository.deleteAll(confirmerRepository.findByPlan_PlanIdOrderByConfirmIdAsc(planId));
+
+        // security_tokens.confirmer_id -> death_confirmers
+        List<Confirmer> confirmers = confirmerRepository.findByPlan_PlanIdOrderByConfirmIdAsc(planId);
+        confirmers.forEach(confirmer -> securityTokenRepository.deleteByConfirmer_ConfirmId(confirmer.getConfirmId()));
+        confirmerRepository.deleteAll(confirmers);
+
         lifeAreaRepository.deleteAll(lifeAreaRepository.findByPlan_PlanId(planId));
         conversationRepository.deleteAll(conversationRepository.findByPlan_PlanId(planId));
         planRepository.delete(plan);
@@ -192,9 +246,13 @@ public class UserService {
 
     // S3 원본까지 함께 정리한다. 이미 자동/수동 삭제 절차로 원본이 지워진 증빙(deletedAt != null)은
     // 다시 지우려고 시도하지 않는다 - 존재하지 않는 스토리지 키를 지우는 시도를 막기 위함.
+    // evidence_download_tokens.evidence_id -> evidences이므로 증빙을 지우기 전에 그 증빙에 발급된
+    // 다운로드 토큰부터 지운다.
     private void deleteEvidenceWithStorage(UUID planId) {
         var evidences = evidenceRepository.findByPlan_PlanId(planId);
         for (Evidence evidence : evidences) {
+            evidenceDownloadTokenRepository.deleteAll(
+                    evidenceDownloadTokenRepository.findByEvidence_EvidenceId(evidence.getEvidenceId()));
             if (evidence.getDeletedAt() == null) {
                 evidenceStorageClient.delete(evidence.getStorageKey());
             }

--- a/src/main/java/com/mamoki/ieojuda/domain/postaccess/repository/AccessTokenRepository.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/postaccess/repository/AccessTokenRepository.java
@@ -23,4 +23,7 @@ public interface AccessTokenRepository extends JpaRepository<AccessToken, UUID> 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select a from AccessToken a where a.tokenHash = :tokenHash")
     Optional<AccessToken> findByTokenHashForUpdate(@Param("tokenHash") String tokenHash);
+
+    // 계정 삭제 - handover_stages를 지우기 전에 이 단계를 참조하는 토큰을 먼저 지워야 FK 위반이 안 난다
+    void deleteByHandoverStage_StageId(UUID stageId);
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/postaccess/repository/PackageActionCompletionRepository.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/postaccess/repository/PackageActionCompletionRepository.java
@@ -17,4 +17,7 @@ public interface PackageActionCompletionRepository extends JpaRepository<Package
 
     // issue #78 - 단계 완료 판정(전체 항목 수 대비 완료된 항목 수)에 사용
     long countByHandoverStage_StageId(UUID stageId);
+
+    // 계정 삭제 - handover_stages를 지우기 전에 이 단계를 참조하는 행동 완료 기록을 먼저 지워야 FK 위반이 안 난다
+    void deleteByHandoverStage_StageId(UUID stageId);
 }

--- a/src/main/java/com/mamoki/ieojuda/domain/securitytoken/repository/SecurityTokenRepository.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/securitytoken/repository/SecurityTokenRepository.java
@@ -26,15 +26,23 @@ public interface SecurityTokenRepository extends JpaRepository<SecurityToken, UU
     // 사건 종료(취소/완료) 시 그 사건에 묶인 목적별 토큰을 일괄 폐기하기 위한 조회
     List<SecurityToken> findByReleaseCase_CaseIdAndPurposeAndUsedAtIsNullAndRevokedAtIsNull(UUID caseId, SecurityTokenPurpose purpose);
 
-    // 테스트 정리용 - 사건에 묶인 토큰(사건 FK 참조)을 전부 지워 사건/확인자 삭제 시 FK 위반을 막는다
+    // 사건/확인자/담당자/이의연락처에 묶인 토큰(FK 참조, 사용·폐기 여부 무관)을 전부 지워 그 대상
+    // 삭제 시 FK 위반을 막는다 - 계정 삭제(UserService.deletePlanData)와 테스트 정리 둘 다에서 쓴다.
     @Modifying
     @Query("DELETE FROM SecurityToken t WHERE t.releaseCase.caseId = :caseId")
     void deleteByReleaseCase_CaseId(@Param("caseId") UUID caseId);
 
-    // 테스트 정리용 - 확인자에 묶인 토큰(확인자 FK 참조, 사용·폐기 여부 무관)을 전부 지워 확인자 삭제 시 FK 위반을 막는다
     @Modifying
     @Query("DELETE FROM SecurityToken t WHERE t.confirmer.confirmId = :confirmId")
     void deleteByConfirmer_ConfirmId(@Param("confirmId") UUID confirmId);
+
+    @Modifying
+    @Query("DELETE FROM SecurityToken t WHERE t.recipient.assigneeId = :assigneeId")
+    void deleteByRecipient_AssigneeId(@Param("assigneeId") UUID assigneeId);
+
+    @Modifying
+    @Query("DELETE FROM SecurityToken t WHERE t.disputeContact.contactId = :contactId")
+    void deleteByDisputeContact_ContactId(@Param("contactId") UUID contactId);
 
     // issue #41 - "토큰 소비를 원자적 단일 사용으로 처리" - 조회 후 갱신이 아니라 조건부 UPDATE 한 번으로
     // 처리해, 동시에 같은 토큰이 들어와도 정확히 하나만 영향받은 행(1)을 얻는다. 나머지는 0을 받아 거절된다.

--- a/src/test/java/com/mamoki/ieojuda/domain/account/service/UserAccountDeletionIntegrationTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/account/service/UserAccountDeletionIntegrationTest.java
@@ -1,0 +1,200 @@
+package com.mamoki.ieojuda.domain.account.service;
+
+import com.mamoki.ieojuda.domain.account.entity.User;
+import com.mamoki.ieojuda.domain.account.repository.UserRepository;
+import com.mamoki.ieojuda.domain.audit.entity.EmailLog;
+import com.mamoki.ieojuda.domain.audit.entity.EmailType;
+import com.mamoki.ieojuda.domain.audit.repository.EmailLogRepository;
+import com.mamoki.ieojuda.domain.confirmer.entity.Confirmer;
+import com.mamoki.ieojuda.domain.confirmer.entity.DisputeContact;
+import com.mamoki.ieojuda.domain.confirmer.entity.Relationship;
+import com.mamoki.ieojuda.domain.confirmer.repository.ConfirmerRepository;
+import com.mamoki.ieojuda.domain.confirmer.repository.DisputeContactRepository;
+import com.mamoki.ieojuda.domain.evidence.entity.Evidence;
+import com.mamoki.ieojuda.domain.evidence.entity.EvidenceDownloadToken;
+import com.mamoki.ieojuda.domain.evidence.entity.EvidenceType;
+import com.mamoki.ieojuda.domain.evidence.repository.EvidenceDownloadTokenRepository;
+import com.mamoki.ieojuda.domain.evidence.repository.EvidenceRepository;
+import com.mamoki.ieojuda.domain.partner.entity.PartnerReviewer;
+import com.mamoki.ieojuda.domain.partner.repository.PartnerReviewerRepository;
+import com.mamoki.ieojuda.domain.plan.entity.Conversation;
+import com.mamoki.ieojuda.domain.plan.entity.DisclosureScope;
+import com.mamoki.ieojuda.domain.plan.entity.LifeArea;
+import com.mamoki.ieojuda.domain.plan.entity.LifeAreaCategory;
+import com.mamoki.ieojuda.domain.plan.entity.Plan;
+import com.mamoki.ieojuda.domain.plan.entity.PlanVersion;
+import com.mamoki.ieojuda.domain.plan.repository.ConversationRepository;
+import com.mamoki.ieojuda.domain.plan.repository.LifeAreaRepository;
+import com.mamoki.ieojuda.domain.plan.repository.PlanRepository;
+import com.mamoki.ieojuda.domain.plan.repository.PlanVersionRepository;
+import com.mamoki.ieojuda.domain.postaccess.entity.AccessToken;
+import com.mamoki.ieojuda.domain.postaccess.entity.PackageActionCompletion;
+import com.mamoki.ieojuda.domain.postaccess.repository.AccessTokenRepository;
+import com.mamoki.ieojuda.domain.postaccess.repository.PackageActionCompletionRepository;
+import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
+import com.mamoki.ieojuda.domain.recipient.entity.RoleType;
+import com.mamoki.ieojuda.domain.recipient.repository.RecipientRepository;
+import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCase;
+import com.mamoki.ieojuda.domain.releasecase.repository.ReleaseCaseRepository;
+import com.mamoki.ieojuda.domain.securitytoken.entity.SecurityTokenPurpose;
+import com.mamoki.ieojuda.domain.securitytoken.service.SecurityTokenService;
+import com.mamoki.ieojuda.domain.stage.entity.HandoverStage;
+import com.mamoki.ieojuda.domain.stage.repository.HandoverStageRepository;
+import com.mamoki.ieojuda.global.email.contract.EmailContent;
+import com.mamoki.ieojuda.global.email.outbox.EmailOutboxRepository;
+import com.mamoki.ieojuda.global.email.outbox.EmailOutboxService;
+import com.mamoki.ieojuda.global.storage.EvidenceStorageClient;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.doNothing;
+
+// 버그 회귀 방지 - 계정 탈퇴(UserService.deleteAccount)는 사용 이력이 있는 계정(담당자 초대, 확인자
+// 지정, 이의제기 연락처 등록, 사후 인계 발송, 이메일 발송 등)에 대해 항상 DataIntegrityViolationException으로
+// 실패했다. email_outbox/posthumouse_access_tokens/package_action_completions/security_tokens/
+// evidence_download_tokens가 전부 ON DELETE 지정 없는(NO ACTION) FK로 부모 행을 참조하고 있는데,
+// deletePlanData()가 이 자식 행들을 먼저 지우지 않고 부모부터 지우려 했기 때문이다. 목 기반 단위
+// 테스트로는 실제 DB 제약을 검증할 수 없어(이 세션에서 반복적으로 겪은 함정과 동일한 종류), 실제
+// Postgres에 이 관계를 전부 채운 뒤 실제 deleteAccount()를 호출하는 통합 테스트로만 검증할 수 있다.
+@SpringBootTest
+class UserAccountDeletionIntegrationTest {
+
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private PlanRepository planRepository;
+    @Autowired
+    private ConversationRepository conversationRepository;
+    @Autowired
+    private LifeAreaRepository lifeAreaRepository;
+    @Autowired
+    private RecipientRepository recipientRepository;
+    @Autowired
+    private ConfirmerRepository confirmerRepository;
+    @Autowired
+    private DisputeContactRepository disputeContactRepository;
+    @Autowired
+    private PlanVersionRepository planVersionRepository;
+    @Autowired
+    private ReleaseCaseRepository releaseCaseRepository;
+    @Autowired
+    private HandoverStageRepository handoverStageRepository;
+    @Autowired
+    private AccessTokenRepository accessTokenRepository;
+    @Autowired
+    private PackageActionCompletionRepository packageActionCompletionRepository;
+    @Autowired
+    private EvidenceRepository evidenceRepository;
+    @Autowired
+    private EvidenceDownloadTokenRepository evidenceDownloadTokenRepository;
+    @Autowired
+    private EmailLogRepository emailLogRepository;
+    @Autowired
+    private EmailOutboxRepository emailOutboxRepository;
+    @Autowired
+    private EmailOutboxService emailOutboxService;
+    @Autowired
+    private SecurityTokenService securityTokenService;
+    @Autowired
+    private PartnerReviewerRepository partnerReviewerRepository;
+    @Autowired
+    private UserService userService;
+
+    @MockitoBean
+    private EvidenceStorageClient evidenceStorageClient;
+
+    @Test
+    void deleteAccount_whenPlanHasFullUsageHistory_succeedsWithoutForeignKeyViolation() {
+        doNothing().when(evidenceStorageClient).delete(org.mockito.ArgumentMatchers.anyString());
+
+        User user = userRepository.saveAndFlush(User.builder()
+                .email("delete-full-" + UUID.randomUUID() + "@test.com").password("hash").name("탈퇴테스트").build());
+        Plan plan = planRepository.saveAndFlush(Plan.builder().user(user).build());
+        Conversation conversation = conversationRepository.saveAndFlush(Conversation.builder().plan(plan).build());
+        LifeArea lifeArea = lifeAreaRepository.saveAndFlush(
+                LifeArea.builder().plan(plan).conversation(conversation).category(LifeAreaCategory.RELATIONSHIP_CLEANUP).build());
+
+        // 주 담당자 + 대체 담당자 (role_assignees.backup_for_id 자기참조 - 삭제 순서 검증) 둘 다 토큰 보유
+        Recipient primary = recipientRepository.saveAndFlush(Recipient.builder()
+                .plan(plan).lifeArea(lifeArea).name("주담당").email("primary-" + UUID.randomUUID() + "@test.com")
+                .roleType(RoleType.RELATIONSHIP_MANAGER).isBackup(false)
+                .disclosureScope(DisclosureScope.RELATIONSHIP).maxWaitHours(168).backupFor(null).build());
+        Recipient backup = recipientRepository.saveAndFlush(Recipient.builder()
+                .plan(plan).lifeArea(lifeArea).name("대체담당").email("backup-" + UUID.randomUUID() + "@test.com")
+                .roleType(RoleType.RELATIONSHIP_MANAGER).isBackup(true)
+                .disclosureScope(DisclosureScope.RELATIONSHIP).maxWaitHours(168).backupFor(primary).build());
+        securityTokenService.issueForRecipient(SecurityTokenPurpose.ACCEPT_ROLE, primary, LocalDateTime.now().plusDays(1));
+        securityTokenService.issueForRecipient(SecurityTokenPurpose.ACCEPT_ROLE, backup, LocalDateTime.now().plusDays(1));
+
+        // 확인자 + 사건 - security_tokens.confirmer_id / case_id 둘 다 검증
+        Confirmer confirmer = confirmerRepository.saveAndFlush(Confirmer.builder()
+                .plan(plan).name("확인자").relationship(Relationship.FRIEND).email("confirmer-" + UUID.randomUUID() + "@test.com").build());
+        PlanVersion planVersion = planVersionRepository.saveAndFlush(
+                PlanVersion.builder().plan(plan).versionNum(1).snapshotData("{}").build());
+        ReleaseCase releaseCase = releaseCaseRepository.saveAndFlush(
+                ReleaseCase.builder().plan(plan).planVersion(planVersion).build());
+        // 삭제 시도 시점에 "진행 중인 사건"으로 간주되지 않도록(ReleaseCaseGuardService) 완료 상태까지 진행시킨다 -
+        // 이 테스트의 목적은 그 계정 삭제 가드가 아니라 그 뒤에 남는 자식 행(security_tokens 등) 정리 검증
+        releaseCase.confirmReport();
+        releaseCase.awaitEvidence();
+        releaseCase.startEvidenceReview();
+        releaseCase.approveEvidenceAndStartWaiting(0);
+        releaseCase.startReleasing();
+        releaseCase.complete();
+        releaseCase = releaseCaseRepository.saveAndFlush(releaseCase);
+        securityTokenService.issueForConfirmer(SecurityTokenPurpose.REPORT_DEATH, confirmer, releaseCase, LocalDateTime.now().plusDays(1));
+
+        // 이의 제기 연락처 - security_tokens.dispute_contact_id
+        DisputeContact disputeContact = disputeContactRepository.saveAndFlush(
+                DisputeContact.builder().plan(plan).name("이의연락처").email("dispute-" + UUID.randomUUID() + "@test.com").build());
+        securityTokenService.issueForDisputeContact(SecurityTokenPurpose.RAISE_OBJECTION, disputeContact, releaseCase, LocalDateTime.now().plusDays(1));
+
+        // 발송된 단계 - posthumouse_access_tokens.stage_id / package_action_completions.stage_id
+        HandoverStage stage = handoverStageRepository.saveAndFlush(
+                HandoverStage.builder().plan(plan).recipient(primary).stageOrder(0).build());
+        stage.send();
+        stage = handoverStageRepository.saveAndFlush(stage);
+        accessTokenRepository.saveAndFlush(AccessToken.builder()
+                .handoverStage(stage).tokenHash("delete-test-token-hash-" + UUID.randomUUID())
+                .expiresAt(LocalDateTime.now().plusDays(1)).build());
+        packageActionCompletionRepository.saveAndFlush(
+                PackageActionCompletion.builder().handoverStage(stage).itemId(UUID.randomUUID()).build());
+
+        // 외부 파트너가 발급받은 증빙 다운로드 토큰 - evidence_download_tokens.evidence_id
+        User reviewerUser = userRepository.saveAndFlush(User.builder()
+                .email("reviewer-" + UUID.randomUUID() + "@test.com").password("hash").name("외부검토자").build());
+        PartnerReviewer reviewer = partnerReviewerRepository.saveAndFlush(
+                PartnerReviewer.builder().user(reviewerUser).name("외부검토자").email(reviewerUser.getEmail()).build());
+        Evidence evidence = evidenceRepository.saveAndFlush(Evidence.builder()
+                .confirmer(confirmer).plan(plan).releaseCase(releaseCase)
+                .storageKey("evidence/delete-test/" + UUID.randomUUID()).fileName("proof.pdf").mimeType("application/pdf")
+                .integrityHash("hash").evidenceType(EvidenceType.DEATH_CERTIFICATE).build());
+        evidenceDownloadTokenRepository.saveAndFlush(EvidenceDownloadToken.builder()
+                .tokenHash("download-token-hash-" + UUID.randomUUID()).evidence(evidence).reviewer(reviewer)
+                .expiresAt(LocalDateTime.now().plusDays(1)).build());
+
+        // 발송 이력 - email_outbox.log_id -> email_logs
+        emailOutboxService.enqueue(plan, null, EmailType.CONFIRMER_ACCEPTANCE_INVITE, confirmer.getEmail(),
+                new EmailContent("제목", "본문"));
+
+        UUID userId = user.getUserId();
+
+        assertThatCode(() -> userService.deleteAccount(userId)).doesNotThrowAnyException();
+
+        assertThat(userRepository.findById(userId)).isEmpty();
+        assertThat(planRepository.findByUser_UserId(userId)).isEmpty();
+
+        // 이 계정 소유가 아닌 외부 검토자 계정은 건드리지 않아야 한다
+        assertThat(userRepository.findById(reviewerUser.getUserId())).isPresent();
+        partnerReviewerRepository.delete(reviewer);
+        userRepository.delete(reviewerUser);
+    }
+}

--- a/src/test/java/com/mamoki/ieojuda/domain/account/service/UserServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/account/service/UserServiceTest.java
@@ -12,6 +12,7 @@ import com.mamoki.ieojuda.domain.confirmer.entity.Relationship;
 import com.mamoki.ieojuda.domain.confirmer.repository.ConfirmerRepository;
 import com.mamoki.ieojuda.domain.confirmer.repository.DisputeContactRepository;
 import com.mamoki.ieojuda.domain.evidence.entity.Evidence;
+import com.mamoki.ieojuda.domain.evidence.repository.EvidenceDownloadTokenRepository;
 import com.mamoki.ieojuda.domain.evidence.repository.EvidenceRepository;
 import com.mamoki.ieojuda.domain.partner.repository.PartnerReviewerRepository;
 import com.mamoki.ieojuda.domain.handoffcheck.repository.HandoffCheckRepository;
@@ -23,6 +24,8 @@ import com.mamoki.ieojuda.domain.plan.repository.LifeAreaMessageRepository;
 import com.mamoki.ieojuda.domain.plan.repository.LifeAreaRepository;
 import com.mamoki.ieojuda.domain.plan.repository.PlanRepository;
 import com.mamoki.ieojuda.domain.plan.repository.PlanVersionRepository;
+import com.mamoki.ieojuda.domain.postaccess.repository.AccessTokenRepository;
+import com.mamoki.ieojuda.domain.postaccess.repository.PackageActionCompletionRepository;
 import com.mamoki.ieojuda.domain.postaccess.repository.PackageIssueRepository;
 import com.mamoki.ieojuda.domain.recipient.entity.Recipient;
 import com.mamoki.ieojuda.domain.recipient.repository.RecipientRepository;
@@ -30,8 +33,10 @@ import com.mamoki.ieojuda.domain.releasecase.repository.ObjectionRepository;
 import com.mamoki.ieojuda.domain.releasecase.repository.ReleaseCaseRepository;
 import com.mamoki.ieojuda.domain.releasecase.service.ReleaseCaseGuardService;
 import com.mamoki.ieojuda.domain.securitytoken.entity.SecurityTokenPurpose;
+import com.mamoki.ieojuda.domain.securitytoken.repository.SecurityTokenRepository;
 import com.mamoki.ieojuda.domain.securitytoken.service.SecurityTokenService;
 import com.mamoki.ieojuda.domain.stage.repository.HandoverStageRepository;
+import com.mamoki.ieojuda.global.email.outbox.EmailOutboxRepository;
 import com.mamoki.ieojuda.global.exception.CustomException;
 import com.mamoki.ieojuda.global.exception.ErrorCode;
 import com.mamoki.ieojuda.global.storage.EvidenceStorageClient;
@@ -80,6 +85,11 @@ class UserServiceTest {
     private RefreshSessionRepository refreshSessionRepository;
     private PartnerReviewerRepository partnerReviewerRepository;
     private SecurityTokenService securityTokenService;
+    private AccessTokenRepository accessTokenRepository;
+    private PackageActionCompletionRepository packageActionCompletionRepository;
+    private SecurityTokenRepository securityTokenRepository;
+    private EmailOutboxRepository emailOutboxRepository;
+    private EvidenceDownloadTokenRepository evidenceDownloadTokenRepository;
     private UserService userService;
 
     @BeforeEach
@@ -108,6 +118,11 @@ class UserServiceTest {
         refreshSessionRepository = mock(RefreshSessionRepository.class);
         partnerReviewerRepository = mock(PartnerReviewerRepository.class);
         securityTokenService = mock(SecurityTokenService.class);
+        accessTokenRepository = mock(AccessTokenRepository.class);
+        packageActionCompletionRepository = mock(PackageActionCompletionRepository.class);
+        securityTokenRepository = mock(SecurityTokenRepository.class);
+        emailOutboxRepository = mock(EmailOutboxRepository.class);
+        evidenceDownloadTokenRepository = mock(EvidenceDownloadTokenRepository.class);
 
         userService = new UserService(
                 userRepository, planRepository, conversationRepository, lifeAreaRepository, lifeAreaMessageRepository,
@@ -115,7 +130,9 @@ class UserServiceTest {
                 releaseCaseRepository, planVersionRepository, evidenceRepository, emailLogRepository,
                 handoverStageRepository, objectionRepository, handoffCheckRepository, handoffCheckResponseRepository,
                 packageIssueRepository, evidenceStorageClient, releaseCaseGuardService,
-                sessionRevocationService, refreshSessionRepository, partnerReviewerRepository, securityTokenService);
+                sessionRevocationService, refreshSessionRepository, partnerReviewerRepository, securityTokenService,
+                accessTokenRepository, packageActionCompletionRepository, securityTokenRepository,
+                emailOutboxRepository, evidenceDownloadTokenRepository);
     }
 
     @Test


### PR DESCRIPTION
## 요약
"계정 탈퇴쪽 코드 문제있나 확인해줘" 요청으로 확인한 결과, 실제 운영 스키마의 FK 제약을 전수 조회(`pg_constraint`)해보니 `deletePlanData()`가 자식 행을 지우지 않고 부모부터 지우려는 지점이 5곳 있었습니다. 전부 `ON DELETE` 지정 없는(NO ACTION) FK라, 정상적으로 서비스를 써본 계정(담당자 초대/확인자 지정/이의제기 연락처 등록/사후 인계 발송/이메일 발송 중 하나라도 있으면)은 탈퇴 시 항상 `DataIntegrityViolationException`으로 실패합니다.

## 누락됐던 자식 → 부모 관계
| 자식 테이블 | 부모 테이블 |
|---|---|
| `email_outbox` (log_id) | `email_logs` |
| `posthumouse_access_tokens` (stage_id) | `handover_stages` |
| `package_action_completions` (stage_id) | `handover_stages` |
| `security_tokens` (recipient_id/dispute_contact_id/case_id/confirmer_id) | `role_assignees`/`dispute_contacts`/`release_cases`/`death_confirmers` |
| `evidence_download_tokens` (evidence_id) | `evidences` |

덧붙여 `role_assignees.backup_for_id`가 자기 자신을 가리키는 자기참조 FK라, 대체 담당자를 주 담당자보다 먼저 지우도록 정렬도 추가했습니다.

## 수정
- 각 자식 테이블에 부모별 일괄 삭제 리포지토리 메서드 추가 (`SecurityTokenRepository`는 이미 "테스트 정리용"으로 만들어져 있던 `deleteByReleaseCase_CaseId`/`deleteByConfirmer_ConfirmId`를 재사용하고 recipient/disputeContact용 2개를 추가 - 정확히 이 문제를 잡으려고 테스트에서만 쓰던 메서드였습니다)
- `deletePlanData()`/`deleteEvidenceWithStorage()`에서 자식을 먼저 지우도록 순서 재배치

## 테스트
- [x] 신규 통합 테스트: 담당자(+대체 담당자)/확인자/이의제기연락처/사건/발송 단계/증빙/이메일까지 전부 실제 DB에 채운 뒤 실제 `deleteAccount()` 호출 → FK 위반 없이 성공 확인
- [x] 수정 전 코드로 되돌려 이 테스트가 실제로 FK 위반으로 실패하는 것 확인
- [x] 전체 테스트 스위트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)