### PR TITLE
[Feat]: waiting 링크 토큰으로 로그인 없이 대기 상태 공개 조회

### DIFF
--- a/src/main/java/com/mamoki/ieojuda/domain/releasecase/controller/PublicWaitingStatusController.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/releasecase/controller/PublicWaitingStatusController.java
@@ -1,0 +1,37 @@
+package com.mamoki.ieojuda.domain.releasecase.controller;
+
+import java.util.UUID;
+
+import com.mamoki.ieojuda.domain.releasecase.dto.PublicWaitingStatusResponse;
+import com.mamoki.ieojuda.domain.releasecase.service.PublicWaitingStatusService;
+import com.mamoki.ieojuda.global.rsdata.RsData;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+// 명세서 "사후 인계" 화면 - 경고 메일의 waiting 링크로 접근 (로그인 불필요, CANCEL_CASE/RAISE_OBJECTION
+// 토큰이 곧 인증). ReleaseStatusController.getStatus()(로그인 필요)와 같은 화면을 보여주되 인증 수단만 다르다.
+@Tag(name = "PublicWaitingStatus", description = "대기 상태 공개 조회 (취소/이의제기 링크)")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/release-cases/{caseId}/waiting")
+public class PublicWaitingStatusController {
+
+    private final PublicWaitingStatusService publicWaitingStatusService;
+
+    @Operation(summary = "대기 상태 공개 조회", description = "경고 메일 링크의 토큰으로 로그인 없이 상태를 조회하고, 이 토큰으로 취소/이의제기 중 무엇이 가능한지 함께 반환합니다.")
+    @GetMapping("/status")
+    public ResponseEntity<RsData<PublicWaitingStatusResponse>> getStatus(
+            @Parameter(description = "사건 ID") @PathVariable UUID caseId,
+            @Parameter(description = "경고 메일 링크 토큰") @RequestParam String token
+    ) {
+        return ResponseEntity.ok(RsData.success(publicWaitingStatusService.getStatus(caseId, token)));
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/releasecase/dto/PublicWaitingStatusResponse.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/releasecase/dto/PublicWaitingStatusResponse.java
@@ -1,0 +1,34 @@
+package com.mamoki.ieojuda.domain.releasecase.dto;
+
+import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCase;
+import com.mamoki.ieojuda.domain.securitytoken.entity.SecurityTokenPurpose;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+// "사후 인계" 화면 - 경고 메일 링크(비로그인)로 접근한 작성자 본인 / 이의 제기 연락처가 보는 대기 상태.
+// 로그인 세션이 있는 ReleaseStatusResponse와 달리, 토큰의 purpose로 어떤 동작을 보여줄지 결정한다.
+public record PublicWaitingStatusResponse(
+        @Schema(description = "진행 중인 사후 인계 사건이 있는지 여부") boolean hasActiveCase,
+        @Schema(description = "사건 상태", example = "WAITING") String status,
+        @Schema(description = "예정 발송일 (대기 중일 때만 값 존재)") LocalDateTime waitingEndsAt,
+        @Schema(description = "남은 기간(일) - 대기 중일 때만 값 존재") Long remainingDays,
+        @Schema(description = "취소된 시각 (취소 안 됐으면 null)") LocalDateTime canceledAt,
+        @Schema(description = "이 토큰으로 수행 가능한 동작", example = "CANCEL") String availableAction
+) {
+    public static PublicWaitingStatusResponse of(ReleaseCase releaseCase, SecurityTokenPurpose purpose) {
+        Long remainingDays = releaseCase.getWaitingEndsAt() == null
+                ? null
+                : Math.max(0, Duration.between(LocalDateTime.now(), releaseCase.getWaitingEndsAt()).toDays());
+        String availableAction = purpose == SecurityTokenPurpose.CANCEL_CASE ? "CANCEL" : "RAISE_OBJECTION";
+        return new PublicWaitingStatusResponse(
+                true,
+                releaseCase.getStatus().name(),
+                releaseCase.getWaitingEndsAt(),
+                remainingDays,
+                releaseCase.getCanceledAt(),
+                availableAction
+        );
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/releasecase/service/PublicWaitingStatusService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/releasecase/service/PublicWaitingStatusService.java
@@ -1,0 +1,39 @@
+package com.mamoki.ieojuda.domain.releasecase.service;
+
+import java.util.EnumSet;
+import java.util.UUID;
+
+import com.mamoki.ieojuda.domain.releasecase.dto.PublicWaitingStatusResponse;
+import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCase;
+import com.mamoki.ieojuda.domain.securitytoken.entity.SecurityToken;
+import com.mamoki.ieojuda.domain.securitytoken.entity.SecurityTokenPurpose;
+import com.mamoki.ieojuda.domain.securitytoken.service.SecurityTokenService;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+// 명세서 "사후 인계" 화면 - 경고 메일 링크로 접근한 작성자 본인 / 이의 제기 연락처가 로그인 없이 대기
+// 상태를 조회한다. CaseCancellationService/ObjectionService와 같은 CANCEL_CASE·RAISE_OBJECTION
+// 토큰을 쓰지만, 여기서는 조회만 하고 토큰을 소비하지 않는다 - 실제 취소/이의제기 시 다시 쓰여야 하므로.
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PublicWaitingStatusService {
+
+    private final SecurityTokenService securityTokenService;
+
+    public PublicWaitingStatusResponse getStatus(UUID caseId, String plainToken) {
+        SecurityToken token = securityTokenService.resolveAny(plainToken,
+                EnumSet.of(SecurityTokenPurpose.CANCEL_CASE, SecurityTokenPurpose.RAISE_OBJECTION));
+
+        // URL의 caseId가 토큰 발급 시 묶인 사건과 실제로 같은지 검증 - CaseCancellationService/ObjectionService와 동일 패턴
+        if (token.getReleaseCase() == null || !token.getReleaseCase().getCaseId().equals(caseId)) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
+        ReleaseCase releaseCase = token.getReleaseCase();
+
+        return PublicWaitingStatusResponse.of(releaseCase, token.getPurpose());
+    }
+}

--- a/src/main/java/com/mamoki/ieojuda/domain/securitytoken/service/SecurityTokenService.java
+++ b/src/main/java/com/mamoki/ieojuda/domain/securitytoken/service/SecurityTokenService.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.EnumSet;
 
 // issue #41 - 목적별 보안 토큰의 발급·검증·소비·폐기를 한 곳에 모은다. 만료·사용·폐기·목적 불일치
 // 검증을 여기서 공통화해서, 각 도메인 서비스(사망신고/증빙제출/이의제기/역할수락)가 직접
@@ -81,10 +82,20 @@ public class SecurityTokenService {
 
     // 조회 + 만료·사용·폐기·목적 불일치 검증 (아직 소비하지 않음 - 실제 처리가 성공한 뒤 consume()을 별도 호출)
     public SecurityToken resolve(String plainToken, SecurityTokenPurpose expectedPurpose) {
+        return resolve(plainToken, EnumSet.of(expectedPurpose));
+    }
+
+    // waiting 페이지처럼 하나의 링크를 CANCEL_CASE(작성자)·RAISE_OBJECTION(이의 제기 연락처) 중
+    // 어느 쪽이 눌러도 조회는 되어야 하는 경우 - 여러 목적을 한 번에 허용한다. 검증 로직은 resolve()와 동일.
+    public SecurityToken resolveAny(String plainToken, java.util.Set<SecurityTokenPurpose> expectedPurposes) {
+        return resolve(plainToken, expectedPurposes);
+    }
+
+    private SecurityToken resolve(String plainToken, java.util.Set<SecurityTokenPurpose> expectedPurposes) {
         SecurityToken token = tokenLookupGuard.resolve(plainToken,
                 () -> securityTokenRepository.findByTokenHash(TokenProvider.hashToken(plainToken)));
 
-        if (token.getPurpose() != expectedPurpose) {
+        if (!expectedPurposes.contains(token.getPurpose())) {
             throw new CustomException(ErrorCode.TOKEN_PURPOSE_MISMATCH);
         }
         if (token.isRevoked()) {

--- a/src/main/java/com/mamoki/ieojuda/global/config/SecurityConfig.java
+++ b/src/main/java/com/mamoki/ieojuda/global/config/SecurityConfig.java
@@ -42,6 +42,7 @@ public class SecurityConfig {
             "/api/dispute-contacts/*/verify",
             "/api/release-cases/*/disputes", // 이의 제기 접수 (초대 토큰이 곧 인증)
             "/api/release-cases/*/cancellations", // 경고 메일 취소 링크 접수 (CANCEL_CASE 토큰이 곧 인증)
+            "/api/release-cases/*/waiting/status", // 경고 메일 waiting 링크 공개 조회 (CANCEL_CASE/RAISE_OBJECTION 토큰이 곧 인증)
             "/api/release-cases/*/evidence/**", // 증빙 제출 (초대 토큰이 곧 인증)
             "/api/recipient-acceptances/**",// 역할 담당자 수락
             "/api/confirmer-acceptances/**", // 지정확인자 수락 / 사망 신고
@@ -90,6 +91,7 @@ public class SecurityConfig {
                 new RateLimitRule("evidence-submit", "/api/release-cases/*/evidence/submit", "POST", 50, Duration.ofHours(1)),
                 new RateLimitRule("objection", "/api/release-cases/*/disputes", "POST", 50, Duration.ofHours(1)),
                 new RateLimitRule("case-cancellation", "/api/release-cases/*/cancellations", "POST", 50, Duration.ofHours(1)),
+                new RateLimitRule("waiting-status", "/api/release-cases/*/waiting/status", "GET", 100, Duration.ofHours(1)),
                 new RateLimitRule("dispute-verify", "/api/dispute-contacts/*/verify", null, 100, Duration.ofHours(1)),
                 new RateLimitRule("dispute-contact-resend", "/api/dispute-contacts/*/verification-email", "POST", 25, Duration.ofHours(1)),
                 new RateLimitRule("self-warning-email", "/api/self-warning-email/**", null, 100, Duration.ofHours(1)),

--- a/src/test/java/com/mamoki/ieojuda/domain/releasecase/service/PublicWaitingStatusServiceTest.java
+++ b/src/test/java/com/mamoki/ieojuda/domain/releasecase/service/PublicWaitingStatusServiceTest.java
@@ -1,0 +1,88 @@
+package com.mamoki.ieojuda.domain.releasecase.service;
+
+import com.mamoki.ieojuda.domain.releasecase.dto.PublicWaitingStatusResponse;
+import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCase;
+import com.mamoki.ieojuda.domain.releasecase.entity.ReleaseCaseStatus;
+import com.mamoki.ieojuda.domain.securitytoken.entity.SecurityToken;
+import com.mamoki.ieojuda.domain.securitytoken.entity.SecurityTokenPurpose;
+import com.mamoki.ieojuda.domain.securitytoken.service.SecurityTokenService;
+import com.mamoki.ieojuda.global.exception.CustomException;
+import com.mamoki.ieojuda.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.EnumSet;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+// waiting 링크는 작성자 본인(CANCEL_CASE)과 이의 제기 연락처(RAISE_OBJECTION)에게 같은 URL 형태로
+// 발송되므로, 조회는 두 목적의 토큰을 모두 받아들이되 토큰의 목적에 따라 availableAction이 갈려야 한다.
+class PublicWaitingStatusServiceTest {
+
+    private static final UUID CASE_ID = UUID.randomUUID();
+    private static final UUID OTHER_CASE_ID = UUID.randomUUID();
+
+    private SecurityTokenService securityTokenService;
+    private PublicWaitingStatusService publicWaitingStatusService;
+    private ReleaseCase releaseCase;
+
+    @BeforeEach
+    void setUp() {
+        securityTokenService = mock(SecurityTokenService.class);
+        publicWaitingStatusService = new PublicWaitingStatusService(securityTokenService);
+
+        releaseCase = mock(ReleaseCase.class);
+        when(releaseCase.getCaseId()).thenReturn(CASE_ID);
+        when(releaseCase.getStatus()).thenReturn(ReleaseCaseStatus.WAITING);
+    }
+
+    private SecurityToken tokenFor(SecurityTokenPurpose purpose, ReleaseCase releaseCase) {
+        SecurityToken token = mock(SecurityToken.class);
+        when(token.getPurpose()).thenReturn(purpose);
+        when(token.getReleaseCase()).thenReturn(releaseCase);
+        return token;
+    }
+
+    @Test
+    void getStatus_withCancelCaseToken_returnsCancelAction() {
+        SecurityToken token = tokenFor(SecurityTokenPurpose.CANCEL_CASE, releaseCase);
+        when(securityTokenService.resolveAny(eq("token"),
+                eq(EnumSet.of(SecurityTokenPurpose.CANCEL_CASE, SecurityTokenPurpose.RAISE_OBJECTION))))
+                .thenReturn(token);
+
+        PublicWaitingStatusResponse response = publicWaitingStatusService.getStatus(CASE_ID, "token");
+
+        assertThat(response.availableAction()).isEqualTo("CANCEL");
+        assertThat(response.hasActiveCase()).isTrue();
+        assertThat(response.status()).isEqualTo("WAITING");
+    }
+
+    @Test
+    void getStatus_withRaiseObjectionToken_returnsRaiseObjectionAction() {
+        SecurityToken token = tokenFor(SecurityTokenPurpose.RAISE_OBJECTION, releaseCase);
+        when(securityTokenService.resolveAny(eq("token"),
+                eq(EnumSet.of(SecurityTokenPurpose.CANCEL_CASE, SecurityTokenPurpose.RAISE_OBJECTION))))
+                .thenReturn(token);
+
+        PublicWaitingStatusResponse response = publicWaitingStatusService.getStatus(CASE_ID, "token");
+
+        assertThat(response.availableAction()).isEqualTo("RAISE_OBJECTION");
+    }
+
+    @Test
+    void getStatus_whenTokenBoundToDifferentCase_throwsForbidden() {
+        SecurityToken token = tokenFor(SecurityTokenPurpose.CANCEL_CASE, releaseCase);
+        when(securityTokenService.resolveAny(eq("token"),
+                eq(EnumSet.of(SecurityTokenPurpose.CANCEL_CASE, SecurityTokenPurpose.RAISE_OBJECTION))))
+                .thenReturn(token);
+
+        assertThatThrownBy(() -> publicWaitingStatusService.getStatus(OTHER_CASE_ID, "token"))
+                .isInstanceOfSatisfying(CustomException.class,
+                        e -> assertThat(e.getErrorCode()).isEqualTo(ErrorCode.FORBIDDEN));
+    }
+}


### PR DESCRIPTION
## 연관 Issue
<!-- 관련 이슈 없음 - 프론트엔드 연동 중 발견한 문제 대응 -->


## 요약
경고 메일의 waiting 링크(`/waiting?caseId=...&token=...`)는 작성자 본인(CANCEL_CASE 토큰)과 이의 제기 연락처(RAISE_OBJECTION 토큰) 모두에게 발송되지만, 기존 `GET /api/release-cases/{caseId}/waiting`은 로그인 세션을 요구해 비로그인 상태로 메일 링크를 클릭한 수신자가 대기 상태를 조회할 방법이 없었다. 로그인 없이 토큰만으로 조회 가능한 공개 엔드포인트를 추가한다.


## 작업 내용
- `SecurityTokenService`에 여러 purpose(CANCEL_CASE, RAISE_OBJECTION)를 동시에 허용하는 `resolveAny()` 추가 (기존 `resolve()`는 내부적으로 재사용, 시그니처 변경 없음)
- `GET /api/release-cases/{caseId}/waiting/status?token=...` 공개 엔드포인트 추가 (`PublicWaitingStatusController`, `PublicWaitingStatusService`)
  - 토큰의 caseId 바인딩 검증 (다른 사건에 끼워 넣는 시도 차단)
  - 응답에 `availableAction`(`CANCEL` / `RAISE_OBJECTION`) 포함 - 프론트가 토큰 목적에 맞는 버튼만 노출할 수 있도록
  - 조회이므로 토큰을 소비(consume)하지 않음 - 이후 실제 취소/이의제기 POST에서 같은 토큰 재사용
- `SecurityConfig`의 `PERMIT_ALL_PATHS`에 새 경로 추가, 레이트리밋 규칙 1건 추가
- `PublicWaitingStatusServiceTest` 단위 테스트 추가 (CANCEL/RAISE_OBJECTION 분기, 사건 불일치 시 FORBIDDEN)


## 범위
### 포함:
- waiting 링크 토큰으로 로그인 없이 상태 조회하는 신규 엔드포인트
### 제외:
- 프론트엔드 연동 (별도 저장소, ieoduda-frontend)
- 기존 로그인 기반 `GET /waiting`, `POST /cancel` (마이페이지 대시보드용) - 무변경
- `POST /cancellations`, `POST /disputes` 로직 - 무변경


## 스크린샷 / 미리 보기
<!-- 백엔드 API 전용 변경으로 스크린샷 없음 -->
